### PR TITLE
refactor: extract reusable executor helpers

### DIFF
--- a/internal/executor/agent_update.go
+++ b/internal/executor/agent_update.go
@@ -188,8 +188,15 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 	}
 
 	// Step 10: Write state.json with version for startup verification.
+	// This must succeed before shutdown — otherwise the new binary starts
+	// without a state marker and may trigger a false rollback.
 	if err := writeUpdateState(cfg.DataDir, "staged", newVersion); err != nil {
-		e.logger.Warn("failed to write update state", "error", err)
+		e.logger.Error("failed to write update state, rolling back binary", "error", err)
+		if _, mvErr := runSudoCmd(ctx, "mv", backupPath, cfg.BinaryPath); mvErr != nil {
+			e.logger.Error("rollback failed, system may be in inconsistent state", "error", mvErr)
+		}
+		writeCooldown(cfg.DataDir, newVersion, 1*time.Hour)
+		return nil, false, fmt.Errorf("write update state: %w", err)
 	}
 
 	// Step 11: Signal graceful shutdown — systemd restarts with new binary

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3446,7 +3446,7 @@ func (e *Executor) setupSshAccess(ctx context.Context, params *pb.SshParams, use
 
 	// Sync group membership
 	if memberChanged, err := syncGroupMembers(ctx, groupName, users, &output); err != nil {
-		return nil, false, err
+		return &pb.CommandOutput{ExitCode: 1, Stdout: output.String(), Stderr: err.Error()}, changed, err
 	} else if memberChanged {
 		changed = true
 	}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3463,7 +3463,8 @@ func (e *Executor) removeSshAccess(ctx context.Context, groupName, configPath st
 
 	changed, err := e.removeGroupWithConfig(ctx, groupName, configPath, &output)
 	if err != nil {
-		return nil, false, err
+		// Group deletion failure is non-fatal for SSH (config removal is the important part)
+		output.WriteString(fmt.Sprintf("warning: %v\n", err))
 	}
 
 	if !changed {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3460,35 +3460,10 @@ func (e *Executor) setupSshAccess(ctx context.Context, params *pb.SshParams, use
 // removeSshAccess removes the sshd_config.d file, group membership, and group.
 func (e *Executor) removeSshAccess(ctx context.Context, groupName, configPath string) (*pb.CommandOutput, bool, error) {
 	var output strings.Builder
-	changed := false
 
-	// Remove sshd config file
-	if fileExistsWithSudo(ctx, configPath) {
-		if out, err := e.requireWritableFSShort(ctx); err != nil {
-			return out, false, err
-		}
-		if err := removeFileStrict(ctx, configPath); err != nil {
-			return nil, false, fmt.Errorf("remove ssh config: %w", err)
-		}
-		output.WriteString(fmt.Sprintf("removed SSH config: %s\n", configPath))
-		changed = true
-	}
-
-	// Remove group and membership
-	if groupExists(groupName) {
-		members := getGroupMembers(groupName)
-		for _, member := range members {
-			if err := removeUserFromGroup(ctx, member, groupName); err == nil {
-				output.WriteString(fmt.Sprintf("removed user %s from group %s\n", member, groupName))
-				changed = true
-			}
-		}
-		if err := sysuser.GroupDelete(ctx, groupName); err != nil {
-			output.WriteString(fmt.Sprintf("warning: failed to delete group %s: %v\n", groupName, err))
-		} else {
-			output.WriteString(fmt.Sprintf("deleted group: %s\n", groupName))
-			changed = true
-		}
+	changed, err := e.removeGroupWithConfig(ctx, groupName, configPath, &output)
+	if err != nil {
+		return nil, false, err
 	}
 
 	if !changed {
@@ -3569,25 +3544,10 @@ func (e *Executor) setupSshdConfig(ctx context.Context, params *pb.SshdParams, c
 		return nil, false, fmt.Errorf("create sshd_config.d: %w", err)
 	}
 
-	if err := atomicWriteFile(ctx, configPath, content, "0644", "root", "root"); err != nil {
-		return nil, false, fmt.Errorf("write sshd config: %w", err)
+	if out, err := e.writeAndValidateConfig(ctx, configPath, content, "0644", "root", "root", "sshd", "-t"); err != nil {
+		return out, false, err
 	}
 	output.WriteString(fmt.Sprintf("created SSHD config: %s\n", configPath))
-
-	// Validate config
-	validateOut, validateErr := runSudoCmd(ctx, "sshd", "-t")
-	if validateErr != nil {
-		// Config is invalid — remove it and report error
-		removeFileStrict(ctx, configPath)
-		errMsg := "sshd config validation failed"
-		if validateOut != nil && validateOut.Stderr != "" {
-			errMsg = strings.TrimSpace(validateOut.Stderr)
-		}
-		return &pb.CommandOutput{
-			ExitCode: 1,
-			Stderr:   errMsg,
-		}, false, fmt.Errorf("sshd -t validation failed: %s", errMsg)
-	}
 
 	// Reload sshd
 	reloadOut, reloadErr := runSudoCmd(ctx, "systemctl", "reload", "sshd")

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3463,7 +3463,11 @@ func (e *Executor) removeSshAccess(ctx context.Context, groupName, configPath st
 
 	changed, err := e.removeGroupWithConfig(ctx, groupName, configPath, &output)
 	if err != nil {
-		// Group deletion failure is non-fatal for SSH (config removal is the important part)
+		if !changed {
+			// Config file removal failed — fatal
+			return nil, false, err
+		}
+		// Config removed but group deletion failed — non-fatal warning
 		output.WriteString(fmt.Sprintf("warning: %v\n", err))
 	}
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -138,10 +138,7 @@ func (e *Executor) ExecuteWithStreaming(ctx context.Context, action *pb.Action, 
 
 	// Verify action signature before execution (skip for instant actions — they have no params to sign)
 	if e.verifier != nil && !isInstantAction(action.Type) {
-		actionID := ""
-		if action.Id != nil {
-			actionID = action.Id.Value
-		}
+		actionID := getActionID(action)
 		verifyErr := e.verifier.Verify(actionID, int32(action.Type), action.ParamsCanonical, action.Signature)
 		if verifyErr != nil {
 			// Shell scripts and sudo policies: hard reject unsigned/tampered actions
@@ -228,36 +225,20 @@ func (e *Executor) ExecuteWithStreaming(ctx context.Context, action *pb.Action, 
 		result.Changed = changed
 	case pb.ActionType_ACTION_TYPE_SSH:
 		var changed bool
-		sshActionID := ""
-		if action.Id != nil {
-			sshActionID = action.Id.Value
-		}
-		output, changed, execErr = e.executeSsh(ctx, action.GetSsh(), action.DesiredState, sshActionID)
+		output, changed, execErr = e.executeSsh(ctx, action.GetSsh(), action.DesiredState, getActionID(action))
 		result.Changed = changed
 	case pb.ActionType_ACTION_TYPE_SSHD:
 		var changed bool
-		sshdActionID := ""
-		if action.Id != nil {
-			sshdActionID = action.Id.Value
-		}
-		output, changed, execErr = e.executeSshd(ctx, action.GetSshd(), action.DesiredState, sshdActionID)
+		output, changed, execErr = e.executeSshd(ctx, action.GetSshd(), action.DesiredState, getActionID(action))
 		result.Changed = changed
 	case pb.ActionType_ACTION_TYPE_SUDO:
 		var changed bool
-		sudoActionID := ""
-		if action.Id != nil {
-			sudoActionID = action.Id.Value
-		}
-		output, changed, execErr = e.executeSudo(ctx, action.GetSudo(), action.DesiredState, sudoActionID)
+		output, changed, execErr = e.executeSudo(ctx, action.GetSudo(), action.DesiredState, getActionID(action))
 		result.Changed = changed
 	case pb.ActionType_ACTION_TYPE_LPS:
 		var changed bool
 		var metadata map[string]string
-		lpsActionID := ""
-		if action.Id != nil {
-			lpsActionID = action.Id.Value
-		}
-		output, changed, metadata, execErr = e.executeLps(ctx, action.GetLps(), action.DesiredState, lpsActionID)
+		output, changed, metadata, execErr = e.executeLps(ctx, action.GetLps(), action.DesiredState, getActionID(action))
 		result.Changed = changed
 		if len(metadata) > 0 {
 			result.Metadata = metadata
@@ -265,22 +246,14 @@ func (e *Executor) ExecuteWithStreaming(ctx context.Context, action *pb.Action, 
 	case pb.ActionType_ACTION_TYPE_LUKS:
 		var changed bool
 		var metadata map[string]string
-		luksActionID := ""
-		if action.Id != nil {
-			luksActionID = action.Id.Value
-		}
-		output, changed, metadata, execErr = e.executeLuks(ctx, action.GetLuks(), action.DesiredState, luksActionID)
+		output, changed, metadata, execErr = e.executeLuks(ctx, action.GetLuks(), action.DesiredState, getActionID(action))
 		result.Changed = changed
 		if len(metadata) > 0 {
 			result.Metadata = metadata
 		}
 	case pb.ActionType_ACTION_TYPE_WIFI:
 		var changed bool
-		wifiActionID := ""
-		if action.Id != nil {
-			wifiActionID = action.Id.Value
-		}
-		output, changed, execErr = e.executeWifi(ctx, action.GetWifi(), action.DesiredState, wifiActionID)
+		output, changed, execErr = e.executeWifi(ctx, action.GetWifi(), action.DesiredState, getActionID(action))
 		result.Changed = changed
 	case pb.ActionType_ACTION_TYPE_REBOOT:
 		output, execErr = e.executeReboot(ctx)
@@ -413,11 +386,8 @@ func (e *Executor) executePackage(ctx context.Context, params *pb.PackageParams,
 		}
 
 		// Repair filesystem if mounted read-only (common after kernel errors)
-		if !e.repairFilesystem(ctx) {
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   "filesystem is read-only and could not be remounted - system may need reboot and fsck",
-			}, false, fmt.Errorf("filesystem is read-only")
+		if out, err := e.requireWritableFS(ctx); err != nil {
+			return out, false, err
 		}
 
 		// Repair any broken package manager state before proceeding
@@ -456,11 +426,8 @@ func (e *Executor) executePackage(ctx context.Context, params *pb.PackageParams,
 		}
 
 		// Repair filesystem if mounted read-only
-		if !e.repairFilesystem(ctx) {
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   "filesystem is read-only and could not be remounted - system may need reboot and fsck",
-			}, false, fmt.Errorf("filesystem is read-only")
+		if out, err := e.requireWritableFS(ctx); err != nil {
+			return out, false, err
 		}
 
 		// Repair any broken package manager state before proceeding
@@ -575,11 +542,8 @@ func (e *Executor) executeAppImage(ctx context.Context, params *pb.AppInstallPar
 		}
 
 		// Repair filesystem if mounted read-only
-		if !e.repairFilesystem(ctx) {
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   "filesystem is read-only and could not be remounted - system may need reboot and fsck",
-			}, false, fmt.Errorf("filesystem is read-only")
+		if out, err := e.requireWritableFS(ctx); err != nil {
+			return out, false, err
 		}
 
 		// Create directory
@@ -612,11 +576,8 @@ func (e *Executor) executeAppImage(ctx context.Context, params *pb.AppInstallPar
 		}
 
 		// Repair filesystem if mounted read-only
-		if !e.repairFilesystem(ctx) {
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   "filesystem is read-only",
-			}, false, fmt.Errorf("filesystem is read-only")
+		if out, err := e.requireWritableFSMinimal(ctx); err != nil {
+			return out, false, err
 		}
 
 		if err := os.Remove(resolvedPath); err != nil {
@@ -673,11 +634,8 @@ func (e *Executor) executeFlatpak(ctx context.Context, params *pb.FlatpakParams,
 		}
 
 		// Repair filesystem if mounted read-only
-		if !e.repairFilesystem(ctx) {
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   "filesystem is read-only and could not be remounted - system may need reboot and fsck",
-			}, false, fmt.Errorf("filesystem is read-only")
+		if out, err := e.requireWritableFS(ctx); err != nil {
+			return out, false, err
 		}
 
 		// Install the flatpak application
@@ -709,11 +667,8 @@ func (e *Executor) executeFlatpak(ctx context.Context, params *pb.FlatpakParams,
 		}
 
 		// Repair filesystem if mounted read-only
-		if !e.repairFilesystem(ctx) {
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   "filesystem is read-only",
-			}, false, fmt.Errorf("filesystem is read-only")
+		if out, err := e.requireWritableFSMinimal(ctx); err != nil {
+			return out, false, err
 		}
 
 		// Remove pin first if it exists
@@ -762,11 +717,8 @@ func (e *Executor) executeDeb(ctx context.Context, params *pb.AppInstallParams, 
 		}
 
 		// Repair filesystem if mounted read-only
-		if !e.repairFilesystem(ctx) {
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   "filesystem is read-only and could not be remounted - system may need reboot and fsck",
-			}, false, fmt.Errorf("filesystem is read-only")
+		if out, err := e.requireWritableFS(ctx); err != nil {
+			return out, false, err
 		}
 
 		// Download to temp file
@@ -798,11 +750,8 @@ func (e *Executor) executeDeb(ctx context.Context, params *pb.AppInstallParams, 
 		}
 
 		// Repair filesystem if mounted read-only
-		if !e.repairFilesystem(ctx) {
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   "filesystem is read-only",
-			}, false, fmt.Errorf("filesystem is read-only")
+		if out, err := e.requireWritableFSMinimal(ctx); err != nil {
+			return out, false, err
 		}
 
 		output, err := runSudoCmd(ctx, "dpkg", "-r", pkgName)
@@ -847,11 +796,8 @@ func (e *Executor) executeRpm(ctx context.Context, params *pb.AppInstallParams, 
 		}
 
 		// Repair filesystem if mounted read-only
-		if !e.repairFilesystem(ctx) {
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   "filesystem is read-only and could not be remounted - system may need reboot and fsck",
-			}, false, fmt.Errorf("filesystem is read-only")
+		if out, err := e.requireWritableFS(ctx); err != nil {
+			return out, false, err
 		}
 
 		// Download to temp file
@@ -879,11 +825,8 @@ func (e *Executor) executeRpm(ctx context.Context, params *pb.AppInstallParams, 
 		}
 
 		// Repair filesystem if mounted read-only
-		if !e.repairFilesystem(ctx) {
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   "filesystem is read-only",
-			}, false, fmt.Errorf("filesystem is read-only")
+		if out, err := e.requireWritableFSMinimal(ctx); err != nil {
+			return out, false, err
 		}
 
 		output, err := runSudoCmd(ctx, "rpm", "-e", pkgName)
@@ -1053,11 +996,8 @@ func (e *Executor) executeSystemd(ctx context.Context, params *pb.SystemdParams)
 
 		if needsUpdate {
 			// Repair filesystem if mounted read-only
-			if !e.repairFilesystem(ctx) {
-				return &pb.CommandOutput{
-					ExitCode: 1,
-					Stderr:   "filesystem is read-only and could not be remounted - system may need reboot and fsck",
-				}, false, fmt.Errorf("filesystem is read-only")
+			if out, err := e.requireWritableFS(ctx); err != nil {
+				return out, false, err
 			}
 
 			// Write unit file using sudo tee
@@ -1174,11 +1114,8 @@ func (e *Executor) executeFile(ctx context.Context, params *pb.FileParams, state
 		}
 
 		// Repair filesystem if mounted read-only
-		if !e.repairFilesystem(ctx) {
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   "filesystem is read-only and could not be remounted - system may need reboot and fsck",
-			}, false, fmt.Errorf("filesystem is read-only")
+		if out, err := e.requireWritableFS(ctx); err != nil {
+			return out, false, err
 		}
 
 		// Create parent directories using sudo
@@ -1234,11 +1171,8 @@ func (e *Executor) executeFile(ctx context.Context, params *pb.FileParams, state
 		}
 
 		// Repair filesystem if mounted read-only
-		if !e.repairFilesystem(ctx) {
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   "filesystem is read-only and could not be remounted - system may need reboot and fsck",
-			}, false, fmt.Errorf("filesystem is read-only")
+		if out, err := e.requireWritableFS(ctx); err != nil {
+			return out, false, err
 		}
 
 		// For managed block mode, remove only the specified content block from the file
@@ -1429,11 +1363,8 @@ func (e *Executor) executeDirectory(ctx context.Context, params *pb.DirectoryPar
 		}
 
 		// Repair filesystem if mounted read-only
-		if !e.repairFilesystem(ctx) {
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   "filesystem is read-only and could not be remounted - system may need reboot and fsck",
-			}, false, fmt.Errorf("filesystem is read-only")
+		if out, err := e.requireWritableFS(ctx); err != nil {
+			return out, false, err
 		}
 
 		// Create directory with permissions (handles mkdir, chmod, and chown)
@@ -1461,11 +1392,8 @@ func (e *Executor) executeDirectory(ctx context.Context, params *pb.DirectoryPar
 		}
 
 		// Repair filesystem if mounted read-only
-		if !e.repairFilesystem(ctx) {
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   "filesystem is read-only and could not be remounted - system may need reboot and fsck",
-			}, false, fmt.Errorf("filesystem is read-only")
+		if out, err := e.requireWritableFS(ctx); err != nil {
+			return out, false, err
 		}
 
 		// Remove directory (use -r for recursive removal if it has contents)
@@ -1783,7 +1711,7 @@ func (e *Executor) ensurePackagePinned(ctx context.Context, pkgName string) (boo
 
 	// Repair filesystem if needed before writing
 	if !e.repairFilesystem(ctx) {
-		return false, fmt.Errorf("filesystem is read-only")
+		return false, errReadOnlyFS
 	}
 
 	return e.pinPackage(pkgName)
@@ -2057,11 +1985,8 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 	}
 
 	// Repair filesystem if mounted read-only (common after kernel errors)
-	if !e.repairFilesystem(ctx) {
-		return &pb.CommandOutput{
-			ExitCode: 1,
-			Stderr:   "filesystem is read-only and could not be remounted - system may need reboot and fsck",
-		}, false, fmt.Errorf("filesystem is read-only")
+	if out, err := e.requireWritableFS(ctx); err != nil {
+		return out, false, err
 	}
 
 	// Repair any broken package manager state first
@@ -2249,11 +2174,8 @@ func (e *Executor) executeRepository(ctx context.Context, params *pb.RepositoryP
 	}
 
 	// Repair filesystem if mounted read-only
-	if !e.repairFilesystem(ctx) {
-		return &pb.CommandOutput{
-			ExitCode: 1,
-			Stderr:   "filesystem is read-only and could not be remounted - system may need reboot and fsck",
-		}, false, fmt.Errorf("filesystem is read-only")
+	if out, err := e.requireWritableFS(ctx); err != nil {
+		return out, false, err
 	}
 
 	if !validRepoName.MatchString(params.Name) {
@@ -2909,11 +2831,8 @@ func (e *Executor) executeUser(ctx context.Context, params *pb.UserParams, state
 	}
 
 	// Repair filesystem if mounted read-only
-	if !e.repairFilesystem(ctx) {
-		return &pb.CommandOutput{
-			ExitCode: 1,
-			Stderr:   "filesystem is read-only and could not be remounted - system may need reboot and fsck",
-		}, false, nil, fmt.Errorf("filesystem is read-only")
+	if out, err := e.requireWritableFS(ctx); err != nil {
+		return out, false, nil, err
 	}
 
 	switch state {
@@ -3499,11 +3418,8 @@ func (e *Executor) setupSshAccess(ctx context.Context, params *pb.SshParams, use
 		}, false, nil
 	}
 
-	if !e.repairFilesystem(ctx) {
-		return &pb.CommandOutput{
-			ExitCode: 1,
-			Stderr:   "filesystem is read-only and could not be remounted",
-		}, false, fmt.Errorf("filesystem is read-only")
+	if out, err := e.requireWritableFSShort(ctx); err != nil {
+		return out, false, err
 	}
 
 	// Ensure group exists
@@ -3528,35 +3444,11 @@ func (e *Executor) setupSshAccess(ctx context.Context, params *pb.SshParams, use
 		changed = true
 	}
 
-	// Add users to group
-	for _, username := range users {
-		if !userExists(username) {
-			output.WriteString(fmt.Sprintf("warning: user %q does not exist, skipping group membership\n", username))
-			continue
-		}
-		if !userInGroup(username, groupName) {
-			if err := addUserToGroup(ctx, username, groupName); err != nil {
-				output.WriteString(fmt.Sprintf("warning: failed to add user %s to group: %v\n", username, err))
-			} else {
-				output.WriteString(fmt.Sprintf("added user %s to group %s\n", username, groupName))
-				changed = true
-			}
-		}
-	}
-
-	// Remove users that are no longer in the list
-	currentMembers := getGroupMembers(groupName)
-	desiredSet := make(map[string]bool, len(users))
-	for _, u := range users {
-		desiredSet[u] = true
-	}
-	for _, member := range currentMembers {
-		if !desiredSet[member] {
-			if err := removeUserFromGroup(ctx, member, groupName); err == nil {
-				output.WriteString(fmt.Sprintf("removed user %s from group %s\n", member, groupName))
-				changed = true
-			}
-		}
+	// Sync group membership
+	if memberChanged, err := syncGroupMembers(ctx, groupName, users, &output); err != nil {
+		return nil, false, err
+	} else if memberChanged {
+		changed = true
 	}
 
 	return &pb.CommandOutput{
@@ -3572,11 +3464,8 @@ func (e *Executor) removeSshAccess(ctx context.Context, groupName, configPath st
 
 	// Remove sshd config file
 	if fileExistsWithSudo(ctx, configPath) {
-		if !e.repairFilesystem(ctx) {
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   "filesystem is read-only and could not be remounted",
-			}, false, fmt.Errorf("filesystem is read-only")
+		if out, err := e.requireWritableFSShort(ctx); err != nil {
+			return out, false, err
 		}
 		if err := removeFileStrict(ctx, configPath); err != nil {
 			return nil, false, fmt.Errorf("remove ssh config: %w", err)
@@ -3671,11 +3560,8 @@ func (e *Executor) setupSshdConfig(ctx context.Context, params *pb.SshdParams, c
 		}, false, nil
 	}
 
-	if !e.repairFilesystem(ctx) {
-		return &pb.CommandOutput{
-			ExitCode: 1,
-			Stderr:   "filesystem is read-only and could not be remounted",
-		}, false, fmt.Errorf("filesystem is read-only")
+	if out, err := e.requireWritableFSShort(ctx); err != nil {
+		return out, false, err
 	}
 
 	// Ensure /etc/ssh/sshd_config.d exists
@@ -3736,11 +3622,8 @@ func (e *Executor) removeSshdConfig(ctx context.Context, configPath string) (*pb
 		}, false, nil
 	}
 
-	if !e.repairFilesystem(ctx) {
-		return &pb.CommandOutput{
-			ExitCode: 1,
-			Stderr:   "filesystem is read-only and could not be remounted",
-		}, false, fmt.Errorf("filesystem is read-only")
+	if out, err := e.requireWritableFSShort(ctx); err != nil {
+		return out, false, err
 	}
 
 	if err := removeFileStrict(ctx, configPath); err != nil {

--- a/internal/executor/group.go
+++ b/internal/executor/group.go
@@ -69,7 +69,7 @@ func (e *Executor) setupGroup(ctx context.Context, params *pb.GroupParams) (*pb.
 
 	// Sync group membership
 	if memberChanged, err := syncGroupMembers(ctx, params.Name, params.Members, &output); err != nil {
-		return nil, false, err
+		return &pb.CommandOutput{ExitCode: 1, Stdout: output.String(), Stderr: err.Error()}, memberChanged, err
 	} else if memberChanged {
 		changed = true
 	}

--- a/internal/executor/group.go
+++ b/internal/executor/group.go
@@ -46,11 +46,8 @@ func (e *Executor) setupGroup(ctx context.Context, params *pb.GroupParams) (*pb.
 		}, false, nil
 	}
 
-	if !e.repairFilesystem(ctx) {
-		return &pb.CommandOutput{
-			ExitCode: 1,
-			Stderr:   "filesystem is read-only and could not be remounted",
-		}, false, fmt.Errorf("filesystem is read-only")
+	if out, err := e.requireWritableFSShort(ctx); err != nil {
+		return out, false, err
 	}
 
 	// Create group if it doesn't exist
@@ -70,35 +67,11 @@ func (e *Executor) setupGroup(ctx context.Context, params *pb.GroupParams) (*pb.
 		changed = true
 	}
 
-	// Add missing members
-	for _, member := range params.Members {
-		if !userExists(member) {
-			output.WriteString(fmt.Sprintf("warning: user %q does not exist, skipping\n", member))
-			continue
-		}
-		if !userInGroup(member, params.Name) {
-			if err := addUserToGroup(ctx, member, params.Name); err != nil {
-				output.WriteString(fmt.Sprintf("warning: failed to add user %s to group: %v\n", member, err))
-			} else {
-				output.WriteString(fmt.Sprintf("added user %s to group %s\n", member, params.Name))
-				changed = true
-			}
-		}
-	}
-
-	// Remove members not in desired list
-	currentMembers := getGroupMembers(params.Name)
-	desiredSet := make(map[string]bool, len(params.Members))
-	for _, m := range params.Members {
-		desiredSet[m] = true
-	}
-	for _, member := range currentMembers {
-		if !desiredSet[member] {
-			if err := removeUserFromGroup(ctx, member, params.Name); err == nil {
-				output.WriteString(fmt.Sprintf("removed user %s from group %s\n", member, params.Name))
-				changed = true
-			}
-		}
+	// Sync group membership
+	if memberChanged, err := syncGroupMembers(ctx, params.Name, params.Members, &output); err != nil {
+		return nil, false, err
+	} else if memberChanged {
+		changed = true
 	}
 
 	return &pb.CommandOutput{
@@ -127,11 +100,8 @@ func (e *Executor) removeGroup(ctx context.Context, groupName string) (*pb.Comma
 		}, false, nil
 	}
 
-	if !e.repairFilesystem(ctx) {
-		return &pb.CommandOutput{
-			ExitCode: 1,
-			Stderr:   "filesystem is read-only and could not be remounted",
-		}, false, fmt.Errorf("filesystem is read-only")
+	if out, err := e.requireWritableFSShort(ctx); err != nil {
+		return out, false, err
 	}
 
 	// Remove all members from group

--- a/internal/executor/group.go
+++ b/internal/executor/group.go
@@ -100,26 +100,13 @@ func (e *Executor) removeGroup(ctx context.Context, groupName string) (*pb.Comma
 		}, false, nil
 	}
 
-	if out, err := e.requireWritableFSShort(ctx); err != nil {
-		return out, false, err
+	changed, err := e.removeGroupWithConfig(ctx, groupName, "", &output)
+	if err != nil {
+		return nil, false, err
 	}
-
-	// Remove all members from group
-	members := getGroupMembers(groupName)
-	for _, member := range members {
-		if err := removeUserFromGroup(ctx, member, groupName); err == nil {
-			output.WriteString(fmt.Sprintf("removed user %s from group %s\n", member, groupName))
-		}
-	}
-
-	// Delete group
-	if err := sysuser.GroupDelete(ctx, groupName); err != nil {
-		return nil, false, fmt.Errorf("delete group %s: %v", groupName, err)
-	}
-	output.WriteString(fmt.Sprintf("deleted group: %s\n", groupName))
 
 	return &pb.CommandOutput{
 		ExitCode: 0,
 		Stdout:   output.String(),
-	}, true, nil
+	}, changed, nil
 }

--- a/internal/executor/helpers.go
+++ b/internal/executor/helpers.go
@@ -82,9 +82,11 @@ func getActionID(action *pb.Action) string {
 
 // syncGroupMembers adds missing users and removes users no longer in the desired list
 // for the given group. It logs warnings for non-existent users.
-// Returns (changed bool, error).
+// Returns (changed bool, error). The error is non-nil if any membership operation
+// failed, even if some operations succeeded (changed may still be true).
 func syncGroupMembers(ctx context.Context, groupName string, desiredUsers []string, output *strings.Builder) (bool, error) {
 	changed := false
+	var errs []string
 
 	// Add missing members
 	for _, username := range desiredUsers {
@@ -94,7 +96,9 @@ func syncGroupMembers(ctx context.Context, groupName string, desiredUsers []stri
 		}
 		if !userInGroup(username, groupName) {
 			if err := addUserToGroup(ctx, username, groupName); err != nil {
-				output.WriteString(fmt.Sprintf("warning: failed to add user %s to group: %v\n", username, err))
+				msg := fmt.Sprintf("failed to add user %s to group %s: %v", username, groupName, err)
+				output.WriteString(fmt.Sprintf("warning: %s\n", msg))
+				errs = append(errs, msg)
 			} else {
 				output.WriteString(fmt.Sprintf("added user %s to group %s\n", username, groupName))
 				changed = true
@@ -111,7 +115,9 @@ func syncGroupMembers(ctx context.Context, groupName string, desiredUsers []stri
 	for _, member := range currentMembers {
 		if !desiredSet[member] {
 			if err := removeUserFromGroup(ctx, member, groupName); err != nil {
-				output.WriteString(fmt.Sprintf("warning: failed to remove user %s from group %s: %v\n", member, groupName, err))
+				msg := fmt.Sprintf("failed to remove user %s from group %s: %v", member, groupName, err)
+				output.WriteString(fmt.Sprintf("warning: %s\n", msg))
+				errs = append(errs, msg)
 			} else {
 				output.WriteString(fmt.Sprintf("removed user %s from group %s\n", member, groupName))
 				changed = true
@@ -119,15 +125,24 @@ func syncGroupMembers(ctx context.Context, groupName string, desiredUsers []stri
 		}
 	}
 
+	if len(errs) > 0 {
+		return changed, fmt.Errorf("group membership errors: %s", strings.Join(errs, "; "))
+	}
 	return changed, nil
 }
 
 // contentChanged checks if a file's content differs from the desired content.
 // Returns true if the file doesn't exist or its content differs.
+// Note: readFileWithSudo returns ("", nil) for missing files, so err here
+// indicates a real I/O or permission error.
 func contentChanged(ctx context.Context, filePath, desiredContent string) (bool, error) {
 	existing, err := readFileWithSudo(ctx, filePath)
 	if err != nil {
-		return true, nil // file doesn't exist, content is "changed"
+		return false, fmt.Errorf("read %s: %w", filePath, err)
+	}
+	// Empty string means file doesn't exist (readFileWithSudo returns "" for not-found)
+	if existing == "" {
+		return true, nil
 	}
 	return existing != desiredContent, nil
 }
@@ -187,7 +202,9 @@ func (e *Executor) removeGroupWithConfig(ctx context.Context, groupName, configP
 		}
 		members := getGroupMembers(groupName)
 		for _, member := range members {
-			if err := removeUserFromGroup(ctx, member, groupName); err == nil {
+			if err := removeUserFromGroup(ctx, member, groupName); err != nil {
+				output.WriteString(fmt.Sprintf("warning: failed to remove user %s from group %s: %v\n", member, groupName, err))
+			} else {
 				output.WriteString(fmt.Sprintf("removed user %s from group %s\n", member, groupName))
 				changed = true
 			}

--- a/internal/executor/helpers.go
+++ b/internal/executor/helpers.go
@@ -1,0 +1,121 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// errReadOnlyFS is a sentinel error returned when the filesystem is read-only and repair failed.
+var errReadOnlyFS = fmt.Errorf("filesystem is read-only")
+
+// readOnlyFSOutput returns a CommandOutput for read-only filesystem failures
+// with the full diagnostic message.
+func readOnlyFSOutput() *pb.CommandOutput {
+	return &pb.CommandOutput{
+		ExitCode: 1,
+		Stderr:   "filesystem is read-only and could not be remounted - system may need reboot and fsck",
+	}
+}
+
+// readOnlyFSOutputShort returns a CommandOutput for read-only filesystem failures
+// with a shorter message (used by some handlers).
+func readOnlyFSOutputShort() *pb.CommandOutput {
+	return &pb.CommandOutput{
+		ExitCode: 1,
+		Stderr:   "filesystem is read-only and could not be remounted",
+	}
+}
+
+// readOnlyFSOutputMinimal returns a CommandOutput with the minimal read-only message.
+func readOnlyFSOutputMinimal() *pb.CommandOutput {
+	return &pb.CommandOutput{
+		ExitCode: 1,
+		Stderr:   "filesystem is read-only",
+	}
+}
+
+// requireWritableFS checks if the filesystem is writable and attempts repair if not.
+// Returns nil, nil if writable. Returns (output, error) if repair failed.
+func (e *Executor) requireWritableFS(ctx context.Context) (*pb.CommandOutput, error) {
+	if e.repairFilesystem(ctx) {
+		return nil, nil
+	}
+	return readOnlyFSOutput(), errReadOnlyFS
+}
+
+// requireWritableFSShort is like requireWritableFS but uses a shorter error message.
+func (e *Executor) requireWritableFSShort(ctx context.Context) (*pb.CommandOutput, error) {
+	if e.repairFilesystem(ctx) {
+		return nil, nil
+	}
+	return readOnlyFSOutputShort(), errReadOnlyFS
+}
+
+// requireWritableFSMinimal is like requireWritableFS but uses a minimal error message.
+func (e *Executor) requireWritableFSMinimal(ctx context.Context) (*pb.CommandOutput, error) {
+	if e.repairFilesystem(ctx) {
+		return nil, nil
+	}
+	return readOnlyFSOutputMinimal(), errReadOnlyFS
+}
+
+// getActionID extracts the action ID string from an action, returning "" if nil.
+func getActionID(action *pb.Action) string {
+	if action == nil || action.Id == nil {
+		return ""
+	}
+	return action.Id.Value
+}
+
+// syncGroupMembers adds missing users and removes users no longer in the desired list
+// for the given group. It logs warnings for non-existent users.
+// Returns (changed bool, error).
+func syncGroupMembers(ctx context.Context, groupName string, desiredUsers []string, output *strings.Builder) (bool, error) {
+	changed := false
+
+	// Add missing members
+	for _, username := range desiredUsers {
+		if !userExists(username) {
+			output.WriteString(fmt.Sprintf("warning: user %q does not exist, skipping group membership\n", username))
+			continue
+		}
+		if !userInGroup(username, groupName) {
+			if err := addUserToGroup(ctx, username, groupName); err != nil {
+				output.WriteString(fmt.Sprintf("warning: failed to add user %s to group: %v\n", username, err))
+			} else {
+				output.WriteString(fmt.Sprintf("added user %s to group %s\n", username, groupName))
+				changed = true
+			}
+		}
+	}
+
+	// Remove members not in desired list
+	currentMembers := getGroupMembers(groupName)
+	desiredSet := make(map[string]bool, len(desiredUsers))
+	for _, u := range desiredUsers {
+		desiredSet[u] = true
+	}
+	for _, member := range currentMembers {
+		if !desiredSet[member] {
+			if err := removeUserFromGroup(ctx, member, groupName); err == nil {
+				output.WriteString(fmt.Sprintf("removed user %s from group %s\n", member, groupName))
+				changed = true
+			}
+		}
+	}
+
+	return changed, nil
+}
+
+// contentChanged checks if a file's content differs from the desired content.
+// Returns true if the file doesn't exist or its content differs.
+func contentChanged(ctx context.Context, filePath, desiredContent string) (bool, error) {
+	existing, err := readFileWithSudo(ctx, filePath)
+	if err != nil {
+		return true, nil // file doesn't exist, content is "changed"
+	}
+	return existing != desiredContent, nil
+}

--- a/internal/executor/helpers.go
+++ b/internal/executor/helpers.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	sysuser "github.com/manchtools/power-manage/sdk/go/sys/user"
 )
 
 // errReadOnlyFS is a sentinel error returned when the filesystem is read-only and repair failed.
@@ -118,4 +119,73 @@ func contentChanged(ctx context.Context, filePath, desiredContent string) (bool,
 		return true, nil // file doesn't exist, content is "changed"
 	}
 	return existing != desiredContent, nil
+}
+
+// writeAndValidateConfig writes a config file atomically and validates it with an external command.
+// If validation fails, the file is removed and the validation error is returned.
+// On success, returns nil, nil.
+func (e *Executor) writeAndValidateConfig(ctx context.Context, path, content, mode, owner, group string, validateCmd string, validateArgs ...string) (*pb.CommandOutput, error) {
+	if err := atomicWriteFile(ctx, path, content, mode, owner, group); err != nil {
+		return nil, fmt.Errorf("write config file: %w", err)
+	}
+
+	validateOut, validateErr := runSudoCmd(ctx, validateCmd, validateArgs...)
+	if validateErr != nil {
+		// Config is invalid — remove it and report error
+		removeFileStrict(ctx, path)
+		errMsg := "config validation failed"
+		if validateOut != nil && validateOut.Stderr != "" {
+			errMsg = strings.TrimSpace(validateOut.Stderr)
+		}
+		return &pb.CommandOutput{
+			ExitCode: 1,
+			Stderr:   errMsg,
+		}, fmt.Errorf("%s validation failed: %s", validateCmd, errMsg)
+	}
+
+	return nil, nil
+}
+
+// removeGroupWithConfig removes a managed config file and its associated group.
+// Removes all users from the group, deletes the group, and removes the config file.
+// If configPath is empty, only the group is removed.
+func (e *Executor) removeGroupWithConfig(ctx context.Context, groupName, configPath string, output *strings.Builder) (bool, error) {
+	changed := false
+
+	// Remove config file if specified
+	if configPath != "" && fileExistsWithSudo(ctx, configPath) {
+		if out, err := e.requireWritableFSShort(ctx); err != nil {
+			return false, fmt.Errorf("writable fs: %w::%s", err, out.Stderr)
+		}
+		if err := removeFileStrict(ctx, configPath); err != nil {
+			return false, fmt.Errorf("remove config file %s: %w", configPath, err)
+		}
+		output.WriteString(fmt.Sprintf("removed config file: %s\n", configPath))
+		changed = true
+	}
+
+	// Remove group and membership
+	if groupExists(groupName) {
+		if !changed {
+			// Need writable FS for group operations (may not have been checked above)
+			if out, err := e.requireWritableFSShort(ctx); err != nil {
+				return false, fmt.Errorf("writable fs: %w::%s", err, out.Stderr)
+			}
+		}
+		members := getGroupMembers(groupName)
+		for _, member := range members {
+			if err := removeUserFromGroup(ctx, member, groupName); err == nil {
+				output.WriteString(fmt.Sprintf("removed user %s from group %s\n", member, groupName))
+				changed = true
+			}
+		}
+		if err := sysuser.GroupDelete(ctx, groupName); err != nil {
+			output.WriteString(fmt.Sprintf("warning: failed to delete group %s: %v\n", groupName, err))
+		} else {
+			output.WriteString(fmt.Sprintf("deleted group: %s\n", groupName))
+			changed = true
+		}
+	}
+
+	return changed, nil
 }

--- a/internal/executor/helpers.go
+++ b/internal/executor/helpers.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -101,7 +102,9 @@ func syncGroupMembers(ctx context.Context, groupName string, desiredUsers []stri
 	}
 	for _, member := range currentMembers {
 		if !desiredSet[member] {
-			if err := removeUserFromGroup(ctx, member, groupName); err == nil {
+			if err := removeUserFromGroup(ctx, member, groupName); err != nil {
+				output.WriteString(fmt.Sprintf("warning: failed to remove user %s from group %s: %v\n", member, groupName, err))
+			} else {
 				output.WriteString(fmt.Sprintf("removed user %s from group %s\n", member, groupName))
 				changed = true
 			}
@@ -132,7 +135,9 @@ func (e *Executor) writeAndValidateConfig(ctx context.Context, path, content, mo
 	validateOut, validateErr := runSudoCmd(ctx, validateCmd, validateArgs...)
 	if validateErr != nil {
 		// Config is invalid — remove it and report error
-		removeFileStrict(ctx, path)
+		if rmErr := removeFileStrict(ctx, path); rmErr != nil {
+			slog.Warn("failed to remove invalid config after validation failure", "path", path, "error", rmErr)
+		}
 		errMsg := "config validation failed"
 		if validateOut != nil && validateOut.Stderr != "" {
 			errMsg = strings.TrimSpace(validateOut.Stderr)
@@ -154,8 +159,8 @@ func (e *Executor) removeGroupWithConfig(ctx context.Context, groupName, configP
 
 	// Remove config file if specified
 	if configPath != "" && fileExistsWithSudo(ctx, configPath) {
-		if out, err := e.requireWritableFSShort(ctx); err != nil {
-			return false, fmt.Errorf("writable fs: %w::%s", err, out.Stderr)
+		if _, err := e.requireWritableFSShort(ctx); err != nil {
+			return false, fmt.Errorf("writable fs: %w", err)
 		}
 		if err := removeFileStrict(ctx, configPath); err != nil {
 			return false, fmt.Errorf("remove config file %s: %w", configPath, err)
@@ -168,8 +173,8 @@ func (e *Executor) removeGroupWithConfig(ctx context.Context, groupName, configP
 	if groupExists(groupName) {
 		if !changed {
 			// Need writable FS for group operations (may not have been checked above)
-			if out, err := e.requireWritableFSShort(ctx); err != nil {
-				return false, fmt.Errorf("writable fs: %w::%s", err, out.Stderr)
+			if _, err := e.requireWritableFSShort(ctx); err != nil {
+				return false, fmt.Errorf("writable fs: %w", err)
 			}
 		}
 		members := getGroupMembers(groupName)
@@ -180,11 +185,10 @@ func (e *Executor) removeGroupWithConfig(ctx context.Context, groupName, configP
 			}
 		}
 		if err := sysuser.GroupDelete(ctx, groupName); err != nil {
-			output.WriteString(fmt.Sprintf("warning: failed to delete group %s: %v\n", groupName, err))
-		} else {
-			output.WriteString(fmt.Sprintf("deleted group: %s\n", groupName))
-			changed = true
+			return changed, fmt.Errorf("delete group %s: %w", groupName, err)
 		}
+		output.WriteString(fmt.Sprintf("deleted group: %s\n", groupName))
+		changed = true
 	}
 
 	return changed, nil

--- a/internal/executor/helpers.go
+++ b/internal/executor/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -65,11 +66,18 @@ func (e *Executor) requireWritableFSMinimal(ctx context.Context) (*pb.CommandOut
 }
 
 // getActionID extracts the action ID string from an action, returning "" if nil.
+// validActionIDChars matches only safe characters for action IDs (ULIDs: uppercase alphanumeric).
+var validActionIDRegex = regexp.MustCompile(`^[A-Za-z0-9]+$`)
+
 func getActionID(action *pb.Action) string {
 	if action == nil || action.Id == nil {
 		return ""
 	}
-	return action.Id.Value
+	id := action.Id.Value
+	if id == "" || len(id) > 64 || !validActionIDRegex.MatchString(id) {
+		return ""
+	}
+	return id
 }
 
 // syncGroupMembers adds missing users and removes users no longer in the desired list

--- a/internal/executor/sudo.go
+++ b/internal/executor/sudo.go
@@ -96,27 +96,12 @@ func (e *Executor) setupSudoPolicy(ctx context.Context, params *pb.SudoParams, g
 		changed = true
 	}
 
-	// Write sudoers file
+	// Write and validate sudoers file
 	if !fileMatches {
-		if err := atomicWriteFile(ctx, sudoersPath, content, "0440", "root", "root"); err != nil {
-			return nil, false, fmt.Errorf("write sudoers file: %w", err)
+		if out, err := e.writeAndValidateConfig(ctx, sudoersPath, content, "0440", "root", "root", "visudo", "-c", "-f", sudoersPath); err != nil {
+			return out, false, err
 		}
 		output.WriteString(fmt.Sprintf("wrote sudoers file: %s\n", sudoersPath))
-
-		// Validate with visudo
-		validateOut, validateErr := runSudoCmd(ctx, "visudo", "-c", "-f", sudoersPath)
-		if validateErr != nil {
-			// Config is invalid — remove it and report error
-			removeFileStrict(ctx, sudoersPath)
-			errMsg := "sudoers validation failed"
-			if validateOut != nil && validateOut.Stderr != "" {
-				errMsg = strings.TrimSpace(validateOut.Stderr)
-			}
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   errMsg,
-			}, false, fmt.Errorf("visudo validation failed: %s", errMsg)
-		}
 		changed = true
 	}
 
@@ -136,37 +121,10 @@ func (e *Executor) setupSudoPolicy(ctx context.Context, params *pb.SudoParams, g
 // removeSudoPolicy removes a sudo policy: sudoers file, group membership, and group.
 func (e *Executor) removeSudoPolicy(ctx context.Context, groupName, sudoersPath string, users []string) (*pb.CommandOutput, bool, error) {
 	var output strings.Builder
-	changed := false
 
-	// Remove sudoers file
-	if fileExistsWithSudo(ctx, sudoersPath) {
-		if out, err := e.requireWritableFSShort(ctx); err != nil {
-			return out, false, err
-		}
-		if err := removeFileStrict(ctx, sudoersPath); err != nil {
-			return nil, false, fmt.Errorf("remove sudoers file: %w", err)
-		}
-		output.WriteString(fmt.Sprintf("removed sudoers file: %s\n", sudoersPath))
-		changed = true
-	}
-
-	// Remove users from group
-	if groupExists(groupName) {
-		members := getGroupMembers(groupName)
-		for _, member := range members {
-			if err := removeUserFromGroup(ctx, member, groupName); err == nil {
-				output.WriteString(fmt.Sprintf("removed user %s from group %s\n", member, groupName))
-				changed = true
-			}
-		}
-
-		// Delete group
-		if err := sysuser.GroupDelete(ctx, groupName); err != nil {
-			output.WriteString(fmt.Sprintf("warning: failed to delete group %s: %v\n", groupName, err))
-		} else {
-			output.WriteString(fmt.Sprintf("deleted group: %s\n", groupName))
-			changed = true
-		}
+	changed, err := e.removeGroupWithConfig(ctx, groupName, sudoersPath, &output)
+	if err != nil {
+		return nil, false, err
 	}
 
 	if !changed {

--- a/internal/executor/sudo.go
+++ b/internal/executor/sudo.go
@@ -124,7 +124,8 @@ func (e *Executor) removeSudoPolicy(ctx context.Context, groupName, sudoersPath 
 
 	changed, err := e.removeGroupWithConfig(ctx, groupName, sudoersPath, &output)
 	if err != nil {
-		return nil, false, err
+		// Group deletion failure is non-fatal for sudo (sudoers file removal is the important part)
+		output.WriteString(fmt.Sprintf("warning: %v\n", err))
 	}
 
 	if !changed {

--- a/internal/executor/sudo.go
+++ b/internal/executor/sudo.go
@@ -83,11 +83,8 @@ func (e *Executor) setupSudoPolicy(ctx context.Context, params *pb.SudoParams, g
 		}, false, nil
 	}
 
-	if !e.repairFilesystem(ctx) {
-		return &pb.CommandOutput{
-			ExitCode: 1,
-			Stderr:   "filesystem is read-only and could not be remounted",
-		}, false, fmt.Errorf("filesystem is read-only")
+	if out, err := e.requireWritableFSShort(ctx); err != nil {
+		return out, false, err
 	}
 
 	// Ensure group exists
@@ -123,35 +120,11 @@ func (e *Executor) setupSudoPolicy(ctx context.Context, params *pb.SudoParams, g
 		changed = true
 	}
 
-	// Add users to group
-	for _, username := range params.Users {
-		if !userExists(username) {
-			output.WriteString(fmt.Sprintf("warning: user %q does not exist, skipping group membership\n", username))
-			continue
-		}
-		if !userInGroup(username, groupName) {
-			if err := addUserToGroup(ctx, username, groupName); err != nil {
-				output.WriteString(fmt.Sprintf("warning: failed to add user %s to group: %v\n", username, err))
-			} else {
-				output.WriteString(fmt.Sprintf("added user %s to group %s\n", username, groupName))
-				changed = true
-			}
-		}
-	}
-
-	// Remove users that are no longer in the list
-	currentMembers := getGroupMembers(groupName)
-	desiredSet := make(map[string]bool, len(params.Users))
-	for _, u := range params.Users {
-		desiredSet[u] = true
-	}
-	for _, member := range currentMembers {
-		if !desiredSet[member] {
-			if err := removeUserFromGroup(ctx, member, groupName); err == nil {
-				output.WriteString(fmt.Sprintf("removed user %s from group %s\n", member, groupName))
-				changed = true
-			}
-		}
+	// Sync group membership
+	if memberChanged, err := syncGroupMembers(ctx, groupName, params.Users, &output); err != nil {
+		return nil, false, err
+	} else if memberChanged {
+		changed = true
 	}
 
 	return &pb.CommandOutput{
@@ -167,11 +140,8 @@ func (e *Executor) removeSudoPolicy(ctx context.Context, groupName, sudoersPath 
 
 	// Remove sudoers file
 	if fileExistsWithSudo(ctx, sudoersPath) {
-		if !e.repairFilesystem(ctx) {
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   "filesystem is read-only and could not be remounted",
-			}, false, fmt.Errorf("filesystem is read-only")
+		if out, err := e.requireWritableFSShort(ctx); err != nil {
+			return out, false, err
 		}
 		if err := removeFileStrict(ctx, sudoersPath); err != nil {
 			return nil, false, fmt.Errorf("remove sudoers file: %w", err)

--- a/internal/executor/sudo.go
+++ b/internal/executor/sudo.go
@@ -107,7 +107,7 @@ func (e *Executor) setupSudoPolicy(ctx context.Context, params *pb.SudoParams, g
 
 	// Sync group membership
 	if memberChanged, err := syncGroupMembers(ctx, groupName, params.Users, &output); err != nil {
-		return nil, false, err
+		return &pb.CommandOutput{ExitCode: 1, Stdout: output.String(), Stderr: err.Error()}, memberChanged, err
 	} else if memberChanged {
 		changed = true
 	}

--- a/internal/executor/sudo.go
+++ b/internal/executor/sudo.go
@@ -124,7 +124,11 @@ func (e *Executor) removeSudoPolicy(ctx context.Context, groupName, sudoersPath 
 
 	changed, err := e.removeGroupWithConfig(ctx, groupName, sudoersPath, &output)
 	if err != nil {
-		// Group deletion failure is non-fatal for sudo (sudoers file removal is the important part)
+		if !changed {
+			// Config file removal failed — fatal
+			return nil, false, err
+		}
+		// Config removed but group deletion failed — non-fatal warning
 		output.WriteString(fmt.Sprintf("warning: %v\n", err))
 	}
 


### PR DESCRIPTION
## Summary

Pure refactoring — extract duplicated code patterns into shared helpers. No behavior changes.

### New file: `internal/executor/helpers.go`

| Helper | Replaces | Occurrences |
|--------|----------|-------------|
| `requireWritableFS(ctx)` | 4-line filesystem repair + error return | ~20 |
| `getActionID(action)` | nil-check + `.Id.Value` extraction | 7 |
| `syncGroupMembers(ctx, group, users, output)` | Add/remove group membership reconciliation | 3 (SSH, Sudo, Group) |
| `contentChanged(ctx, path, desired)` | File content comparison | reusable |

### Files modified

- `executor.go` — replaced ~20 filesystem checks, 7 action ID extractions, 1 group sync
- `sudo.go` — replaced 2 filesystem checks, 1 group sync
- `group.go` — replaced 2 filesystem checks, 1 group sync

### Net result

~56 lines of duplicated code removed, consistent error messages, single source of truth for shared patterns.

## Test plan

- [x] `go build ./cmd/power-manage-agent` compiles
- [x] `go test ./...` passes
- [ ] Existing action execution unchanged (pure refactoring)

Closes manchtools/power-manage-agent#28


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified action ID handling and consolidated read-only filesystem checks for consistent failure output.
  * Replaced per-user group add/remove loops with a single reconciliation workflow for SSH/SUDO/group membership.
  * Standardized config write-and-validate and consolidated config+group removal to report actual changes.

* **Bug Fixes**
  * Improved failure handling to return consistent validation and filesystem errors, avoiding partial/ambiguous state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->