### PR TITLE
feat: always report first execution results to server

### DIFF
--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -648,9 +648,9 @@ func sendScheduledResults(ctx context.Context, client *sdk.Client, sched *schedu
 				return
 			}
 
-			// Only send results that have changes (or are failures)
-			if !result.HasChanges {
-				logger.Debug("skipping result without changes",
+			// Skip unchanged results unless this is the first execution of the action
+			if !result.HasChanges && sched.Store().HasPriorExecution(result.ActionID) {
+				logger.Debug("skipping unchanged result (not first run)",
 					"action_id", result.ActionID,
 				)
 				continue
@@ -742,9 +742,8 @@ func syncPendingResults(ctx context.Context, sched *scheduler.Scheduler, client 
 		default:
 		}
 
-		// Skip results without changes (unless they failed)
-		if !r.HasChanges && r.Status == pm.ExecutionStatus_EXECUTION_STATUS_SUCCESS {
-			// Mark as synced since we don't need to report no-change successes
+		// Skip unchanged successes unless this is the first execution of the action
+		if !r.HasChanges && r.Status == pm.ExecutionStatus_EXECUTION_STATUS_SUCCESS && sched.Store().HasPriorExecution(r.ActionID) {
 			if err := sched.MarkResultSynced(r.ID); err != nil {
 				logger.Warn("failed to mark result synced", "result_id", r.ID, "error", err)
 			}

--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -649,7 +649,7 @@ func sendScheduledResults(ctx context.Context, client *sdk.Client, sched *schedu
 			}
 
 			// Skip unchanged results unless this is the first execution of the action
-			if !result.HasChanges && sched.Store().HasPriorExecution(result.ActionID) {
+			if !result.HasChanges && sched.HasPriorExecution(result.ActionID) {
 				logger.Debug("skipping unchanged result (not first run)",
 					"action_id", result.ActionID,
 				)
@@ -743,7 +743,7 @@ func syncPendingResults(ctx context.Context, sched *scheduler.Scheduler, client 
 		}
 
 		// Skip unchanged successes unless this is the first execution of the action
-		if !r.HasChanges && r.Status == pm.ExecutionStatus_EXECUTION_STATUS_SUCCESS && sched.Store().HasPriorExecution(r.ActionID) {
+		if !r.HasChanges && r.Status == pm.ExecutionStatus_EXECUTION_STATUS_SUCCESS && sched.HasPriorExecution(r.ActionID) {
 			if err := sched.MarkResultSynced(r.ID); err != nil {
 				logger.Warn("failed to mark result synced", "result_id", r.ID, "error", err)
 			}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -59,9 +59,11 @@ func New(store *store.Store, executor ActionExecutor, logger *slog.Logger) *Sche
 	}
 }
 
-// Store returns the underlying action store.
-func (s *Scheduler) Store() *store.Store {
-	return s.store
+// HasPriorExecution returns true if the action has been executed before.
+// Used to determine if an unchanged result should be reported (first run)
+// or skipped (subsequent runs).
+func (s *Scheduler) HasPriorExecution(actionID string) bool {
+	return s.store.HasPriorExecution(actionID)
 }
 
 // Start begins the scheduler loop.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -59,6 +59,11 @@ func New(store *store.Store, executor ActionExecutor, logger *slog.Logger) *Sche
 	}
 }
 
+// Store returns the underlying action store.
+func (s *Scheduler) Store() *store.Store {
+	return s.store
+}
+
 // Start begins the scheduler loop.
 func (s *Scheduler) Start(ctx context.Context) {
 	s.mu.Lock()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -538,6 +538,18 @@ func (s *Store) MarkResultSynced(resultID string) error {
 	return err
 }
 
+// HasPriorExecution returns true if the action has more than one recorded execution.
+// This is used to distinguish first-run results (which should always be reported)
+// from subsequent unchanged results (which can be skipped).
+func (s *Store) HasPriorExecution(actionID string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var count int
+	err := s.db.QueryRow("SELECT COUNT(*) FROM results WHERE action_id = ?", actionID).Scan(&count)
+	return err == nil && count > 1
+}
+
 // CleanupOldResults removes synced results older than the retention period.
 func (s *Store) CleanupOldResults(retention time.Duration) error {
 	s.mu.Lock()


### PR DESCRIPTION
## Summary

First-run executions are always reported back even when unchanged. Subsequent scheduled runs continue to skip unchanged results.

- Add `HasPriorExecution(actionID)` to store (checks execution count > 1)
- Add `Store()` accessor to scheduler
- Update both result-sending paths to check first-run before skipping

Fixes #6

## Test plan

- [ ] Assign a new action to a device where the package is already installed
- [ ] Verify the first execution reports back to the server with changed=false
- [ ] Verify subsequent scheduled runs skip reporting when unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppress redundant unchanged successful result notifications only after an action has a prior execution, ensuring first executions are always recorded and synced.

* **Refactor**
  * Added an internal prior-execution check and adjusted result handling and sync logic for more accurate and efficient reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->