### PR TITLE
fix: system update action always reports changed=true

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1656,6 +1656,16 @@ func dnfAutoremove(ctx context.Context) (*pb.CommandOutput, error) {
 	return runSudoCmd(ctx, "dnf", "-y", "autoremove")
 }
 
+// dnfAutoremoveChanged returns true if dnf autoremove output indicates packages were removed.
+func dnfAutoremoveChanged(stdout string) bool {
+	return !strings.Contains(stdout, "Nothing to do")
+}
+
+// aptAutoremoveChanged returns true if apt autoremove output indicates packages were removed.
+func aptAutoremoveChanged(stdout string) bool {
+	return !strings.Contains(stdout, "0 upgraded, 0 newly installed, 0 to remove")
+}
+
 // =============================================================================
 // Zypper Helper Functions
 // =============================================================================
@@ -2109,14 +2119,14 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 			apt := pkg.NewAptWithContext(ctx)
 			if output, err := apt.Autoremove(); err == nil {
 				allOutput.WriteString(output.Stdout)
-				autoremoved = !strings.Contains(output.Stdout, "0 upgraded, 0 newly installed, 0 to remove")
+				autoremoved = aptAutoremoveChanged(output.Stdout)
 			} else if output != nil {
 				allOutput.WriteString(output.Stderr)
 			}
 		} else if pkg.IsDnf() {
 			if output, err := dnfAutoremove(ctx); err == nil {
 				allOutput.WriteString(output.Stdout)
-				autoremoved = !strings.Contains(output.Stdout, "Nothing to do")
+				autoremoved = dnfAutoremoveChanged(output.Stdout)
 			} else if output != nil {
 				allOutput.WriteString(output.Stderr)
 			}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1600,11 +1600,14 @@ func dnfMakecache(ctx context.Context) (*pb.CommandOutput, error) {
 }
 
 // hasUpdatesAvailable checks if there are pending package updates.
-// dnf check-update returns exit code 100 if updates are available, 0 if none.
-// apt: checks if `apt list --upgradable` produces any output beyond the header.
-func (e *Executor) hasUpdatesAvailable(ctx context.Context) bool {
+// When securityOnly is true, only security updates are considered.
+func (e *Executor) hasUpdatesAvailable(ctx context.Context, securityOnly bool) bool {
 	if pkg.IsDnf() {
-		_, exitCode, _ := queryCmdOutput("dnf", "check-update")
+		args := []string{"check-update"}
+		if securityOnly {
+			args = append(args, "--security")
+		}
+		_, exitCode, _ := queryCmdOutput("dnf", args...)
 		return exitCode == 100
 	}
 	if pkg.IsApt() {
@@ -1612,10 +1615,26 @@ func (e *Executor) hasUpdatesAvailable(ctx context.Context) bool {
 		if exitCode != 0 {
 			return true // assume updates on error
 		}
-		// apt outputs a header line "Listing..." even when no updates
 		for _, line := range strings.Split(out, "\n") {
 			line = strings.TrimSpace(line)
 			if line != "" && !strings.HasPrefix(line, "Listing") {
+				return true
+			}
+		}
+		return false
+	}
+	if pkg.IsPacman() {
+		// pacman -Qu lists upgradable packages (exit 0 = has updates, 1 = none)
+		_, exitCode, _ := queryCmdOutput("pacman", "-Qu")
+		return exitCode == 0
+	}
+	if pkg.IsZypper() {
+		// zypper list-updates returns 0 with output if updates available
+		out, _, _ := queryCmdOutput("zypper", "--non-interactive", "list-updates")
+		// Output contains a table — if there's content beyond the header, updates exist
+		for _, line := range strings.Split(out, "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "v |") || strings.HasPrefix(line, "i |") {
 				return true
 			}
 		}
@@ -2029,8 +2048,13 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 	var allOutput strings.Builder
 	var lastErr error
 
+	securityOnly := params != nil && params.SecurityOnly
+
 	// Check if updates are available before running the upgrade.
-	updatesAvailable := e.hasUpdatesAvailable(ctx)
+	updatesAvailable := e.hasUpdatesAvailable(ctx, securityOnly)
+
+	// Record pre-update reboot state to detect new reboot requirements.
+	rebootRequiredBefore := e.checkRebootRequired()
 
 	// Update package index
 	if updateResult, err := e.pkgManager.Update(); err != nil {
@@ -2051,7 +2075,7 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 
 	// Re-check after index update (new updates may now be visible)
 	if !updatesAvailable {
-		updatesAvailable = e.hasUpdatesAvailable(ctx)
+		updatesAvailable = e.hasUpdatesAvailable(ctx, securityOnly)
 	}
 
 	// Perform the upgrade
@@ -2099,11 +2123,12 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 		}
 	}
 
-	// Check if reboot is required
-	rebootRequired := e.checkRebootRequired()
-	if rebootRequired {
+	// Check if this run created a new reboot requirement.
+	rebootRequiredAfter := e.checkRebootRequired()
+	newRebootRequired := rebootRequiredAfter && !rebootRequiredBefore
+	if rebootRequiredAfter {
 		allOutput.WriteString("\n*** REBOOT REQUIRED ***\n")
-		if params != nil && params.RebootIfRequired {
+		if newRebootRequired && params != nil && params.RebootIfRequired {
 			sysnotify.NotifyAll(ctx, "System Reboot", "A system update requires a reboot. This system will reboot in 1 minute.")
 			allOutput.WriteString("Scheduling reboot in 1 minute...\n")
 			runSudoCmd(ctx, "shutdown", "-r", "+1", "System update requires reboot")
@@ -2115,7 +2140,7 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 		exitCode = 1
 	}
 
-	changed := updatesAvailable || autoremoved || rebootRequired
+	changed := updatesAvailable || autoremoved || newRebootRequired
 	return &pb.CommandOutput{
 		ExitCode: exitCode,
 		Stdout:   allOutput.String(),

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1629,16 +1629,8 @@ func (e *Executor) hasUpdatesAvailable(ctx context.Context, securityOnly bool) b
 		return exitCode == 0
 	}
 	if pkg.IsZypper() {
-		// zypper list-updates returns 0 with output if updates available
 		out, _, _ := queryCmdOutput("zypper", "--non-interactive", "list-updates")
-		// Output contains a table — if there's content beyond the header, updates exist
-		for _, line := range strings.Split(out, "\n") {
-			line = strings.TrimSpace(line)
-			if strings.HasPrefix(line, "v |") || strings.HasPrefix(line, "i |") {
-				return true
-			}
-		}
-		return false
+		return zypperHasUpdates(out)
 	}
 	return true // assume updates for unknown package managers
 }
@@ -1654,6 +1646,26 @@ func dnfUpgrade(ctx context.Context, securityOnly bool) (*pb.CommandOutput, erro
 // dnfAutoremove runs dnf autoremove -y to remove unused packages.
 func dnfAutoremove(ctx context.Context) (*pb.CommandOutput, error) {
 	return runSudoCmd(ctx, "dnf", "-y", "autoremove")
+}
+
+// zypperHasUpdates parses zypper list-updates output to detect pending updates.
+// Zypper outputs table rows where the status column is "v" (available) or "i" (installed).
+// The format is "v  | repo | name | ..." with variable whitespace.
+func zypperHasUpdates(output string) bool {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if len(line) == 0 || line[0] == '-' || line[0] == 'S' {
+			continue // skip empty, separator, and header lines
+		}
+		// Status column is the first field before "|"
+		if idx := strings.Index(line, "|"); idx > 0 {
+			status := strings.TrimSpace(line[:idx])
+			if status == "v" || status == "i" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // dnfAutoremoveChanged returns true if dnf autoremove output indicates packages were removed.

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -170,7 +170,9 @@ func (e *Executor) ExecuteWithStreaming(ctx context.Context, action *pb.Action, 
 		output, changed, execErr = e.executePackage(ctx, action.GetPackage(), action.DesiredState)
 		result.Changed = changed
 	case pb.ActionType_ACTION_TYPE_UPDATE:
-		output, execErr = e.executeUpdate(ctx, action.GetUpdate())
+		var changed bool
+		output, changed, execErr = e.executeUpdate(ctx, action.GetUpdate())
+		result.Changed = changed
 	case pb.ActionType_ACTION_TYPE_APP_IMAGE:
 		var changed bool
 		output, changed, execErr = e.executeAppImage(ctx, action.GetApp(), action.DesiredState)
@@ -1597,6 +1599,31 @@ func dnfMakecache(ctx context.Context) (*pb.CommandOutput, error) {
 	return runSudoCmd(ctx, "dnf", "-y", "makecache")
 }
 
+// hasUpdatesAvailable checks if there are pending package updates.
+// dnf check-update returns exit code 100 if updates are available, 0 if none.
+// apt: checks if `apt list --upgradable` produces any output beyond the header.
+func (e *Executor) hasUpdatesAvailable(ctx context.Context) bool {
+	if pkg.IsDnf() {
+		_, exitCode, _ := queryCmdOutput("dnf", "check-update")
+		return exitCode == 100
+	}
+	if pkg.IsApt() {
+		out, exitCode, _ := queryCmdOutput("apt", "list", "--upgradable")
+		if exitCode != 0 {
+			return true // assume updates on error
+		}
+		// apt outputs a header line "Listing..." even when no updates
+		for _, line := range strings.Split(out, "\n") {
+			line = strings.TrimSpace(line)
+			if line != "" && !strings.HasPrefix(line, "Listing") {
+				return true
+			}
+		}
+		return false
+	}
+	return true // assume updates for unknown package managers
+}
+
 // dnfUpgrade runs dnf upgrade. If securityOnly is true, only security updates are applied.
 func dnfUpgrade(ctx context.Context, securityOnly bool) (*pb.CommandOutput, error) {
 	if securityOnly {
@@ -1983,9 +2010,9 @@ func (e *Executor) repairFlatpak(ctx context.Context) {
 
 // executeUpdate performs a system-wide package update.
 // It respects version pinning (apt-mark hold / dnf versionlock).
-func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (*pb.CommandOutput, error) {
+func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (*pb.CommandOutput, bool, error) {
 	if e.pkgManager == nil {
-		return nil, fmt.Errorf("no supported package manager found")
+		return nil, false, fmt.Errorf("no supported package manager found")
 	}
 
 	// Repair filesystem if mounted read-only (common after kernel errors)
@@ -1993,7 +2020,7 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 		return &pb.CommandOutput{
 			ExitCode: 1,
 			Stderr:   "filesystem is read-only and could not be remounted - system may need reboot and fsck",
-		}, fmt.Errorf("filesystem is read-only")
+		}, false, fmt.Errorf("filesystem is read-only")
 	}
 
 	// Repair any broken package manager state first
@@ -2001,6 +2028,9 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 
 	var allOutput strings.Builder
 	var lastErr error
+
+	// Check if updates are available before running the upgrade.
+	updatesAvailable := e.hasUpdatesAvailable(ctx)
 
 	// Update package index
 	if updateResult, err := e.pkgManager.Update(); err != nil {
@@ -2017,6 +2047,11 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 			allOutput.WriteString(updateResult.Stderr)
 		}
 		allOutput.WriteString("\n")
+	}
+
+	// Re-check after index update (new updates may now be visible)
+	if !updatesAvailable {
+		updatesAvailable = e.hasUpdatesAvailable(ctx)
 	}
 
 	// Perform the upgrade
@@ -2043,18 +2078,21 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 	}
 
 	// Autoremove if requested
+	autoremoved := false
 	if params != nil && params.Autoremove {
 		allOutput.WriteString("\n=== Autoremove Unused Packages ===\n")
 		if pkg.IsApt() {
 			apt := pkg.NewAptWithContext(ctx)
 			if output, err := apt.Autoremove(); err == nil {
 				allOutput.WriteString(output.Stdout)
+				autoremoved = !strings.Contains(output.Stdout, "0 upgraded, 0 newly installed, 0 to remove")
 			} else if output != nil {
 				allOutput.WriteString(output.Stderr)
 			}
 		} else if pkg.IsDnf() {
 			if output, err := dnfAutoremove(ctx); err == nil {
 				allOutput.WriteString(output.Stdout)
+				autoremoved = !strings.Contains(output.Stdout, "Nothing to do")
 			} else if output != nil {
 				allOutput.WriteString(output.Stderr)
 			}
@@ -2077,10 +2115,11 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 		exitCode = 1
 	}
 
+	changed := updatesAvailable || autoremoved || rebootRequired
 	return &pb.CommandOutput{
 		ExitCode: exitCode,
 		Stdout:   allOutput.String(),
-	}, lastErr
+	}, changed, lastErr
 }
 
 // executeAptUpgrade performs apt-specific upgrade.

--- a/internal/executor/update_test.go
+++ b/internal/executor/update_test.go
@@ -115,3 +115,84 @@ func TestAptAutoremoveChanged(t *testing.T) {
 		})
 	}
 }
+
+// TestHasUpdatesAvailable_Pacman tests the pacman -Qu path on Arch systems.
+func TestHasUpdatesAvailable_Pacman(t *testing.T) {
+	if !pkg.IsPacman() {
+		t.Skip("not a pacman-based system")
+	}
+
+	e := NewExecutor(nil)
+	result := e.hasUpdatesAvailable(context.Background(), false)
+	t.Logf("hasUpdatesAvailable (pacman) = %v", result)
+
+	// Cross-check with pacman -Qu exit code (0 = updates, 1 = none)
+	_, exitCode, _ := queryCmdOutput("pacman", "-Qu")
+	expected := exitCode == 0
+
+	if result != expected {
+		t.Errorf("hasUpdatesAvailable() = %v, but pacman -Qu exit code = %d (expected updates=%v)", result, exitCode, expected)
+	}
+}
+
+// TestHasUpdatesAvailable_Zypper tests the zypper list-updates path on openSUSE systems.
+func TestHasUpdatesAvailable_Zypper(t *testing.T) {
+	if !pkg.IsZypper() {
+		t.Skip("not a zypper-based system")
+	}
+
+	e := NewExecutor(nil)
+	result := e.hasUpdatesAvailable(context.Background(), false)
+	t.Logf("hasUpdatesAvailable (zypper) = %v", result)
+}
+
+// TestZypperHasUpdates tests parsing of zypper list-updates output.
+func TestZypperHasUpdates(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "no updates",
+			output: "Loading repository data...\nReading installed packages...\nNo updates found.\n",
+			want:   false,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   false,
+		},
+		{
+			name: "updates available",
+			output: `Loading repository data...
+Reading installed packages...
+
+S  | Repository | Name     | Current Version | Available Version | Arch
+---+------------+----------+-----------------+-------------------+-------
+v  | update     | libzypp  | 17.31.8-1       | 17.31.9-1         | x86_64
+v  | update     | zypper   | 1.14.59-1       | 1.14.60-1         | x86_64
+`,
+			want: true,
+		},
+		{
+			name: "installed updates",
+			output: `Loading repository data...
+Reading installed packages...
+
+S  | Repository | Name     | Current Version | Available Version | Arch
+---+------------+----------+-----------------+-------------------+-------
+i  | update     | kernel   | 6.7.1-1         | 6.7.2-1           | x86_64
+`,
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if zypperHasUpdates(tt.output) != tt.want {
+				t.Errorf("zypperHasUpdates() = %v, want %v", !tt.want, tt.want)
+			}
+		})
+	}
+}

--- a/internal/executor/update_test.go
+++ b/internal/executor/update_test.go
@@ -1,0 +1,103 @@
+package executor
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestHasUpdatesAvailable_Dnf tests the dnf check-update path on Fedora systems.
+func TestHasUpdatesAvailable_Dnf(t *testing.T) {
+	if _, err := exec.LookPath("dnf"); err != nil {
+		t.Skip("dnf not available on this system")
+	}
+
+	e := NewExecutor(nil)
+	// Just verify it doesn't panic/crash — the actual result depends on system state
+	result := e.hasUpdatesAvailable(context.Background(), false)
+	t.Logf("hasUpdatesAvailable (dnf) = %v", result)
+
+	// Cross-check with dnf check-update exit code
+	cmd := exec.Command("dnf", "check-update")
+	cmd.Run()
+	exitCode := cmd.ProcessState.ExitCode()
+	expected := exitCode == 100
+
+	if result != expected {
+		t.Errorf("hasUpdatesAvailable() = %v, but dnf check-update exit code = %d (expected updates=%v)", result, exitCode, expected)
+	}
+}
+
+// TestHasUpdatesAvailable_Apt tests the apt list --upgradable path on Debian systems.
+func TestHasUpdatesAvailable_Apt(t *testing.T) {
+	if _, err := exec.LookPath("apt"); err != nil {
+		t.Skip("apt not available on this system")
+	}
+	// Only run on actual apt-based systems (Fedora has apt but it's not the primary PM)
+	if _, err := exec.LookPath("dpkg"); err != nil {
+		t.Skip("not a dpkg-based system")
+	}
+
+	e := NewExecutor(nil)
+	result := e.hasUpdatesAvailable(context.Background(), false)
+	t.Logf("hasUpdatesAvailable (apt) = %v", result)
+}
+
+// TestAutoremoveChangedDetection_Dnf tests parsing of dnf autoremove output.
+func TestAutoremoveChangedDetection_Dnf(t *testing.T) {
+	tests := []struct {
+		name    string
+		stdout  string
+		changed bool
+	}{
+		{
+			name:    "nothing to do",
+			stdout:  "Dependencies resolved.\nNothing to do.\nComplete!\n",
+			changed: false,
+		},
+		{
+			name:    "packages removed",
+			stdout:  "Dependencies resolved.\nRemoving:\n maliit-keyboard  x86_64  2.3.1  @System  1.2M\nRemoved:\n maliit-keyboard-2.3.1\nComplete!\n",
+			changed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changed := !strings.Contains(tt.stdout, "Nothing to do")
+			if changed != tt.changed {
+				t.Errorf("expected changed=%v for output %q", tt.changed, tt.stdout)
+			}
+		})
+	}
+}
+
+// TestAutoremoveChangedDetection_Apt tests parsing of apt autoremove output.
+func TestAutoremoveChangedDetection_Apt(t *testing.T) {
+	tests := []struct {
+		name    string
+		stdout  string
+		changed bool
+	}{
+		{
+			name:    "nothing to remove",
+			stdout:  "Reading package lists... Done\nBuilding dependency tree... Done\n0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.\n",
+			changed: false,
+		},
+		{
+			name:    "packages removed",
+			stdout:  "Reading package lists... Done\nBuilding dependency tree... Done\nThe following packages will be REMOVED:\n  libfoo libbar\n0 upgraded, 0 newly installed, 2 to remove and 0 not upgraded.\nRemoving libfoo...\n",
+			changed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changed := !strings.Contains(tt.stdout, "0 upgraded, 0 newly installed, 0 to remove")
+			if changed != tt.changed {
+				t.Errorf("expected changed=%v for output %q", tt.changed, tt.stdout)
+			}
+		})
+	}
+}

--- a/internal/executor/update_test.go
+++ b/internal/executor/update_test.go
@@ -2,26 +2,24 @@ package executor
 
 import (
 	"context"
-	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/pkg"
 )
 
 // TestHasUpdatesAvailable_Dnf tests the dnf check-update path on Fedora systems.
 func TestHasUpdatesAvailable_Dnf(t *testing.T) {
-	if _, err := exec.LookPath("dnf"); err != nil {
-		t.Skip("dnf not available on this system")
+	if !pkg.IsDnf() {
+		t.Skip("not a dnf-based system")
 	}
 
 	e := NewExecutor(nil)
-	// Just verify it doesn't panic/crash — the actual result depends on system state
 	result := e.hasUpdatesAvailable(context.Background(), false)
 	t.Logf("hasUpdatesAvailable (dnf) = %v", result)
 
 	// Cross-check with dnf check-update exit code
-	cmd := exec.Command("dnf", "check-update")
-	cmd.Run()
-	exitCode := cmd.ProcessState.ExitCode()
+	_, exitCode, _ := queryCmdOutput("dnf", "check-update")
 	expected := exitCode == 100
 
 	if result != expected {
@@ -31,21 +29,39 @@ func TestHasUpdatesAvailable_Dnf(t *testing.T) {
 
 // TestHasUpdatesAvailable_Apt tests the apt list --upgradable path on Debian systems.
 func TestHasUpdatesAvailable_Apt(t *testing.T) {
-	if _, err := exec.LookPath("apt"); err != nil {
-		t.Skip("apt not available on this system")
-	}
-	// Only run on actual apt-based systems (Fedora has apt but it's not the primary PM)
-	if _, err := exec.LookPath("dpkg"); err != nil {
-		t.Skip("not a dpkg-based system")
+	if !pkg.IsApt() {
+		t.Skip("not an apt-based system")
 	}
 
 	e := NewExecutor(nil)
 	result := e.hasUpdatesAvailable(context.Background(), false)
 	t.Logf("hasUpdatesAvailable (apt) = %v", result)
+
+	// Cross-check with apt list --upgradable
+	out, _, _ := queryCmdOutput("apt", "list", "--upgradable")
+	expected := false
+	for _, line := range splitLines(out) {
+		if line != "" && line != "Listing..." {
+			expected = true
+			break
+		}
+	}
+
+	if result != expected {
+		t.Errorf("hasUpdatesAvailable() = %v, but apt list --upgradable says updates=%v", result, expected)
+	}
 }
 
-// TestAutoremoveChangedDetection_Dnf tests parsing of dnf autoremove output.
-func TestAutoremoveChangedDetection_Dnf(t *testing.T) {
+func splitLines(s string) []string {
+	var lines []string
+	for _, l := range strings.Split(s, "\n") {
+		lines = append(lines, strings.TrimSpace(l))
+	}
+	return lines
+}
+
+// TestDnfAutoremoveChanged tests parsing of dnf autoremove output.
+func TestDnfAutoremoveChanged(t *testing.T) {
 	tests := []struct {
 		name    string
 		stdout  string
@@ -65,16 +81,15 @@ func TestAutoremoveChangedDetection_Dnf(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			changed := !strings.Contains(tt.stdout, "Nothing to do")
-			if changed != tt.changed {
-				t.Errorf("expected changed=%v for output %q", tt.changed, tt.stdout)
+			if dnfAutoremoveChanged(tt.stdout) != tt.changed {
+				t.Errorf("dnfAutoremoveChanged() = %v, want %v", !tt.changed, tt.changed)
 			}
 		})
 	}
 }
 
-// TestAutoremoveChangedDetection_Apt tests parsing of apt autoremove output.
-func TestAutoremoveChangedDetection_Apt(t *testing.T) {
+// TestAptAutoremoveChanged tests parsing of apt autoremove output.
+func TestAptAutoremoveChanged(t *testing.T) {
 	tests := []struct {
 		name    string
 		stdout  string
@@ -94,9 +109,8 @@ func TestAutoremoveChangedDetection_Apt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			changed := !strings.Contains(tt.stdout, "0 upgraded, 0 newly installed, 0 to remove")
-			if changed != tt.changed {
-				t.Errorf("expected changed=%v for output %q", tt.changed, tt.stdout)
+			if aptAutoremoveChanged(tt.stdout) != tt.changed {
+				t.Errorf("aptAutoremoveChanged() = %v, want %v", !tt.changed, tt.changed)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

`executeUpdate` returned `(*pb.CommandOutput, error)` without a `changed` bool. The default in `ExecuteWithStreaming` is `Changed: true`, so every system update reported changes even when no packages were upgraded and autoremove removed nothing.

### Changes
- Change `executeUpdate` signature to `(*pb.CommandOutput, bool, error)`
- Add `hasUpdatesAvailable()` — checks `dnf check-update` (exit 100 = updates pending) or `apt list --upgradable`
- Re-check after index update in case new updates became visible
- Detect whether autoremove actually removed packages (dnf: "Nothing to do", apt: "0 to remove")
- Report `changed = updatesAvailable || autoremoved || rebootRequired`

## Test plan

- [ ] `go build ./cmd/power-manage-agent` compiles
- [ ] `go test ./...` passes
- [ ] System update with no pending updates and no autoremove → `changed=false`
- [ ] System update with pending updates → `changed=true`
- [ ] System update with autoremove removing packages → `changed=true`

Closes manchtools/power-manage-agent#21


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Accurate reporting when update actions actually change the system (including autoremove outcomes).
  * Improved detection of available updates across APT, DNF, Pacman, Zypper and safer fallback for unknown managers.
  * Reboot-required state now influences post-update notification/scheduling.

* **Tests**
  * Added tests for update-availability detection and autoremove/reboot-detection parsing across package managers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->