### PR TITLE
fix: skip DEB, RPM, and Flatpak actions on unsupported distros

### DIFF
--- a/internal/executor/distro_skip_test.go
+++ b/internal/executor/distro_skip_test.go
@@ -1,0 +1,137 @@
+package executor
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// TestExecuteDeb_SkipsWhenDpkgMissing verifies that the DEB executor
+// returns a skip message when dpkg is not available.
+func TestExecuteDeb_SkipsWhenDpkgMissing(t *testing.T) {
+	if _, err := exec.LookPath("dpkg"); err == nil {
+		t.Skip("dpkg is available on this system — test requires a system without dpkg")
+	}
+
+	e := NewExecutor(nil)
+	output, changed, err := e.executeDeb(context.Background(), &pb.AppInstallParams{
+		Url: "https://example.com/test.deb",
+	}, pb.DesiredState_DESIRED_STATE_PRESENT)
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if changed {
+		t.Error("expected changed=false for skipped action")
+	}
+	if output == nil || !strings.Contains(output.Stdout, "skipped") {
+		t.Errorf("expected skip message, got: %v", output)
+	}
+}
+
+// TestExecuteRpm_SkipsWhenRpmMissing verifies that the RPM executor
+// returns a skip message when rpm is not available.
+func TestExecuteRpm_SkipsWhenRpmMissing(t *testing.T) {
+	if _, err := exec.LookPath("rpm"); err == nil {
+		t.Skip("rpm is available on this system — test requires a system without rpm")
+	}
+
+	e := NewExecutor(nil)
+	output, changed, err := e.executeRpm(context.Background(), &pb.AppInstallParams{
+		Url: "https://example.com/test.rpm",
+	}, pb.DesiredState_DESIRED_STATE_PRESENT)
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if changed {
+		t.Error("expected changed=false for skipped action")
+	}
+	if output == nil || !strings.Contains(output.Stdout, "skipped") {
+		t.Errorf("expected skip message, got: %v", output)
+	}
+}
+
+// TestExecuteFlatpak_SkipsWhenFlatpakMissing verifies that the Flatpak executor
+// returns a skip message when flatpak is not available.
+func TestExecuteFlatpak_SkipsWhenFlatpakMissing(t *testing.T) {
+	if _, err := exec.LookPath("flatpak"); err == nil {
+		t.Skip("flatpak is available on this system — test requires a system without flatpak")
+	}
+
+	e := NewExecutor(nil)
+	output, changed, err := e.executeFlatpak(context.Background(), &pb.FlatpakParams{
+		AppId: "org.example.Test",
+	}, pb.DesiredState_DESIRED_STATE_PRESENT)
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if changed {
+		t.Error("expected changed=false for skipped action")
+	}
+	if output == nil || !strings.Contains(output.Stdout, "skipped") {
+		t.Errorf("expected skip message, got: %v", output)
+	}
+}
+
+// TestExecuteDeb_DoesNotSkipWhenDpkgPresent verifies that the DEB executor
+// proceeds (doesn't skip) when dpkg is available.
+func TestExecuteDeb_DoesNotSkipWhenDpkgPresent(t *testing.T) {
+	if _, err := exec.LookPath("dpkg"); err != nil {
+		t.Skip("dpkg is not available on this system")
+	}
+
+	e := NewExecutor(nil)
+	// Use an invalid URL so it fails after the tool check (proving it didn't skip)
+	output, _, err := e.executeDeb(context.Background(), &pb.AppInstallParams{
+		Url: "https://invalid.example.com/nonexistent.deb",
+	}, pb.DesiredState_DESIRED_STATE_PRESENT)
+
+	// Should NOT contain "skipped" — it should proceed and fail on download or install
+	if output != nil && strings.Contains(output.Stdout, "skipped") {
+		t.Error("DEB executor should not skip when dpkg is available")
+	}
+	// We expect an error (download/install failure), not a skip
+	_ = err // error is expected
+}
+
+// TestExecuteRpm_DoesNotSkipWhenRpmPresent verifies that the RPM executor
+// proceeds (doesn't skip) when rpm is available.
+func TestExecuteRpm_DoesNotSkipWhenRpmPresent(t *testing.T) {
+	if _, err := exec.LookPath("rpm"); err != nil {
+		t.Skip("rpm is not available on this system")
+	}
+
+	e := NewExecutor(nil)
+	output, _, err := e.executeRpm(context.Background(), &pb.AppInstallParams{
+		Url: "https://invalid.example.com/nonexistent.rpm",
+	}, pb.DesiredState_DESIRED_STATE_PRESENT)
+
+	if output != nil && strings.Contains(output.Stdout, "skipped") {
+		t.Error("RPM executor should not skip when rpm is available")
+	}
+	_ = err
+}
+
+// TestExecuteFlatpak_DoesNotSkipWhenFlatpakPresent verifies that the Flatpak executor
+// proceeds (doesn't skip) when flatpak is available.
+func TestExecuteFlatpak_DoesNotSkipWhenFlatpakPresent(t *testing.T) {
+	if _, err := exec.LookPath("flatpak"); err != nil {
+		t.Skip("flatpak is not available on this system")
+	}
+
+	e := NewExecutor(nil)
+	// Use a nonexistent app — it will proceed past the guard and fail on install
+	output, _, err := e.executeFlatpak(context.Background(), &pb.FlatpakParams{
+		AppId: "org.nonexistent.surely_does_not_exist_12345",
+	}, pb.DesiredState_DESIRED_STATE_PRESENT)
+
+	if output != nil && strings.Contains(output.Stdout, "skipped") {
+		t.Error("Flatpak executor should not skip when flatpak is available")
+	}
+	_ = err
+}

--- a/internal/executor/distro_skip_test.go
+++ b/internal/executor/distro_skip_test.go
@@ -91,12 +91,13 @@ func TestExecuteDeb_DoesNotSkipWhenDpkgPresent(t *testing.T) {
 		Url: "https://invalid.example.com/nonexistent.deb",
 	}, pb.DesiredState_DESIRED_STATE_PRESENT)
 
-	// Should NOT contain "skipped" — it should proceed and fail on download or install
+	// Should NOT contain "skipped" — it should proceed and fail on download/install
 	if output != nil && strings.Contains(output.Stdout, "skipped") {
 		t.Error("DEB executor should not skip when dpkg is available")
 	}
-	// We expect an error (download/install failure), not a skip
-	_ = err // error is expected
+	if err == nil {
+		t.Error("expected error from download/install of invalid URL, got nil")
+	}
 }
 
 // TestExecuteRpm_DoesNotSkipWhenRpmPresent verifies that the RPM executor
@@ -114,7 +115,9 @@ func TestExecuteRpm_DoesNotSkipWhenRpmPresent(t *testing.T) {
 	if output != nil && strings.Contains(output.Stdout, "skipped") {
 		t.Error("RPM executor should not skip when rpm is available")
 	}
-	_ = err
+	if err == nil {
+		t.Error("expected error from download/install of invalid URL, got nil")
+	}
 }
 
 // TestExecuteFlatpak_DoesNotSkipWhenFlatpakPresent verifies that the Flatpak executor
@@ -125,7 +128,6 @@ func TestExecuteFlatpak_DoesNotSkipWhenFlatpakPresent(t *testing.T) {
 	}
 
 	e := NewExecutor(nil)
-	// Use a nonexistent app — it will proceed past the guard and fail on install
 	output, _, err := e.executeFlatpak(context.Background(), &pb.FlatpakParams{
 		AppId: "org.nonexistent.surely_does_not_exist_12345",
 	}, pb.DesiredState_DESIRED_STATE_PRESENT)
@@ -133,5 +135,7 @@ func TestExecuteFlatpak_DoesNotSkipWhenFlatpakPresent(t *testing.T) {
 	if output != nil && strings.Contains(output.Stdout, "skipped") {
 		t.Error("Flatpak executor should not skip when flatpak is available")
 	}
-	_ = err
+	if err == nil {
+		t.Error("expected error from install of nonexistent app, got nil")
+	}
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -4,6 +4,7 @@ package executor
 import (
 	"bytes"
 	"context"
+	"errors"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -635,7 +636,10 @@ func (e *Executor) executeFlatpak(ctx context.Context, params *pb.FlatpakParams,
 
 	// Skip on systems without flatpak
 	if _, err := exec.LookPath("flatpak"); err != nil {
-		return &pb.CommandOutput{Stdout: "skipped: flatpak not available on this system"}, false, nil
+		if errors.Is(err, exec.ErrNotFound) {
+			return &pb.CommandOutput{Stdout: "skipped: flatpak not available on this system"}, false, nil
+		}
+		return nil, false, fmt.Errorf("flatpak lookup: %w", err)
 	}
 
 	if params.AppId == "" {
@@ -733,7 +737,10 @@ func (e *Executor) executeDeb(ctx context.Context, params *pb.AppInstallParams, 
 
 	// Skip on non-deb systems
 	if _, err := exec.LookPath("dpkg"); err != nil {
-		return &pb.CommandOutput{Stdout: "skipped: dpkg not available on this system"}, false, nil
+		if errors.Is(err, exec.ErrNotFound) {
+			return &pb.CommandOutput{Stdout: "skipped: dpkg not available on this system"}, false, nil
+		}
+		return nil, false, fmt.Errorf("dpkg lookup: %w", err)
 	}
 
 	// Extract package name from URL for checking
@@ -815,7 +822,10 @@ func (e *Executor) executeRpm(ctx context.Context, params *pb.AppInstallParams, 
 
 	// Skip on non-rpm systems
 	if _, err := exec.LookPath("rpm"); err != nil {
-		return &pb.CommandOutput{Stdout: "skipped: rpm not available on this system"}, false, nil
+		if errors.Is(err, exec.ErrNotFound) {
+			return &pb.CommandOutput{Stdout: "skipped: rpm not available on this system"}, false, nil
+		}
+		return nil, false, fmt.Errorf("rpm lookup: %w", err)
 	}
 
 	// Extract package name from URL for checking

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -633,6 +633,11 @@ func (e *Executor) executeFlatpak(ctx context.Context, params *pb.FlatpakParams,
 		return nil, false, fmt.Errorf("flatpak params required")
 	}
 
+	// Skip on systems without flatpak
+	if _, err := exec.LookPath("flatpak"); err != nil {
+		return &pb.CommandOutput{Stdout: "skipped: flatpak not available on this system"}, false, nil
+	}
+
 	if params.AppId == "" {
 		return nil, false, fmt.Errorf("flatpak app_id is required")
 	}
@@ -726,6 +731,11 @@ func (e *Executor) executeDeb(ctx context.Context, params *pb.AppInstallParams, 
 		return nil, false, fmt.Errorf("app params required")
 	}
 
+	// Skip on non-deb systems
+	if _, err := exec.LookPath("dpkg"); err != nil {
+		return &pb.CommandOutput{Stdout: "skipped: dpkg not available on this system"}, false, nil
+	}
+
 	// Extract package name from URL for checking
 	filename := filepath.Base(params.Url)
 	pkgName := strings.Split(filename, "_")[0]
@@ -801,6 +811,11 @@ func (e *Executor) isDebInstalled(pkgName string) bool {
 func (e *Executor) executeRpm(ctx context.Context, params *pb.AppInstallParams, state pb.DesiredState) (*pb.CommandOutput, bool, error) {
 	if params == nil {
 		return nil, false, fmt.Errorf("app params required")
+	}
+
+	// Skip on non-rpm systems
+	if _, err := exec.LookPath("rpm"); err != nil {
+		return &pb.CommandOutput{Stdout: "skipped: rpm not available on this system"}, false, nil
 	}
 
 	// Extract package name from URL for checking


### PR DESCRIPTION
## Summary

DEB, RPM, and Flatpak executors now check for their tools (`dpkg`, `rpm`, `flatpak`) via `exec.LookPath` before executing. When the tool isn't available, they return success with "skipped" instead of failing with "command not found".

This allows mixed-distro action sets (e.g. DEB + RPM for the same package) assigned to device groups containing both Debian and Fedora devices.

## Test plan

- [ ] `go build ./cmd/power-manage-agent` compiles
- [ ] `go test ./internal/executor/...` passes
- [ ] RPM action on Debian device → "skipped: rpm not available"
- [ ] DEB action on Fedora device → "skipped: dpkg not available"
- [ ] Flatpak action on system without flatpak → "skipped: flatpak not available"

Closes manchtools/power-manage-agent#19


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Operations now detect missing package managers (dpkg, rpm, flatpak) and skip those actions with a clear "skipped" status instead of failing.
* **Tests**
  * Added tests verifying skip behavior when package managers are absent and expected handling when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->