### PR TITLE
fix: use sudo cp for agent binary install

### DIFF
--- a/internal/executor/agent_update.go
+++ b/internal/executor/agent_update.go
@@ -157,13 +157,23 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 
 	e.logger.Info("updating agent", "from", cfg.Version, "to", newVersion)
 
-	// Step 8: Install binary via sudo (target dir is root-owned)
-	if _, err := runSudoCmd(ctx, "cp", tmpPath, cfg.BinaryPath); err != nil {
+	// Step 8: Atomic staged install via sudo (target dir is root-owned).
+	// Copy to a sibling temp, chmod, then mv — the live binary is only
+	// replaced after the new one is fully written and executable.
+	stagePath := cfg.BinaryPath + ".new"
+	if _, err := runSudoCmd(ctx, "cp", tmpPath, stagePath); err != nil {
 		writeCooldown(cfg.DataDir, newVersion, 1*time.Hour)
-		return nil, false, fmt.Errorf("install binary: %w", err)
+		return nil, false, fmt.Errorf("stage binary: %w", err)
 	}
-	if _, err := runSudoCmd(ctx, "chmod", "+x", cfg.BinaryPath); err != nil {
-		e.logger.Warn("chmod after install failed", "error", err)
+	if _, err := runSudoCmd(ctx, "chmod", "+x", stagePath); err != nil {
+		runSudoCmd(ctx, "rm", "-f", stagePath)
+		writeCooldown(cfg.DataDir, newVersion, 1*time.Hour)
+		return nil, false, fmt.Errorf("chmod staged binary: %w", err)
+	}
+	if _, err := runSudoCmd(ctx, "mv", stagePath, cfg.BinaryPath); err != nil {
+		runSudoCmd(ctx, "rm", "-f", stagePath)
+		writeCooldown(cfg.DataDir, newVersion, 1*time.Hour)
+		return nil, false, fmt.Errorf("swap binary: %w", err)
 	}
 
 	// Step 9: Write state.json

--- a/internal/executor/agent_update.go
+++ b/internal/executor/agent_update.go
@@ -97,8 +97,9 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 		return nil, false, fmt.Errorf("checksum URL validation: %w", err)
 	}
 
-	// Step 4: Download checksum file and extract checksum for our binary
-	binaryFilename := filepath.Base(arch.BinaryUrl)
+	// Step 4: Download checksum file and extract checksum for our binary.
+	// Use url.Parse to strip query parameters (e.g. S3 presigned URLs).
+	binaryFilename := extractFilename(arch.BinaryUrl)
 	expectedChecksum, err := downloadAndExtractChecksum(ctx, e.httpClient, arch.ChecksumUrl, binaryFilename)
 	if err != nil {
 		return nil, false, fmt.Errorf("download checksum: %w", err)
@@ -174,11 +175,26 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 	stdout := fmt.Sprintf("Updated from %s to %s. Restarting.", cfg.Version, newVersion)
 	e.logger.Info(stdout)
 
+	// Delay shutdown to allow the result to be recorded and sent to the server.
+	// The scheduler checks ctx.Err() after Execute returns — if we cancel
+	// immediately, the result is dropped.
 	if cfg.Shutdown != nil {
-		go cfg.Shutdown()
+		go func() {
+			time.Sleep(3 * time.Second)
+			cfg.Shutdown()
+		}()
 	}
 
 	return &pb.CommandOutput{Stdout: stdout}, true, nil
+}
+
+// extractFilename returns the filename from a URL, stripping query parameters.
+func extractFilename(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return filepath.Base(rawURL)
+	}
+	return filepath.Base(u.Path)
 }
 
 // getArchEntry returns the AgentUpdateArch for the current runtime architecture.

--- a/internal/executor/agent_update.go
+++ b/internal/executor/agent_update.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,7 +16,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -106,14 +104,14 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 		return nil, false, fmt.Errorf("download checksum: %w", err)
 	}
 
-	// Step 5: Download binary to temp file in the same directory as the target
-	// binary to ensure os.Rename works (avoids EXDEV cross-device errors).
-	targetDir := filepath.Dir(cfg.BinaryPath)
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
-		return nil, false, fmt.Errorf("create target dir: %w", err)
+	// Step 5: Download binary to temp file in DataDir (agent-owned).
+	// The final install uses sudo cp since the target dir is root-owned.
+	updateDir := filepath.Join(cfg.DataDir, "update")
+	if err := os.MkdirAll(updateDir, 0755); err != nil {
+		return nil, false, fmt.Errorf("create update dir: %w", err)
 	}
 
-	tmpFile, err := os.CreateTemp(targetDir, ".agent-update-*.tmp")
+	tmpFile, err := os.CreateTemp(updateDir, "agent-update-*.tmp")
 	if err != nil {
 		return nil, false, fmt.Errorf("create temp file: %w", err)
 	}
@@ -158,10 +156,13 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 
 	e.logger.Info("updating agent", "from", cfg.Version, "to", newVersion)
 
-	// Step 8: Atomically swap binary
-	if err := atomicSwap(tmpPath, cfg.BinaryPath); err != nil {
+	// Step 8: Install binary via sudo (target dir is root-owned)
+	if _, err := runSudoCmd(ctx, "cp", tmpPath, cfg.BinaryPath); err != nil {
 		writeCooldown(cfg.DataDir, newVersion, 1*time.Hour)
-		return nil, false, fmt.Errorf("swap binary: %w", err)
+		return nil, false, fmt.Errorf("install binary: %w", err)
+	}
+	if _, err := runSudoCmd(ctx, "chmod", "+x", cfg.BinaryPath); err != nil {
+		e.logger.Warn("chmod after install failed", "error", err)
 	}
 
 	// Step 9: Write state.json
@@ -178,62 +179,6 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 	}
 
 	return &pb.CommandOutput{Stdout: stdout}, true, nil
-}
-
-// atomicSwap moves src to dst. If they are on different filesystems (EXDEV),
-// it falls back to copy-to-target-dir + rename.
-func atomicSwap(src, dst string) error {
-	err := os.Rename(src, dst)
-	if err == nil {
-		return nil
-	}
-	if !errors.Is(err, syscall.EXDEV) {
-		return err
-	}
-
-	// Cross-device fallback: copy into target dir, then rename.
-	dstDir := filepath.Dir(dst)
-	tmp, err := os.CreateTemp(dstDir, ".agent-swap-*.tmp")
-	if err != nil {
-		return fmt.Errorf("create swap temp: %w", err)
-	}
-	tmpPath := tmp.Name()
-
-	srcFile, err := os.Open(src)
-	if err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
-		return fmt.Errorf("open source: %w", err)
-	}
-
-	if _, err := io.Copy(tmp, srcFile); err != nil {
-		srcFile.Close()
-		tmp.Close()
-		os.Remove(tmpPath)
-		return fmt.Errorf("copy to target dir: %w", err)
-	}
-	srcFile.Close()
-
-	if err := tmp.Chmod(0755); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
-		return fmt.Errorf("chmod swap temp: %w", err)
-	}
-
-	if err := tmp.Sync(); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
-		return fmt.Errorf("fsync swap temp: %w", err)
-	}
-	tmp.Close()
-
-	if err := os.Rename(tmpPath, dst); err != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("rename swap temp: %w", err)
-	}
-
-	os.Remove(src)
-	return nil
 }
 
 // getArchEntry returns the AgentUpdateArch for the current runtime architecture.

--- a/internal/executor/agent_update_test.go
+++ b/internal/executor/agent_update_test.go
@@ -301,6 +301,24 @@ func TestGetBinaryVersion_Empty(t *testing.T) {
 	}
 }
 
+func TestExtractFilename(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"https://github.com/org/repo/releases/latest/download/agent-linux-amd64", "agent-linux-amd64"},
+		{"https://s3.amazonaws.com/bucket/agent-linux-amd64?X-Amz-Signature=abc&token=xyz", "agent-linux-amd64"},
+		{"https://example.com/path/to/binary?v=2", "binary"},
+		{"https://example.com/binary", "binary"},
+	}
+	for _, tt := range tests {
+		got := extractFilename(tt.url)
+		if got != tt.want {
+			t.Errorf("extractFilename(%q) = %q, want %q", tt.url, got, tt.want)
+		}
+	}
+}
+
 // testLogger is a simple logger for testing.
 type testLogger struct {
 	infos  []string


### PR DESCRIPTION
## Summary

The agent runs as the `power-manage` user but `/usr/local/bin/` is root-owned. The update executor tried to create temp files in the target directory, failing with `permission denied`.

- Download to DataDir (`/var/lib/power-manage-agent/update/`) which the agent owns
- Use `sudo cp` + `sudo chmod` to install the binary — same pattern the old `updater/install.go` used
- Remove unused `atomicSwap` function and `errors`/`syscall` imports

## Test plan

- [ ] `go build ./cmd/power-manage-agent` compiles
- [ ] `go test ./internal/executor/...` passes
- [ ] Agent update action succeeds on device with root-owned `/usr/local/bin/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved update installation flow: downloads staged in agent-owned update directory and installed via a staged replace sequence to ensure executable permissions.
  * Shutdown during update is deferred slightly to allow safer replacement.
  * Installation failures now trigger cleanup and a cooldown for the attempted version.

* **Tests**
  * Added unit coverage for filename extraction from various download URLs.

* **Chores**
  * Removed unused code and imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->