### PR TITLE
fix: language-agnostic change detection for system updates

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1612,9 +1612,12 @@ func (e *Executor) hasUpdatesAvailable(ctx context.Context, securityOnly bool) b
 		return exitCode == 100
 	}
 	if pkg.IsApt() {
-		// apt-get -s upgrade: simulate and count lines with "Inst " prefix (language-agnostic)
-		args := []string{"-s", "upgrade"}
-		out, _, _ := queryCmdOutput("apt-get", args...)
+		// apt/apt-get -s upgrade: simulate and count lines with "Inst " prefix (language-agnostic)
+		aptCmd := "apt-get"
+		if _, err := exec.LookPath("apt"); err == nil {
+			aptCmd = "apt"
+		}
+		out, _, _ := queryCmdOutput(aptCmd, "-s", "upgrade")
 		for _, line := range strings.Split(out, "\n") {
 			if strings.HasPrefix(line, "Inst ") {
 				return true

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1600,9 +1600,10 @@ func dnfMakecache(ctx context.Context) (*pb.CommandOutput, error) {
 }
 
 // hasUpdatesAvailable checks if there are pending package updates.
-// When securityOnly is true, only security updates are considered.
+// Uses exit codes and structured queries — language-agnostic.
 func (e *Executor) hasUpdatesAvailable(ctx context.Context, securityOnly bool) bool {
 	if pkg.IsDnf() {
+		// dnf check-update: exit 100 = updates available, 0 = none (language-agnostic)
 		args := []string{"check-update"}
 		if securityOnly {
 			args = append(args, "--security")
@@ -1611,28 +1612,59 @@ func (e *Executor) hasUpdatesAvailable(ctx context.Context, securityOnly bool) b
 		return exitCode == 100
 	}
 	if pkg.IsApt() {
-		out, exitCode, _ := queryCmdOutput("apt", "list", "--upgradable")
-		if exitCode != 0 {
-			return true // assume updates on error
-		}
+		// apt-get -s upgrade: simulate and count lines with "Inst " prefix (language-agnostic)
+		args := []string{"-s", "upgrade"}
+		out, _, _ := queryCmdOutput("apt-get", args...)
 		for _, line := range strings.Split(out, "\n") {
-			line = strings.TrimSpace(line)
-			if line != "" && !strings.HasPrefix(line, "Listing") {
+			if strings.HasPrefix(line, "Inst ") {
 				return true
 			}
 		}
 		return false
 	}
 	if pkg.IsPacman() {
-		// pacman -Qu lists upgradable packages (exit 0 = has updates, 1 = none)
+		// pacman -Qu: exit 0 = updates available, 1 = none (language-agnostic)
 		_, exitCode, _ := queryCmdOutput("pacman", "-Qu")
 		return exitCode == 0
 	}
 	if pkg.IsZypper() {
-		out, _, _ := queryCmdOutput("zypper", "--non-interactive", "list-updates")
-		return zypperHasUpdates(out)
+		// zypper: exit 100 = updates available, 0 = none
+		_, exitCode, _ := queryCmdOutput("zypper", "--non-interactive", "list-updates")
+		return exitCode == 100
 	}
 	return true // assume updates for unknown package managers
+}
+
+// installedPackageCount returns the number of installed packages (language-agnostic).
+func installedPackageCount() int {
+	if pkg.IsDnf() {
+		out, exitCode, _ := queryCmdOutput("rpm", "-qa", "--qf", "x\n")
+		if exitCode != 0 {
+			return -1
+		}
+		return strings.Count(out, "x\n")
+	}
+	if pkg.IsApt() {
+		out, exitCode, _ := queryCmdOutput("dpkg-query", "-f", "x\n", "-W")
+		if exitCode != 0 {
+			return -1
+		}
+		return strings.Count(out, "x\n")
+	}
+	if pkg.IsPacman() {
+		out, exitCode, _ := queryCmdOutput("pacman", "-Qq")
+		if exitCode != 0 {
+			return -1
+		}
+		count := 0
+		for _, line := range strings.Split(out, "\n") {
+			if strings.TrimSpace(line) != "" {
+				count++
+			}
+		}
+		return count
+	}
+	return -1
 }
 
 // dnfUpgrade runs dnf upgrade. If securityOnly is true, only security updates are applied.
@@ -1648,35 +1680,6 @@ func dnfAutoremove(ctx context.Context) (*pb.CommandOutput, error) {
 	return runSudoCmd(ctx, "dnf", "-y", "autoremove")
 }
 
-// zypperHasUpdates parses zypper list-updates output to detect pending updates.
-// Zypper outputs table rows where the status column is "v" (available) or "i" (installed).
-// The format is "v  | repo | name | ..." with variable whitespace.
-func zypperHasUpdates(output string) bool {
-	for _, line := range strings.Split(output, "\n") {
-		line = strings.TrimSpace(line)
-		if len(line) == 0 || line[0] == '-' || line[0] == 'S' {
-			continue // skip empty, separator, and header lines
-		}
-		// Status column is the first field before "|"
-		if idx := strings.Index(line, "|"); idx > 0 {
-			status := strings.TrimSpace(line[:idx])
-			if status == "v" || status == "i" {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// dnfAutoremoveChanged returns true if dnf autoremove output indicates packages were removed.
-func dnfAutoremoveChanged(stdout string) bool {
-	return !strings.Contains(stdout, "Nothing to do")
-}
-
-// aptAutoremoveChanged returns true if apt autoremove output indicates packages were removed.
-func aptAutoremoveChanged(stdout string) bool {
-	return !strings.Contains(stdout, "0 upgraded, 0 newly installed, 0 to remove")
-}
 
 // =============================================================================
 // Zypper Helper Functions
@@ -2123,26 +2126,27 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 		}
 	}
 
-	// Autoremove if requested
+	// Autoremove if requested — use package count comparison (language-agnostic)
 	autoremoved := false
 	if params != nil && params.Autoremove {
 		allOutput.WriteString("\n=== Autoremove Unused Packages ===\n")
+		countBefore := installedPackageCount()
 		if pkg.IsApt() {
 			apt := pkg.NewAptWithContext(ctx)
 			if output, err := apt.Autoremove(); err == nil {
 				allOutput.WriteString(output.Stdout)
-				autoremoved = aptAutoremoveChanged(output.Stdout)
 			} else if output != nil {
 				allOutput.WriteString(output.Stderr)
 			}
 		} else if pkg.IsDnf() {
 			if output, err := dnfAutoremove(ctx); err == nil {
 				allOutput.WriteString(output.Stdout)
-				autoremoved = dnfAutoremoveChanged(output.Stdout)
 			} else if output != nil {
 				allOutput.WriteString(output.Stderr)
 			}
 		}
+		countAfter := installedPackageCount()
+		autoremoved = countBefore > 0 && countAfter > 0 && countBefore != countAfter
 	}
 
 	// Check if this run created a new reboot requirement.

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1640,7 +1640,7 @@ func (e *Executor) hasUpdatesAvailable(ctx context.Context, securityOnly bool) b
 
 // installedPackageCount returns the number of installed packages (language-agnostic).
 func installedPackageCount() int {
-	if pkg.IsDnf() {
+	if pkg.IsDnf() || pkg.IsZypper() {
 		out, exitCode, _ := queryCmdOutput("rpm", "-qa", "--qf", "x\n")
 		if exitCode != 0 {
 			return -1

--- a/internal/executor/update_test.go
+++ b/internal/executor/update_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -37,12 +38,16 @@ func TestHasUpdatesAvailable_Apt(t *testing.T) {
 	result := e.hasUpdatesAvailable(context.Background(), false)
 	t.Logf("hasUpdatesAvailable (apt) = %v", result)
 
-	// Cross-check: apt-get -s upgrade "Inst " prefix is language-agnostic
-	out, _, _ := queryCmdOutput("apt-get", "-s", "upgrade")
+	// Cross-check: apt/apt-get -s upgrade "Inst " prefix is language-agnostic
+	aptCmd := "apt-get"
+	if _, err := exec.LookPath("apt"); err == nil {
+		aptCmd = "apt"
+	}
+	out, _, _ := queryCmdOutput(aptCmd, "-s", "upgrade")
 	expected := strings.Contains(out, "Inst ")
 
 	if result != expected {
-		t.Errorf("hasUpdatesAvailable() = %v, but apt-get -s upgrade says updates=%v", result, expected)
+		t.Errorf("hasUpdatesAvailable() = %v, but %s -s upgrade says updates=%v", result, aptCmd, expected)
 	}
 }
 

--- a/internal/executor/update_test.go
+++ b/internal/executor/update_test.go
@@ -18,7 +18,7 @@ func TestHasUpdatesAvailable_Dnf(t *testing.T) {
 	result := e.hasUpdatesAvailable(context.Background(), false)
 	t.Logf("hasUpdatesAvailable (dnf) = %v", result)
 
-	// Cross-check with dnf check-update exit code
+	// Cross-check with dnf check-update exit code (language-agnostic)
 	_, exitCode, _ := queryCmdOutput("dnf", "check-update")
 	expected := exitCode == 100
 
@@ -27,7 +27,7 @@ func TestHasUpdatesAvailable_Dnf(t *testing.T) {
 	}
 }
 
-// TestHasUpdatesAvailable_Apt tests the apt list --upgradable path on Debian systems.
+// TestHasUpdatesAvailable_Apt tests the apt-get -s upgrade path on Debian systems.
 func TestHasUpdatesAvailable_Apt(t *testing.T) {
 	if !pkg.IsApt() {
 		t.Skip("not an apt-based system")
@@ -37,82 +37,12 @@ func TestHasUpdatesAvailable_Apt(t *testing.T) {
 	result := e.hasUpdatesAvailable(context.Background(), false)
 	t.Logf("hasUpdatesAvailable (apt) = %v", result)
 
-	// Cross-check with apt list --upgradable
-	out, _, _ := queryCmdOutput("apt", "list", "--upgradable")
-	expected := false
-	for _, line := range splitLines(out) {
-		if line != "" && line != "Listing..." {
-			expected = true
-			break
-		}
-	}
+	// Cross-check: apt-get -s upgrade "Inst " prefix is language-agnostic
+	out, _, _ := queryCmdOutput("apt-get", "-s", "upgrade")
+	expected := strings.Contains(out, "Inst ")
 
 	if result != expected {
-		t.Errorf("hasUpdatesAvailable() = %v, but apt list --upgradable says updates=%v", result, expected)
-	}
-}
-
-func splitLines(s string) []string {
-	var lines []string
-	for _, l := range strings.Split(s, "\n") {
-		lines = append(lines, strings.TrimSpace(l))
-	}
-	return lines
-}
-
-// TestDnfAutoremoveChanged tests parsing of dnf autoremove output.
-func TestDnfAutoremoveChanged(t *testing.T) {
-	tests := []struct {
-		name    string
-		stdout  string
-		changed bool
-	}{
-		{
-			name:    "nothing to do",
-			stdout:  "Dependencies resolved.\nNothing to do.\nComplete!\n",
-			changed: false,
-		},
-		{
-			name:    "packages removed",
-			stdout:  "Dependencies resolved.\nRemoving:\n maliit-keyboard  x86_64  2.3.1  @System  1.2M\nRemoved:\n maliit-keyboard-2.3.1\nComplete!\n",
-			changed: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if dnfAutoremoveChanged(tt.stdout) != tt.changed {
-				t.Errorf("dnfAutoremoveChanged() = %v, want %v", !tt.changed, tt.changed)
-			}
-		})
-	}
-}
-
-// TestAptAutoremoveChanged tests parsing of apt autoremove output.
-func TestAptAutoremoveChanged(t *testing.T) {
-	tests := []struct {
-		name    string
-		stdout  string
-		changed bool
-	}{
-		{
-			name:    "nothing to remove",
-			stdout:  "Reading package lists... Done\nBuilding dependency tree... Done\n0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.\n",
-			changed: false,
-		},
-		{
-			name:    "packages removed",
-			stdout:  "Reading package lists... Done\nBuilding dependency tree... Done\nThe following packages will be REMOVED:\n  libfoo libbar\n0 upgraded, 0 newly installed, 2 to remove and 0 not upgraded.\nRemoving libfoo...\n",
-			changed: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if aptAutoremoveChanged(tt.stdout) != tt.changed {
-				t.Errorf("aptAutoremoveChanged() = %v, want %v", !tt.changed, tt.changed)
-			}
-		})
+		t.Errorf("hasUpdatesAvailable() = %v, but apt-get -s upgrade says updates=%v", result, expected)
 	}
 }
 
@@ -126,7 +56,6 @@ func TestHasUpdatesAvailable_Pacman(t *testing.T) {
 	result := e.hasUpdatesAvailable(context.Background(), false)
 	t.Logf("hasUpdatesAvailable (pacman) = %v", result)
 
-	// Cross-check with pacman -Qu exit code (0 = updates, 1 = none)
 	_, exitCode, _ := queryCmdOutput("pacman", "-Qu")
 	expected := exitCode == 0
 
@@ -146,53 +75,26 @@ func TestHasUpdatesAvailable_Zypper(t *testing.T) {
 	t.Logf("hasUpdatesAvailable (zypper) = %v", result)
 }
 
-// TestZypperHasUpdates tests parsing of zypper list-updates output.
-func TestZypperHasUpdates(t *testing.T) {
-	tests := []struct {
-		name   string
-		output string
-		want   bool
-	}{
-		{
-			name:   "no updates",
-			output: "Loading repository data...\nReading installed packages...\nNo updates found.\n",
-			want:   false,
-		},
-		{
-			name:   "empty output",
-			output: "",
-			want:   false,
-		},
-		{
-			name: "updates available",
-			output: `Loading repository data...
-Reading installed packages...
-
-S  | Repository | Name     | Current Version | Available Version | Arch
----+------------+----------+-----------------+-------------------+-------
-v  | update     | libzypp  | 17.31.8-1       | 17.31.9-1         | x86_64
-v  | update     | zypper   | 1.14.59-1       | 1.14.60-1         | x86_64
-`,
-			want: true,
-		},
-		{
-			name: "installed updates",
-			output: `Loading repository data...
-Reading installed packages...
-
-S  | Repository | Name     | Current Version | Available Version | Arch
----+------------+----------+-----------------+-------------------+-------
-i  | update     | kernel   | 6.7.1-1         | 6.7.2-1           | x86_64
-`,
-			want: true,
-		},
+// TestInstalledPackageCount verifies the package count function works on the current system.
+func TestInstalledPackageCount(t *testing.T) {
+	count := installedPackageCount()
+	if count <= 0 {
+		t.Skipf("installedPackageCount() = %d (no supported package manager or error)", count)
 	}
+	t.Logf("installedPackageCount() = %d", count)
+	if count < 100 {
+		t.Errorf("suspiciously low package count: %d", count)
+	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if zypperHasUpdates(tt.output) != tt.want {
-				t.Errorf("zypperHasUpdates() = %v, want %v", !tt.want, tt.want)
-			}
-		})
+// TestInstalledPackageCount_Stable verifies that two consecutive calls return the same count.
+func TestInstalledPackageCount_Stable(t *testing.T) {
+	a := installedPackageCount()
+	if a <= 0 {
+		t.Skip("no supported package manager")
+	}
+	b := installedPackageCount()
+	if a != b {
+		t.Errorf("package count not stable: %d vs %d", a, b)
 	}
 }

--- a/internal/executor/update_test.go
+++ b/internal/executor/update_test.go
@@ -47,7 +47,10 @@ func TestHasUpdatesAvailable_Apt(t *testing.T) {
 	if _, err := exec.LookPath("apt"); err == nil {
 		aptCmd = "apt"
 	}
-	out, _, _ := queryCmdOutput(aptCmd, "-s", "upgrade")
+	out, exitCode, err := queryCmdOutput(aptCmd, "-s", "upgrade")
+	if err != nil && exitCode != 0 {
+		t.Fatalf("%s -s upgrade failed with exit %d: %v", aptCmd, exitCode, err)
+	}
 	expected := strings.Contains(out, "Inst ")
 
 	if result != expected {

--- a/internal/executor/update_test.go
+++ b/internal/executor/update_test.go
@@ -20,7 +20,11 @@ func TestHasUpdatesAvailable_Dnf(t *testing.T) {
 	t.Logf("hasUpdatesAvailable (dnf) = %v", result)
 
 	// Cross-check with dnf check-update exit code (language-agnostic)
-	_, exitCode, _ := queryCmdOutput("dnf", "check-update")
+	// Exit 0 = no updates, 100 = updates available, anything else = error
+	_, exitCode, err := queryCmdOutput("dnf", "check-update")
+	if err != nil && exitCode != 100 {
+		t.Skipf("dnf check-update failed with exit %d: %v", exitCode, err)
+	}
 	expected := exitCode == 100
 
 	if result != expected {
@@ -87,9 +91,6 @@ func TestInstalledPackageCount(t *testing.T) {
 		t.Skipf("installedPackageCount() = %d (no supported package manager or error)", count)
 	}
 	t.Logf("installedPackageCount() = %d", count)
-	if count < 100 {
-		t.Errorf("suspiciously low package count: %d", count)
-	}
 }
 
 // TestInstalledPackageCount_Stable verifies that two consecutive calls return the same count.


### PR DESCRIPTION
## Summary

Change detection for system updates failed on non-English locales. The old approach parsed localized strings like `"Nothing to do"` (German: `"Nichts zu tun"`) and `"0 to remove"` (German: `"Entferne: 0"`), causing `changed=true` on every run.

### New approach — fully language-agnostic

**Update detection:**
- apt: `apt-get -s upgrade` with `"Inst "` prefix (always English, even on localized systems)
- dnf: `check-update` exit code 100 (already was language-agnostic)
- pacman: `-Qu` exit code (already was language-agnostic)
- zypper: exit code 100

**Autoremove detection:**
- Compare `installedPackageCount()` before and after the operation
- Uses `dpkg-query -W`, `rpm -qa`, or `pacman -Qq` — all return structured output regardless of locale

### Removed
- `aptAutoremoveChanged()` — parsed English "0 to remove"
- `dnfAutoremoveChanged()` — parsed English "Nothing to do"
- `zypperHasUpdates()` — parsed table format

## Test plan

- [ ] `go build ./cmd/power-manage-agent` compiles
- [ ] `go test ./...` passes
- [ ] System update on German Debian with no updates → `changed=false`
- [ ] System update on German Fedora with no updates → `changed=false`
- [ ] `installedPackageCount()` returns stable, sane values

Closes manchtools/power-manage-agent#23


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate detection of available updates across package managers by replacing fragile output parsing with more reliable checks.
  * More reliable detection of whether automatic package removal changed the system by comparing installed-package counts.
  * Improved consistency of overall package status reporting.

* **Tests**
  * Updated update-detection tests and removed fragile parsing tests.
  * Added system-level installed-package count checks and a stability test for consecutive readings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->