### PR TITLE
feat: implement cron expression scheduling

### DIFF
--- a/internal/store/cron.go
+++ b/internal/store/cron.go
@@ -39,8 +39,8 @@ func nextCronTime(expr string, after time.Time) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("day-of-week: %w", err)
 	}
 
-	domWild := fields[2] == "*"
-	dowWild := fields[4] == "*"
+	domWild := isFullRange(doms, 1, 31)
+	dowWild := isFullRange(dows, 0, 6)
 
 	// Start searching from one minute after the reference time
 	t := after.Truncate(time.Minute).Add(time.Minute)
@@ -147,4 +147,15 @@ func parseField(field string, min, max int) (map[int]bool, error) {
 		return nil, fmt.Errorf("empty field")
 	}
 	return set, nil
+}
+
+// isFullRange returns true if the set contains every value in [min, max].
+// Used to detect wildcard-equivalent patterns like */1 or 0-6.
+func isFullRange(set map[int]bool, min, max int) bool {
+	for i := min; i <= max; i++ {
+		if !set[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/store/cron.go
+++ b/internal/store/cron.go
@@ -1,0 +1,150 @@
+package store
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// nextCronTime parses a standard 5-field cron expression and returns the next
+// execution time after the given reference time.
+//
+// Format: minute hour day-of-month month day-of-week
+// Supports: numbers, *, */N, N-M, comma-separated lists.
+func nextCronTime(expr string, after time.Time) (time.Time, error) {
+	fields := strings.Fields(expr)
+	if len(fields) != 5 {
+		return time.Time{}, fmt.Errorf("expected 5 fields, got %d", len(fields))
+	}
+
+	minutes, err := parseField(fields[0], 0, 59)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("minute: %w", err)
+	}
+	hours, err := parseField(fields[1], 0, 23)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("hour: %w", err)
+	}
+	doms, err := parseField(fields[2], 1, 31)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("day-of-month: %w", err)
+	}
+	months, err := parseField(fields[3], 1, 12)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("month: %w", err)
+	}
+	dows, err := parseField(fields[4], 0, 6)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("day-of-week: %w", err)
+	}
+
+	domWild := fields[2] == "*"
+	dowWild := fields[4] == "*"
+
+	// Start searching from one minute after the reference time
+	t := after.Truncate(time.Minute).Add(time.Minute)
+
+	// Search up to 366 days ahead to avoid infinite loops
+	limit := t.Add(366 * 24 * time.Hour)
+
+	for t.Before(limit) {
+		if !months[int(t.Month())] {
+			// Skip to next month
+			t = time.Date(t.Year(), t.Month()+1, 1, 0, 0, 0, 0, t.Location())
+			continue
+		}
+
+		dayMatch := false
+		if domWild && dowWild {
+			dayMatch = true
+		} else if domWild {
+			dayMatch = dows[int(t.Weekday())]
+		} else if dowWild {
+			dayMatch = doms[t.Day()]
+		} else {
+			// When both are specified, cron uses OR (either matches)
+			dayMatch = doms[t.Day()] || dows[int(t.Weekday())]
+		}
+
+		if !dayMatch {
+			t = time.Date(t.Year(), t.Month(), t.Day()+1, 0, 0, 0, 0, t.Location())
+			continue
+		}
+
+		if !hours[t.Hour()] {
+			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour()+1, 0, 0, 0, t.Location())
+			continue
+		}
+
+		if !minutes[t.Minute()] {
+			t = t.Add(time.Minute)
+			continue
+		}
+
+		return t, nil
+	}
+
+	return time.Time{}, fmt.Errorf("no matching time found within 366 days")
+}
+
+// parseField parses a cron field into a boolean set of allowed values.
+// Supports: *, */N, N, N-M, comma-separated combinations.
+func parseField(field string, min, max int) (map[int]bool, error) {
+	set := make(map[int]bool)
+
+	for _, part := range strings.Split(field, ",") {
+		part = strings.TrimSpace(part)
+
+		if part == "*" {
+			for i := min; i <= max; i++ {
+				set[i] = true
+			}
+			continue
+		}
+
+		if strings.HasPrefix(part, "*/") {
+			step, err := strconv.Atoi(part[2:])
+			if err != nil || step <= 0 {
+				return nil, fmt.Errorf("invalid step %q", part)
+			}
+			for i := min; i <= max; i += step {
+				set[i] = true
+			}
+			continue
+		}
+
+		if strings.Contains(part, "-") {
+			bounds := strings.SplitN(part, "-", 2)
+			lo, err := strconv.Atoi(bounds[0])
+			if err != nil {
+				return nil, fmt.Errorf("invalid range %q", part)
+			}
+			hi, err := strconv.Atoi(bounds[1])
+			if err != nil {
+				return nil, fmt.Errorf("invalid range %q", part)
+			}
+			if lo < min || hi > max || lo > hi {
+				return nil, fmt.Errorf("range %q out of bounds [%d-%d]", part, min, max)
+			}
+			for i := lo; i <= hi; i++ {
+				set[i] = true
+			}
+			continue
+		}
+
+		val, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value %q", part)
+		}
+		if val < min || val > max {
+			return nil, fmt.Errorf("value %d out of bounds [%d-%d]", val, min, max)
+		}
+		set[val] = true
+	}
+
+	if len(set) == 0 {
+		return nil, fmt.Errorf("empty field")
+	}
+	return set, nil
+}

--- a/internal/store/cron_test.go
+++ b/internal/store/cron_test.go
@@ -1,0 +1,137 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNextCronTime(t *testing.T) {
+	loc := time.UTC
+	ref := time.Date(2026, 4, 4, 10, 30, 0, 0, loc) // Friday 2026-04-04 10:30 UTC
+
+	tests := []struct {
+		name string
+		expr string
+		want time.Time
+	}{
+		{
+			name: "every minute",
+			expr: "* * * * *",
+			want: time.Date(2026, 4, 4, 10, 31, 0, 0, loc),
+		},
+		{
+			name: "daily at 3am",
+			expr: "0 3 * * *",
+			want: time.Date(2026, 4, 5, 3, 0, 0, 0, loc),
+		},
+		{
+			name: "every 8 hours",
+			expr: "0 */8 * * *",
+			want: time.Date(2026, 4, 4, 16, 0, 0, 0, loc),
+		},
+		{
+			name: "midnight daily",
+			expr: "0 0 * * *",
+			want: time.Date(2026, 4, 5, 0, 0, 0, 0, loc),
+		},
+		{
+			name: "hourly at :00",
+			expr: "0 * * * *",
+			want: time.Date(2026, 4, 4, 11, 0, 0, 0, loc),
+		},
+		{
+			name: "every 15 minutes",
+			expr: "*/15 * * * *",
+			want: time.Date(2026, 4, 4, 10, 45, 0, 0, loc),
+		},
+		{
+			name: "sunday at 3am",
+			expr: "0 3 * * 0",
+			want: time.Date(2026, 4, 5, 3, 0, 0, 0, loc), // Apr 5 is Sunday
+		},
+		{
+			name: "first of month at 3am",
+			expr: "0 3 1 * *",
+			want: time.Date(2026, 5, 1, 3, 0, 0, 0, loc),
+		},
+		{
+			name: "weekdays at 9am",
+			expr: "0 9 * * 1-5",
+			want: time.Date(2026, 4, 6, 9, 0, 0, 0, loc), // Monday
+		},
+		{
+			name: "specific minutes",
+			expr: "15,45 * * * *",
+			want: time.Date(2026, 4, 4, 10, 45, 0, 0, loc),
+		},
+		{
+			name: "specific months jan and jul",
+			expr: "0 0 1 1,7 *",
+			want: time.Date(2026, 7, 1, 0, 0, 0, 0, loc),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := nextCronTime(tt.expr, ref)
+			if err != nil {
+				t.Fatalf("nextCronTime(%q) error: %v", tt.expr, err)
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("nextCronTime(%q) = %v, want %v", tt.expr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNextCronTime_Invalid(t *testing.T) {
+	ref := time.Now()
+
+	invalid := []string{
+		"",
+		"* * *",
+		"* * * * * *",
+		"60 * * * *",
+		"* 25 * * *",
+		"* * 32 * *",
+		"* * * 13 *",
+		"* * * * 7",
+		"abc * * * *",
+	}
+
+	for _, expr := range invalid {
+		_, err := nextCronTime(expr, ref)
+		if err == nil {
+			t.Errorf("nextCronTime(%q) expected error, got nil", expr)
+		}
+	}
+}
+
+func TestParseField(t *testing.T) {
+	tests := []struct {
+		field    string
+		min, max int
+		want     []int
+	}{
+		{"*", 0, 5, []int{0, 1, 2, 3, 4, 5}},
+		{"*/2", 0, 5, []int{0, 2, 4}},
+		{"1,3,5", 0, 5, []int{1, 3, 5}},
+		{"1-3", 0, 5, []int{1, 2, 3}},
+		{"0", 0, 59, []int{0}},
+	}
+
+	for _, tt := range tests {
+		set, err := parseField(tt.field, tt.min, tt.max)
+		if err != nil {
+			t.Fatalf("parseField(%q, %d, %d) error: %v", tt.field, tt.min, tt.max, err)
+		}
+		for _, v := range tt.want {
+			if !set[v] {
+				t.Errorf("parseField(%q) missing %d", tt.field, v)
+			}
+		}
+		if len(set) != len(tt.want) {
+			t.Errorf("parseField(%q) got %d values, want %d", tt.field, len(set), len(tt.want))
+		}
+	}
+}

--- a/internal/store/cron_test.go
+++ b/internal/store/cron_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestNextCronTime(t *testing.T) {
 	loc := time.UTC
-	ref := time.Date(2026, 4, 4, 10, 30, 0, 0, loc) // Friday 2026-04-04 10:30 UTC
+	ref := time.Date(2026, 4, 4, 10, 30, 0, 0, loc) // Saturday 2026-04-04 10:30 UTC
 
 	tests := []struct {
 		name string

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -729,7 +729,7 @@ func (s *Store) calculateNextExecute(action *pb.Action, lastExecuted *time.Time,
 		if err == nil {
 			return next
 		}
-		// Invalid cron expression — fall through to interval
+		slog.Warn("invalid cron expression, using interval fallback", "cron", schedule.Cron, "error", err)
 	}
 
 	// Use interval

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -723,14 +723,20 @@ func (s *Store) calculateNextExecute(action *pb.Action, lastExecuted *time.Time,
 		return now
 	}
 
-	// Use interval if specified (and no cron)
+	// Cron takes precedence over interval
+	if schedule.Cron != "" {
+		next, err := nextCronTime(schedule.Cron, now)
+		if err == nil {
+			return next
+		}
+		// Invalid cron expression — fall through to interval
+	}
+
+	// Use interval
 	interval := schedule.IntervalHours
 	if interval <= 0 {
 		interval = 8 // Default 8 hours
 	}
-
-	// TODO: Add cron parsing support
-	// For now, just use interval
 	if lastExecuted == nil {
 		return now
 	}


### PR DESCRIPTION
## Summary

- Add cron parser supporting standard 5-field expressions (minute, hour, day-of-month, month, day-of-week)
- Supports: numbers, `*`, `*/N`, `N-M` ranges, comma-separated lists
- Cron takes precedence over `interval_hours` when both are set
- Invalid cron expressions silently fall back to interval
- 13 unit tests covering common patterns and invalid inputs

## Test plan

- [ ] `go test ./internal/store/...` passes (13 new cron tests)
- [ ] `go build ./cmd/power-manage-agent` compiles
- [ ] Agent with cron-scheduled action executes at correct times

Closes manchtools/power-manage-agent#14


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cron scheduling capability for task execution timing
  * System now evaluates cron expressions before falling back to interval-based scheduling
  * Supports standard 5-field cron expression syntax with validation and error handling

* **Tests**
  * Comprehensive test coverage added for cron expression parsing and execution time calculation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->