### PR TITLE
fix: SSH config validation and store migration versioning

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3522,7 +3522,7 @@ func (e *Executor) setupSshAccess(ctx context.Context, params *pb.SshParams, use
 		changed = true
 	}
 
-	// Write sshd config file
+	// Write sshd config file with validation
 	if !fileMatches {
 		// Ensure /etc/ssh/sshd_config.d exists
 		if err := createDirectory(ctx, "/etc/ssh/sshd_config.d", true); err != nil {
@@ -3531,8 +3531,24 @@ func (e *Executor) setupSshAccess(ctx context.Context, params *pb.SshParams, use
 		if err := atomicWriteFile(ctx, configPath, content, "0644", "root", "root"); err != nil {
 			return nil, false, fmt.Errorf("write ssh config: %w", err)
 		}
+		// Validate with sshd -t (tests full config including drop-ins)
+		if _, err := runSudoCmd(ctx, "sshd", "-t"); err != nil {
+			// Invalid config — remove it to avoid breaking sshd
+			removeFileStrict(ctx, configPath)
+			return &pb.CommandOutput{
+				ExitCode: 1,
+				Stderr:   "sshd config validation failed after writing drop-in",
+			}, false, fmt.Errorf("sshd -t validation failed: %w", err)
+		}
 		output.WriteString(fmt.Sprintf("wrote SSH config: %s\n", configPath))
 		changed = true
+
+		// Reload sshd to apply the new config
+		if _, err := runSudoCmd(ctx, "systemctl", "reload", "sshd"); err != nil {
+			output.WriteString(fmt.Sprintf("warning: failed to reload sshd: %v\n", err))
+		} else {
+			output.WriteString("reloaded sshd\n")
+		}
 	}
 
 	// Add users to group

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3416,6 +3416,38 @@ func (e *Executor) setupSSHKeys(ctx context.Context, params *pb.UserParams, outp
 	return true, nil
 }
 
+// validateSshdConfig runs sshd -t to validate the full config (including drop-ins).
+// If validation fails, the given config file is removed and an error is returned.
+func validateSshdConfig(ctx context.Context, configPath string) (*pb.CommandOutput, error) {
+	validateOut, validateErr := runSudoCmd(ctx, "sshd", "-t")
+	if validateErr != nil {
+		removeFileStrict(ctx, configPath)
+		errMsg := "sshd config validation failed"
+		if validateOut != nil && validateOut.Stderr != "" {
+			errMsg = strings.TrimSpace(validateOut.Stderr)
+		}
+		return &pb.CommandOutput{ExitCode: 1, Stderr: errMsg}, fmt.Errorf("sshd -t validation failed: %s", errMsg)
+	}
+	return nil, nil
+}
+
+// reloadSshd reloads the sshd service, falling back to the "ssh" service name
+// for Debian/Ubuntu. Writes the result to output.
+func reloadSshd(ctx context.Context, output *strings.Builder) {
+	reloadOut, reloadErr := runSudoCmd(ctx, "systemctl", "reload", "sshd")
+	if reloadErr != nil {
+		reloadOut, reloadErr = runSudoCmd(ctx, "systemctl", "reload", "ssh")
+	}
+	if reloadErr != nil {
+		output.WriteString("warning: failed to reload sshd\n")
+		if reloadOut != nil && reloadOut.Stderr != "" {
+			output.WriteString(strings.TrimSpace(reloadOut.Stderr) + "\n")
+		}
+	} else {
+		output.WriteString("reloaded sshd\n")
+	}
+}
+
 // sshGroupName creates a valid Linux group name from the action ID for SSH access.
 // Linux group names: max 32 chars. pm-ssh- (7 chars) + up to 25 chars of action ID.
 func sshGroupName(actionID string) string {
@@ -3531,33 +3563,12 @@ func (e *Executor) setupSshAccess(ctx context.Context, params *pb.SshParams, use
 		if err := atomicWriteFile(ctx, configPath, content, "0644", "root", "root"); err != nil {
 			return nil, false, fmt.Errorf("write ssh config: %w", err)
 		}
-		// Validate with sshd -t (tests full config including drop-ins)
-		validateOut, validateErr := runSudoCmd(ctx, "sshd", "-t")
-		if validateErr != nil {
-			// Invalid config — remove it to avoid breaking sshd
-			removeFileStrict(ctx, configPath)
-			errMsg := "sshd config validation failed"
-			if validateOut != nil && validateOut.Stderr != "" {
-				errMsg = strings.TrimSpace(validateOut.Stderr)
-			}
-			return &pb.CommandOutput{
-				ExitCode: 1,
-				Stderr:   errMsg,
-			}, false, fmt.Errorf("sshd -t validation failed: %s", errMsg)
+		if out, err := validateSshdConfig(ctx, configPath); err != nil {
+			return out, false, err
 		}
 		output.WriteString(fmt.Sprintf("wrote SSH config: %s\n", configPath))
 		changed = true
-
-		// Reload sshd to apply the new config (try "sshd" then "ssh" for Debian/Ubuntu)
-		if _, err := runSudoCmd(ctx, "systemctl", "reload", "sshd"); err != nil {
-			if _, err := runSudoCmd(ctx, "systemctl", "reload", "ssh"); err != nil {
-				output.WriteString(fmt.Sprintf("warning: failed to reload sshd/ssh: %v\n", err))
-			} else {
-				output.WriteString("reloaded ssh\n")
-			}
-		} else {
-			output.WriteString("reloaded sshd\n")
-		}
+		reloadSshd(ctx, &output)
 	}
 
 	// Add users to group
@@ -3720,35 +3731,10 @@ func (e *Executor) setupSshdConfig(ctx context.Context, params *pb.SshdParams, c
 	}
 	output.WriteString(fmt.Sprintf("created SSHD config: %s\n", configPath))
 
-	// Validate config
-	validateOut, validateErr := runSudoCmd(ctx, "sshd", "-t")
-	if validateErr != nil {
-		// Config is invalid — remove it and report error
-		removeFileStrict(ctx, configPath)
-		errMsg := "sshd config validation failed"
-		if validateOut != nil && validateOut.Stderr != "" {
-			errMsg = strings.TrimSpace(validateOut.Stderr)
-		}
-		return &pb.CommandOutput{
-			ExitCode: 1,
-			Stderr:   errMsg,
-		}, false, fmt.Errorf("sshd -t validation failed: %s", errMsg)
+	if out, err := validateSshdConfig(ctx, configPath); err != nil {
+		return out, false, err
 	}
-
-	// Reload sshd
-	reloadOut, reloadErr := runSudoCmd(ctx, "systemctl", "reload", "sshd")
-	if reloadErr != nil {
-		// Try ssh.service as fallback (some distros use ssh instead of sshd)
-		reloadOut, reloadErr = runSudoCmd(ctx, "systemctl", "reload", "ssh")
-	}
-	if reloadErr != nil {
-		output.WriteString("warning: failed to reload sshd\n")
-		if reloadOut != nil && reloadOut.Stderr != "" {
-			output.WriteString(strings.TrimSpace(reloadOut.Stderr) + "\n")
-		}
-	} else {
-		output.WriteString("reloaded sshd\n")
-	}
+	reloadSshd(ctx, &output)
 
 	return &pb.CommandOutput{
 		ExitCode: 0,
@@ -3779,20 +3765,7 @@ func (e *Executor) removeSshdConfig(ctx context.Context, configPath string) (*pb
 		return nil, false, fmt.Errorf("remove sshd config: %w", err)
 	}
 	output.WriteString(fmt.Sprintf("removed SSHD config: %s\n", configPath))
-
-	// Reload sshd
-	reloadOut, reloadErr := runSudoCmd(ctx, "systemctl", "reload", "sshd")
-	if reloadErr != nil {
-		reloadOut, reloadErr = runSudoCmd(ctx, "systemctl", "reload", "ssh")
-	}
-	if reloadErr != nil {
-		output.WriteString("warning: failed to reload sshd\n")
-		if reloadOut != nil && reloadOut.Stderr != "" {
-			output.WriteString(strings.TrimSpace(reloadOut.Stderr) + "\n")
-		}
-	} else {
-		output.WriteString("reloaded sshd\n")
-	}
+	reloadSshd(ctx, &output)
 
 	return &pb.CommandOutput{
 		ExitCode: 0,

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3421,7 +3421,9 @@ func (e *Executor) setupSSHKeys(ctx context.Context, params *pb.UserParams, outp
 func validateSshdConfig(ctx context.Context, configPath string) (*pb.CommandOutput, error) {
 	validateOut, validateErr := runSudoCmd(ctx, "sshd", "-t")
 	if validateErr != nil {
-		removeFileStrict(ctx, configPath)
+		if rmErr := removeFileStrict(ctx, configPath); rmErr != nil {
+			slog.Warn("failed to remove invalid sshd config after validation failure", "path", configPath, "error", rmErr)
+		}
 		errMsg := "sshd config validation failed"
 		if validateOut != nil && validateOut.Stderr != "" {
 			errMsg = strings.TrimSpace(validateOut.Stderr)
@@ -3626,13 +3628,16 @@ func (e *Executor) removeSshAccess(ctx context.Context, groupName, configPath st
 		}
 		output.WriteString(fmt.Sprintf("removed SSH config: %s\n", configPath))
 		changed = true
+		reloadSshd(ctx, &output)
 	}
 
 	// Remove group and membership
 	if groupExists(groupName) {
 		members := getGroupMembers(groupName)
 		for _, member := range members {
-			if err := removeUserFromGroup(ctx, member, groupName); err == nil {
+			if err := removeUserFromGroup(ctx, member, groupName); err != nil {
+				output.WriteString(fmt.Sprintf("warning: failed to remove user %s from group %s: %v\n", member, groupName, err))
+			} else {
 				output.WriteString(fmt.Sprintf("removed user %s from group %s\n", member, groupName))
 				changed = true
 			}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3532,20 +3532,29 @@ func (e *Executor) setupSshAccess(ctx context.Context, params *pb.SshParams, use
 			return nil, false, fmt.Errorf("write ssh config: %w", err)
 		}
 		// Validate with sshd -t (tests full config including drop-ins)
-		if _, err := runSudoCmd(ctx, "sshd", "-t"); err != nil {
+		validateOut, validateErr := runSudoCmd(ctx, "sshd", "-t")
+		if validateErr != nil {
 			// Invalid config — remove it to avoid breaking sshd
 			removeFileStrict(ctx, configPath)
+			errMsg := "sshd config validation failed"
+			if validateOut != nil && validateOut.Stderr != "" {
+				errMsg = strings.TrimSpace(validateOut.Stderr)
+			}
 			return &pb.CommandOutput{
 				ExitCode: 1,
-				Stderr:   "sshd config validation failed after writing drop-in",
-			}, false, fmt.Errorf("sshd -t validation failed: %w", err)
+				Stderr:   errMsg,
+			}, false, fmt.Errorf("sshd -t validation failed: %s", errMsg)
 		}
 		output.WriteString(fmt.Sprintf("wrote SSH config: %s\n", configPath))
 		changed = true
 
-		// Reload sshd to apply the new config
+		// Reload sshd to apply the new config (try "sshd" then "ssh" for Debian/Ubuntu)
 		if _, err := runSudoCmd(ctx, "systemctl", "reload", "sshd"); err != nil {
-			output.WriteString(fmt.Sprintf("warning: failed to reload sshd: %v\n", err))
+			if _, err := runSudoCmd(ctx, "systemctl", "reload", "ssh"); err != nil {
+				output.WriteString(fmt.Sprintf("warning: failed to reload sshd/ssh: %v\n", err))
+			} else {
+				output.WriteString("reloaded ssh\n")
+			}
 		} else {
 			output.WriteString("reloaded sshd\n")
 		}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -85,84 +85,124 @@ func New(dataDir string) (*Store, error) {
 	return store, nil
 }
 
-// migrate creates or updates the database schema.
+// currentSchemaVersion is the latest schema version. Increment when adding migrations.
+const currentSchemaVersion = 3
+
+// migrate creates or updates the database schema using PRAGMA user_version for tracking.
 func (s *Store) migrate(dataDir string) error {
-	schema := `
-	CREATE TABLE IF NOT EXISTS actions (
-		id TEXT PRIMARY KEY,
-		action_json TEXT NOT NULL,
-		assigned_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-		last_executed_at DATETIME,
-		next_execute_at DATETIME NOT NULL,
-		last_result_hash TEXT DEFAULT ''
-	);
-
-	CREATE TABLE IF NOT EXISTS results (
-		id TEXT PRIMARY KEY,
-		action_id TEXT NOT NULL,
-		executed_at DATETIME NOT NULL,
-		status INTEGER NOT NULL,
-		error TEXT DEFAULT '',
-		output_json TEXT,
-		duration_ms INTEGER NOT NULL DEFAULT 0,
-		has_changes BOOLEAN NOT NULL DEFAULT 0,
-		synced BOOLEAN NOT NULL DEFAULT 0,
-		FOREIGN KEY (action_id) REFERENCES actions(id) ON DELETE CASCADE
-	);
-
-	CREATE INDEX IF NOT EXISTS idx_actions_next_execute ON actions(next_execute_at);
-	CREATE INDEX IF NOT EXISTS idx_results_synced ON results(synced) WHERE synced = 0;
-	CREATE INDEX IF NOT EXISTS idx_results_action ON results(action_id);
-	`
-
-	if _, err := s.db.Exec(schema); err != nil {
-		return err
+	var version int
+	if err := s.db.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
+		return fmt.Errorf("read schema version: %w", err)
 	}
 
-	// Add desired_state column if it doesn't exist (migration)
+	if version < 1 {
+		if err := s.migrateV1(); err != nil {
+			return fmt.Errorf("migration v1: %w", err)
+		}
+	}
+	if version < 2 {
+		if err := s.migrateV2(); err != nil {
+			return fmt.Errorf("migration v2: %w", err)
+		}
+	}
+	if version < 3 {
+		if err := s.migrateV3(dataDir); err != nil {
+			return fmt.Errorf("migration v3: %w", err)
+		}
+	}
+
+	if version < currentSchemaVersion {
+		if _, err := s.db.Exec(fmt.Sprintf("PRAGMA user_version = %d", currentSchemaVersion)); err != nil {
+			return fmt.Errorf("set schema version: %w", err)
+		}
+		slog.Info("database migrated", "from_version", version, "to_version", currentSchemaVersion)
+	}
+
+	return nil
+}
+
+// migrateV1 creates the core actions and results tables.
+func (s *Store) migrateV1() error {
+	_, err := s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS actions (
+			id TEXT PRIMARY KEY,
+			action_json TEXT NOT NULL,
+			assigned_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			last_executed_at DATETIME,
+			next_execute_at DATETIME NOT NULL,
+			last_result_hash TEXT DEFAULT '',
+			desired_state INTEGER NOT NULL DEFAULT 0
+		);
+
+		CREATE TABLE IF NOT EXISTS results (
+			id TEXT PRIMARY KEY,
+			action_id TEXT NOT NULL,
+			executed_at DATETIME NOT NULL,
+			status INTEGER NOT NULL,
+			error TEXT DEFAULT '',
+			output_json TEXT,
+			duration_ms INTEGER NOT NULL DEFAULT 0,
+			has_changes BOOLEAN NOT NULL DEFAULT 0,
+			synced BOOLEAN NOT NULL DEFAULT 0,
+			FOREIGN KEY (action_id) REFERENCES actions(id) ON DELETE CASCADE
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_actions_next_execute ON actions(next_execute_at);
+		CREATE INDEX IF NOT EXISTS idx_results_synced ON results(synced) WHERE synced = 0;
+		CREATE INDEX IF NOT EXISTS idx_results_action ON results(action_id);
+	`)
+	return err
+}
+
+// migrateV2 adds LUKS state tables and the desired_state column for existing databases.
+func (s *Store) migrateV2() error {
+	// Add desired_state column for databases created before v1 included it.
+	// ALTER TABLE ADD COLUMN is a no-op error if the column already exists.
 	if _, err := s.db.Exec("ALTER TABLE actions ADD COLUMN desired_state INTEGER NOT NULL DEFAULT 0"); err != nil {
-		slog.Debug("migration: desired_state column may already exist", "error", err)
+		if !strings.Contains(err.Error(), "duplicate column") {
+			return err
+		}
 	}
 
-	// LUKS state tables
-	luksSchema := `
-	CREATE TABLE IF NOT EXISTS luks_state (
-		action_id TEXT PRIMARY KEY,
-		device_path TEXT NOT NULL DEFAULT '',
-		ownership_taken BOOLEAN NOT NULL DEFAULT FALSE,
-		device_key_type TEXT NOT NULL DEFAULT 'none',
-		last_rotated_at TEXT NOT NULL DEFAULT ''
-	);
+	_, err := s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS luks_state (
+			action_id TEXT PRIMARY KEY,
+			device_path TEXT NOT NULL DEFAULT '',
+			ownership_taken BOOLEAN NOT NULL DEFAULT FALSE,
+			device_key_type TEXT NOT NULL DEFAULT 'none',
+			last_rotated_at TEXT NOT NULL DEFAULT ''
+		);
 
-	CREATE TABLE IF NOT EXISTS luks_user_passphrase_history (
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
-		action_id TEXT NOT NULL,
-		passphrase_hash TEXT NOT NULL,
-		created_at TEXT NOT NULL DEFAULT (datetime('now'))
-	);
+		CREATE TABLE IF NOT EXISTS luks_user_passphrase_history (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			action_id TEXT NOT NULL,
+			passphrase_hash TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT (datetime('now'))
+		);
 
-	CREATE INDEX IF NOT EXISTS idx_luks_passphrase_history_action ON luks_user_passphrase_history(action_id);
-	`
-	if _, err := s.db.Exec(luksSchema); err != nil {
-		return err
-	}
+		CREATE INDEX IF NOT EXISTS idx_luks_passphrase_history_action ON luks_user_passphrase_history(action_id);
+	`)
+	return err
+}
 
-	// Add last_rotated_at column if it doesn't exist (migration for pre-existing tables)
+// migrateV3 adds LPS state table and LUKS last_rotated_at column, migrates legacy LPS JSON files.
+func (s *Store) migrateV3(dataDir string) error {
+	// Add last_rotated_at for databases created before v2 included it.
 	if _, err := s.db.Exec("ALTER TABLE luks_state ADD COLUMN last_rotated_at TEXT NOT NULL DEFAULT ''"); err != nil {
-		slog.Debug("migration: last_rotated_at column may already exist", "error", err)
+		if !strings.Contains(err.Error(), "duplicate column") {
+			return err
+		}
 	}
 
-	// LPS state table
-	lpsSchema := `
-	CREATE TABLE IF NOT EXISTS lps_state (
-		action_id TEXT NOT NULL,
-		username TEXT NOT NULL,
-		last_rotated_at TEXT NOT NULL DEFAULT '',
-		password_hash TEXT NOT NULL DEFAULT '',
-		PRIMARY KEY (action_id, username)
-	);
-	`
-	if _, err := s.db.Exec(lpsSchema); err != nil {
+	if _, err := s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS lps_state (
+			action_id TEXT NOT NULL,
+			username TEXT NOT NULL,
+			last_rotated_at TEXT NOT NULL DEFAULT '',
+			password_hash TEXT NOT NULL DEFAULT '',
+			PRIMARY KEY (action_id, username)
+		);
+	`); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

Addresses items A6 and B3 from #31 (agent maintainability audit).

### SSH config validation (A6)
The SSH access executor (`executeSsh`) writes sshd config drop-ins to `/etc/ssh/sshd_config.d/` but unlike the SSHD executor, it never validated the config. An invalid drop-in could break sshd on reload.

Now:
- Validates with `sshd -t` after writing the drop-in
- Removes the file and fails the action if validation fails
- Reloads sshd after successful write (parity with SSHD executor)

### Store migration versioning (B3)
The store used `ALTER TABLE ADD COLUMN` with error swallowing on every startup, logging noisy debug messages for columns that already exist.

Now uses `PRAGMA user_version` for proper schema versioning:
- v1: Core actions + results tables (includes desired_state from the start)
- v2: LUKS state tables + desired_state backfill for pre-v1 databases
- v3: LPS state table + LUKS last_rotated_at backfill + legacy JSON migration

Migrations only run when the version is behind. Existing databases (user_version=0) run all three migrations, then get stamped to version 3.

### Items verified as already fixed
- **A5** (systemd restart changed flag): Already correct — returns early on error before setting changed=true
- **A2** (action ID path traversal): Fixed in PR #29 via `getActionID()` validation
- **A3** (agent update atomicity): Fixed in PR #29
- **A4** (group membership sync): Fixed in PR #29 via `syncGroupMembers` error accumulation
- **B1** (config duplication): Fixed in PR #29 via `writeAndValidateConfig`/`removeGroupWithConfig`
- **B4** (hardcoded values): Already named constants (`maxDownloadSize`, `wifiCertDir`, etc.)

Refs #31

## Test plan
- [x] `go build -o /dev/null ./cmd/power-manage-agent`
- [x] `go vet ./...`
- [x] `go test ./internal/store/... ./internal/executor/...`
- [ ] Manual: assign SSH action to device, verify sshd reload + config validation