### PR TITLE
feat: TerminalHandler implementation for remote PTY sessions

### DIFF
--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -379,6 +379,12 @@ func runAgent(ctx context.Context, creds *credentials.Credentials, hostname stri
 		// Wire LUKS key store to the current client for this connection session
 		h.Executor().SetLuksKeyStore(&clientLuksKeyStore{client: client})
 
+		// Wire the terminal sender so the handler's terminal session
+		// goroutines can push TerminalOutput / TerminalStateChange
+		// frames back via the SDK Client. The first call also starts
+		// the idle-session sweeper goroutine.
+		h.SetTerminalSender(client)
+
 		// Start stream in background (opens connection, heartbeats, receives)
 		streamDone := make(chan error, 1)
 		go func() {

--- a/go.mod
+++ b/go.mod
@@ -6,16 +6,17 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/manchtools/power-manage/sdk v0.0.0
-	github.com/oklog/ulid/v2 v2.1.0
+	github.com/pressly/goose/v3 v3.26.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.47.0
-	golang.org/x/net v0.49.0
 	golang.org/x/term v0.40.0
 	google.golang.org/protobuf v1.36.11
 	modernc.org/sqlite v1.44.3
 )
 
 require (
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
@@ -27,13 +28,13 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
+	github.com/oklog/ulid/v2 v2.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/pressly/goose/v3 v3.26.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
+	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 connectrpc.com/connect v1.18.1 h1:PAg7CjSAGvscaf6YZKUefjoih5Z/qYkyaTrBW8xvYPw=
 connectrpc.com/connect v1.18.1/go.mod h1:0292hj1rnx8oFrStN7cB4jjVBeqs+Yx5yDIC2prWDO8=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -27,9 +27,21 @@ type Handler struct {
 	osquery      *osquery.Registry // nil if osquery is not installed
 	scheduler    *scheduler.Scheduler
 	syncTrigger  chan<- struct{} // triggers an immediate action sync (for SYNC instant action)
-	mu           sync.Mutex     // protects connectedCh and connectedSet
+	mu           sync.Mutex     // protects connectedCh, connectedSet and the terminal* fields below
 	connectedCh  chan struct{}   // closed when welcome is received and connection is ready
 	connectedSet bool           // tracks if connectedCh has been closed
+
+	// Remote terminal session state. terminals is the live registry,
+	// guarded by mu. terminalSender is the SDK Client (or any
+	// TerminalSender) injected at startup via SetTerminalSender; it
+	// must be set before the SDK dispatch loop delivers the first
+	// TerminalStart message. The sweeper goroutine is started lazily
+	// on the first SetTerminalSender call.
+	terminalSender         TerminalSender
+	terminals              map[string]*terminalSession
+	terminalLimit          int
+	terminalIdleTimeout    time.Duration
+	terminalSweeperStarted bool
 }
 
 // NewHandler creates a new stream handler.

--- a/internal/handler/terminal.go
+++ b/internal/handler/terminal.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -32,7 +33,7 @@ const (
 	// Activated shell to assign to the TTY user during a session. The
 	// agent reverts to nologin on disconnect; this is intentionally
 	// hard-coded so it cannot be overridden from the gateway side.
-	terminalActivatedShell  = "/bin/bash"
+	terminalActivatedShell   = "/bin/bash"
 	terminalDeactivatedShell = "/usr/sbin/nologin"
 )
 
@@ -46,20 +47,48 @@ type TerminalSender interface {
 	SendTerminalStateChange(ctx context.Context, change *pb.TerminalStateChange) error
 }
 
+// sessionState tracks the lifecycle of a terminal session.
+type sessionState int
+
+const (
+	// sessionStateStarting is the brief window between reservation
+	// (when the slot is reserved under h.mu) and activation (when the
+	// PTY has been allocated and OnTerminalStart is about to send
+	// STARTED). closeTerminal during this window marks the session
+	// stopping and cancels the start context; OnTerminalStart sees the
+	// state transition between sudo calls and tears down its own
+	// partial state instead of finishing.
+	sessionStateStarting sessionState = iota
+	// sessionStateActive is the steady-state: PTY allocated, pump
+	// goroutine running, normal I/O flowing.
+	sessionStateActive
+	// sessionStateStopping signals the session has been ordered to
+	// terminate, either by an external Stop or by an internal
+	// teardown (idle sweeper, send failure, natural exit). Any
+	// subsequent operation on the session is a no-op.
+	sessionStateStopping
+)
+
 // terminalSession is the agent's per-session bookkeeping. It owns the
 // SDK terminal.Session, the activated tty user (so we know what to
-// revert on Stop), and the cancel function for its I/O goroutine.
+// revert on Stop), the cancel function for its I/O goroutine, and a
+// snapshot of the TerminalSender captured at creation time so the
+// pump goroutine never has to touch h.mu to read the sender.
 type terminalSession struct {
-	id       string
-	ttyUser  string
-	tempHome string
-	session  *terminal.Session
-	cancel   context.CancelFunc
+	id      string
+	ttyUser string
+	// sender is captured once at creation and is immutable for the
+	// session's lifetime. The pump goroutine uses this field directly
+	// rather than h.terminalSender so SetTerminalSender races on the
+	// handler are impossible.
+	sender TerminalSender
 
-	// lastActivity is updated whenever a frame is read or written;
-	// the sweeper closes sessions whose lastActivity is older than
-	// the configured idle timeout.
+	// mu protects state, session, tempHome, cancel, and lastActivity.
 	mu           sync.Mutex
+	state        sessionState
+	session      *terminal.Session  // nil during sessionStateStarting
+	tempHome     string             // "" during sessionStateStarting
+	cancel       context.CancelFunc // bound to a sessionCtx that gates both start prep and the I/O loop
 	lastActivity time.Time
 }
 
@@ -73,6 +102,12 @@ func (ts *terminalSession) idleSince() time.Time {
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
 	return ts.lastActivity
+}
+
+func (ts *terminalSession) isStopping() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.state == sessionStateStopping
 }
 
 // SetTerminalSender wires the SDK Client (or any compatible sender)
@@ -98,6 +133,16 @@ func (h *Handler) SetTerminalSender(sender TerminalSender) {
 	}
 }
 
+// snapshotTerminalSender returns the currently-installed sender under
+// h.mu so callers don't race with SetTerminalSender. Returns nil if no
+// sender has been wired (the agent dropped the start request before it
+// could spawn anything).
+func (h *Handler) snapshotTerminalSender() TerminalSender {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.terminalSender
+}
+
 // OnTerminalStart implements sdk.TerminalHandler. It validates the
 // dedicated TTY user, activates its shell, allocates the PTY via the
 // SDK terminal package, kicks off the read goroutine that pumps PTY
@@ -105,24 +150,39 @@ func (h *Handler) SetTerminalSender(sender TerminalSender) {
 // failure surfaces via SendTerminalStateChange with STATE_ERROR
 // instead of returning an error from the dispatch loop, so a single
 // bad request never tears down the agent connection.
+//
+// The slow setup path (sudo Modify, mkdir, chown, terminal.Start)
+// runs after the slot is reserved but before the session is marked
+// active. A concurrent OnTerminalStop during that window marks the
+// session stopping and cancels the start context; this method checks
+// for that state between every step and reverts whichever side
+// effects already landed.
 func (h *Handler) OnTerminalStart(ctx context.Context, req *pb.TerminalStart) error {
 	logger := h.logger.With("session_id", req.SessionId, "tty_user", req.TtyUser)
 	logger.Info("opening terminal session")
 
-	if h.terminalSender == nil {
+	// Snapshot the sender once under the lock so we never read
+	// h.terminalSender concurrently with SetTerminalSender. The
+	// captured value is what the pump goroutine uses too — see
+	// terminalSession.sender.
+	sender := h.snapshotTerminalSender()
+	if sender == nil {
 		// Should not happen — SetTerminalSender is called at startup.
-		// Surface the misconfiguration as a state-change error so the
-		// gateway/web client sees a clean failure.
+		// Surface the misconfiguration as a log line; we have no way
+		// to send a state-change error without a sender.
 		logger.Error("terminal sender not configured; dropping start request")
 		return nil
 	}
 
 	// Refuse anything that doesn't look like a Power Manage TTY user.
-	// The proto layer enforces ulid session IDs, but the username
-	// comes from the control server's resolution and we re-validate
-	// here as defense in depth.
-	if !sysuser.IsValidName(req.TtyUser) {
-		h.failTerminalStart(ctx, req.SessionId, "invalid tty username")
+	// IsValidName covers the syntactic constraints (lowercase, length,
+	// charset). The HasPrefix check enforces the dedicated pm-tty-*
+	// namespace so the agent can never operate on an arbitrary system
+	// account, even if the control server's resolution is buggy or
+	// compromised. The constant comes from the SDK so the prefix is
+	// the single source of truth.
+	if !sysuser.IsValidName(req.TtyUser) || !strings.HasPrefix(req.TtyUser, terminal.TTYUsernamePrefix) {
+		h.failTerminalStart(ctx, sender, req.SessionId, "invalid tty username")
 		return nil
 	}
 
@@ -132,15 +192,27 @@ func (h *Handler) OnTerminalStart(ctx context.Context, req *pb.TerminalStart) er
 	// yet, or the user has been disabled.
 	info, err := sysuser.Get(req.TtyUser)
 	if err != nil {
-		h.failTerminalStart(ctx, req.SessionId, fmt.Sprintf("tty user %q not provisioned: %v", req.TtyUser, err))
+		h.failTerminalStart(ctx, sender, req.SessionId, fmt.Sprintf("tty user %q not provisioned: %v", req.TtyUser, err))
 		return nil
 	}
 	if info.Locked {
-		h.failTerminalStart(ctx, req.SessionId, fmt.Sprintf("tty user %q is disabled", req.TtyUser))
+		h.failTerminalStart(ctx, sender, req.SessionId, fmt.Sprintf("tty user %q is disabled", req.TtyUser))
 		return nil
 	}
 
-	// Reserve a slot under the lock so concurrent Start requests can't
+	// Build the session record up front so closeTerminal can find it
+	// during the slow start path and signal cancellation.
+	sessionCtx, cancel := context.WithCancel(context.Background())
+	ts := &terminalSession{
+		id:      req.SessionId,
+		ttyUser: req.TtyUser,
+		sender:  sender,
+		state:   sessionStateStarting,
+		cancel:  cancel,
+	}
+	ts.touch()
+
+	// Reserve the slot under h.mu so concurrent Start requests can't
 	// both pass the limit check.
 	h.mu.Lock()
 	if h.terminals == nil {
@@ -148,7 +220,8 @@ func (h *Handler) OnTerminalStart(ctx context.Context, req *pb.TerminalStart) er
 	}
 	if _, exists := h.terminals[req.SessionId]; exists {
 		h.mu.Unlock()
-		h.failTerminalStart(ctx, req.SessionId, "session already exists")
+		cancel()
+		h.failTerminalStart(ctx, sender, req.SessionId, "session already exists")
 		return nil
 	}
 	limit := h.terminalLimit
@@ -157,19 +230,65 @@ func (h *Handler) OnTerminalStart(ctx context.Context, req *pb.TerminalStart) er
 	}
 	if len(h.terminals) >= limit {
 		h.mu.Unlock()
-		h.failTerminalStart(ctx, req.SessionId, fmt.Sprintf("device terminal session limit reached (%d)", limit))
+		cancel()
+		h.failTerminalStart(ctx, sender, req.SessionId, fmt.Sprintf("device terminal session limit reached (%d)", limit))
 		return nil
 	}
-	h.terminals[req.SessionId] = nil // reserve
+	h.terminals[req.SessionId] = ts
 	h.mu.Unlock()
 
-	// Activate the shell. usermod via the SDK helper which already
-	// uses sudo -n.
-	if err := sysuser.Modify(ctx, req.TtyUser, "-s", terminalActivatedShell); err != nil {
+	// Track which side effects have landed so the abort path can
+	// unwind exactly what was applied. Captured by the closures below.
+	var (
+		shellActivated bool
+		tempHomeDir    string
+	)
+
+	cleanup := func() {
+		if tempHomeDir != "" {
+			if err := os.RemoveAll(tempHomeDir); err != nil {
+				logger.Warn("failed to remove terminal temp home", "path", tempHomeDir, "error", err)
+			}
+		}
+		if shellActivated {
+			// Only revert if no other session for this user is still
+			// active — matches the live-session cleanup path.
+			if !h.anySessionForUserExcept(req.TtyUser, req.SessionId) {
+				h.deactivateShell(ctx, req.TtyUser)
+			}
+		}
 		h.removeTerminal(req.SessionId)
-		h.failTerminalStart(ctx, req.SessionId, fmt.Sprintf("activate shell: %v", err))
+	}
+
+	// abortFail tears down whatever was built and emits STATE_ERROR.
+	// Used for failures during start prep that the gateway hasn't
+	// asked for.
+	abortFail := func(reason string) {
+		cleanup()
+		h.failTerminalStart(ctx, sender, req.SessionId, reason)
+	}
+
+	// abortStopped tears down whatever was built but does NOT emit a
+	// STATE_ERROR — Stop arrived externally and the gateway already
+	// knows the session is being killed.
+	abortStopped := func() {
+		logger.Info("terminal start aborted by concurrent stop")
+		cleanup()
+	}
+
+	// Activate the shell. usermod via the SDK helper which already
+	// uses sudo -n. Note: sysuser.Modify ignores the context for
+	// cancellation today (it shells out via sudo), so we still gate
+	// on isStopping() between steps as a fallback.
+	if ts.isStopping() {
+		abortStopped()
 		return nil
 	}
+	if err := sysuser.Modify(sessionCtx, req.TtyUser, "-s", terminalActivatedShell); err != nil {
+		abortFail(fmt.Sprintf("activate shell: %v", err))
+		return nil
+	}
+	shellActivated = true
 
 	// Per-session temp home so the activated shell has a writable
 	// CWD without polluting any real user's $HOME. Owned by the TTY
@@ -182,27 +301,29 @@ func (h *Handler) OnTerminalStart(ctx context.Context, req *pb.TerminalStart) er
 	// system file ownership. ULID session ids make accidental
 	// collisions statistically impossible, so EEXIST really does
 	// mean "something is wrong".
-	tempHome := filepath.Join("/tmp", req.TtyUser+"."+req.SessionId)
-	if err := os.Mkdir(tempHome, 0o700); err != nil {
-		h.deactivateShell(ctx, req.TtyUser)
-		h.removeTerminal(req.SessionId)
-		h.failTerminalStart(ctx, req.SessionId, fmt.Sprintf("create temp home: %v", err))
+	if ts.isStopping() {
+		abortStopped()
 		return nil
 	}
+	tempHome := filepath.Join("/tmp", req.TtyUser+"."+req.SessionId)
+	if err := os.Mkdir(tempHome, 0o700); err != nil {
+		abortFail(fmt.Sprintf("create temp home: %v", err))
+		return nil
+	}
+	tempHomeDir = tempHome
 	// Belt and braces: confirm the freshly-created path is actually
 	// a directory and not a symlink before chowning anything.
 	if info, err := os.Lstat(tempHome); err != nil || !info.Mode().IsDir() {
-		_ = os.RemoveAll(tempHome)
-		h.deactivateShell(ctx, req.TtyUser)
-		h.removeTerminal(req.SessionId)
-		h.failTerminalStart(ctx, req.SessionId, "temp home is not a regular directory")
+		abortFail("temp home is not a regular directory")
 		return nil
 	}
-	if err := sysuser.ChownRecursive(ctx, tempHome, req.TtyUser, req.TtyUser); err != nil {
-		_ = os.RemoveAll(tempHome)
-		h.deactivateShell(ctx, req.TtyUser)
-		h.removeTerminal(req.SessionId)
-		h.failTerminalStart(ctx, req.SessionId, fmt.Sprintf("chown temp home: %v", err))
+	if err := sysuser.ChownRecursive(sessionCtx, tempHome, req.TtyUser, req.TtyUser); err != nil {
+		abortFail(fmt.Sprintf("chown temp home: %v", err))
+		return nil
+	}
+
+	if ts.isStopping() {
+		abortStopped()
 		return nil
 	}
 
@@ -219,41 +340,48 @@ func (h *Handler) OnTerminalStart(ctx context.Context, req *pb.TerminalStart) er
 
 	sess, err := terminal.Start(cfg)
 	if err != nil {
-		_ = os.RemoveAll(tempHome)
-		h.deactivateShell(ctx, req.TtyUser)
-		h.removeTerminal(req.SessionId)
-		h.failTerminalStart(ctx, req.SessionId, fmt.Sprintf("allocate pty: %v", err))
+		abortFail(fmt.Sprintf("allocate pty: %v", err))
 		return nil
 	}
 
-	// Per-session context for the I/O goroutine. Cancelled by Stop or
-	// by the natural exit reaper.
-	sessionCtx, cancel := context.WithCancel(context.Background())
-	ts := &terminalSession{
-		id:       req.SessionId,
-		ttyUser:  req.TtyUser,
-		tempHome: tempHome,
-		session:  sess,
-		cancel:   cancel,
+	// Promote to active under the session lock. If we were marked
+	// stopping in the gap between the last isStopping() check and
+	// here, tear down the freshly-allocated PTY before returning.
+	ts.mu.Lock()
+	if ts.state == sessionStateStopping {
+		ts.mu.Unlock()
+		_ = sess.Close()
+		abortStopped()
+		return nil
 	}
-	ts.touch()
-
-	h.mu.Lock()
-	h.terminals[req.SessionId] = ts
-	h.mu.Unlock()
+	ts.session = sess
+	ts.tempHome = tempHomeDir
+	ts.state = sessionStateActive
+	ts.touchLocked()
+	ts.mu.Unlock()
 
 	// Tell the gateway/web client we're live BEFORE starting the
 	// reader, so the first byte of output cannot race ahead of the
-	// STARTED state change.
-	if err := h.terminalSender.SendTerminalStateChange(ctx, &pb.TerminalStateChange{
+	// STARTED state change. If this fails, the gateway never
+	// learned we're alive — there's no point keeping the PTY open
+	// and burning a slot, so tear the session down.
+	if err := sender.SendTerminalStateChange(ctx, &pb.TerminalStateChange{
 		SessionId: req.SessionId,
 		State:     pb.TerminalSessionState_TERMINAL_SESSION_STATE_STARTED,
 	}); err != nil {
-		logger.Warn("failed to send STARTED state change", "error", err)
+		logger.Warn("failed to send STARTED state change; aborting session", "error", err)
+		h.closeTerminal(context.Background(), req.SessionId, "send started failed")
+		return nil
 	}
 
 	go h.pumpTerminalOutput(sessionCtx, ts)
 	return nil
+}
+
+// touchLocked is the lock-free variant of touch, used when the caller
+// already holds ts.mu (e.g. inside the activation transition).
+func (ts *terminalSession) touchLocked() {
+	ts.lastActivity = time.Now()
 }
 
 // OnTerminalInput writes the bytes to the named session's PTY. Unknown
@@ -265,7 +393,16 @@ func (h *Handler) OnTerminalInput(ctx context.Context, req *pb.TerminalInput) er
 		h.logger.Debug("terminal input for unknown session", "session_id", req.SessionId)
 		return nil
 	}
-	if _, err := ts.session.Write(req.Data); err != nil {
+	// Sessions in the starting state have no PTY yet; ignore until
+	// they activate.
+	ts.mu.Lock()
+	sess := ts.session
+	ts.mu.Unlock()
+	if sess == nil {
+		h.logger.Debug("terminal input for not-yet-active session", "session_id", req.SessionId)
+		return nil
+	}
+	if _, err := sess.Write(req.Data); err != nil {
 		h.logger.Warn("terminal input write failed", "session_id", req.SessionId, "error", err)
 		// Don't tear down the session — the read pump will detect the
 		// PTY going away and emit EXITED.
@@ -282,7 +419,14 @@ func (h *Handler) OnTerminalResize(ctx context.Context, req *pb.TerminalResize) 
 		h.logger.Debug("terminal resize for unknown session", "session_id", req.SessionId)
 		return nil
 	}
-	if err := ts.session.Resize(uint16(req.Cols), uint16(req.Rows)); err != nil {
+	ts.mu.Lock()
+	sess := ts.session
+	ts.mu.Unlock()
+	if sess == nil {
+		h.logger.Debug("terminal resize for not-yet-active session", "session_id", req.SessionId)
+		return nil
+	}
+	if err := sess.Resize(uint16(req.Cols), uint16(req.Rows)); err != nil {
 		h.logger.Warn("terminal resize failed", "session_id", req.SessionId, "error", err)
 	}
 	return nil
@@ -292,7 +436,9 @@ func (h *Handler) OnTerminalResize(ctx context.Context, req *pb.TerminalResize) 
 // effects: closes the PTY, removes the temp home, and reverts the
 // TTY user's shell to nologin if it was the last active session for
 // that user. Idempotent: unknown sessions are no-ops so the gateway
-// can fire and forget.
+// can fire and forget. Sessions still in the starting state are
+// marked stopping and cleaned up by OnTerminalStart on its next
+// state check.
 func (h *Handler) OnTerminalStop(ctx context.Context, req *pb.TerminalStop) error {
 	if req.Reason != "" {
 		h.logger.Info("stopping terminal session", "session_id", req.SessionId, "reason", req.Reason)
@@ -308,6 +454,9 @@ func (h *Handler) OnTerminalStop(ctx context.Context, req *pb.TerminalStop) erro
 // (PTY closed by Stop or natural shell exit) or when sessionCtx is
 // cancelled. Always emits a final state change before returning so
 // the web client knows whether the shell exited cleanly or errored.
+//
+// All sender access goes through the per-session ts.sender snapshot,
+// not h.terminalSender, so this goroutine never has to touch h.mu.
 func (h *Handler) pumpTerminalOutput(sessionCtx context.Context, ts *terminalSession) {
 	defer func() {
 		// Wait for the shell to actually exit so we can report the
@@ -319,7 +468,7 @@ func (h *Handler) pumpTerminalOutput(sessionCtx context.Context, ts *terminalSes
 			State:     pb.TerminalSessionState_TERMINAL_SESSION_STATE_EXITED,
 			ExitCode:  int32(exitCode),
 		}
-		if err := h.terminalSender.SendTerminalStateChange(context.Background(), state); err != nil {
+		if err := ts.sender.SendTerminalStateChange(context.Background(), state); err != nil {
 			h.logger.Warn("failed to send EXITED state change",
 				"session_id", ts.id, "error", err)
 		}
@@ -342,9 +491,13 @@ func (h *Handler) pumpTerminalOutput(sessionCtx context.Context, ts *terminalSes
 				SessionId: ts.id,
 				Data:      append([]byte(nil), buf[:n]...),
 			}
-			if sendErr := h.terminalSender.SendTerminalOutput(context.Background(), out); sendErr != nil {
-				h.logger.Warn("failed to send terminal output",
+			if sendErr := ts.sender.SendTerminalOutput(context.Background(), out); sendErr != nil {
+				h.logger.Warn("failed to send terminal output; tearing down session",
 					"session_id", ts.id, "error", sendErr)
+				// Returning here triggers the deferred Wait + EXITED
+				// + closeTerminal path, so the PTY is torn down and
+				// the slot is freed. Without this teardown, a
+				// disconnected gateway would leak the PTY indefinitely.
 				return
 			}
 		}
@@ -361,9 +514,13 @@ func (h *Handler) pumpTerminalOutput(sessionCtx context.Context, ts *terminalSes
 // before the I/O goroutine has been started; once the goroutine is
 // running, errors flow through pumpTerminalOutput's deferred
 // EXITED/closeTerminal path.
-func (h *Handler) failTerminalStart(ctx context.Context, sessionID, msg string) {
+//
+// Takes an explicit sender so the caller — which has already
+// snapshotted h.terminalSender once under h.mu — does not have to
+// re-acquire the lock.
+func (h *Handler) failTerminalStart(ctx context.Context, sender TerminalSender, sessionID, msg string) {
 	h.logger.Warn("terminal session start failed", "session_id", sessionID, "error", msg)
-	if h.terminalSender == nil {
+	if sender == nil {
 		return
 	}
 	change := &pb.TerminalStateChange{
@@ -371,7 +528,7 @@ func (h *Handler) failTerminalStart(ctx context.Context, sessionID, msg string) 
 		State:     pb.TerminalSessionState_TERMINAL_SESSION_STATE_ERROR,
 		Error:     msg,
 	}
-	if err := h.terminalSender.SendTerminalStateChange(ctx, change); err != nil {
+	if err := sender.SendTerminalStateChange(ctx, change); err != nil {
 		h.logger.Warn("failed to send ERROR state change",
 			"session_id", sessionID, "error", err)
 	}
@@ -379,17 +536,48 @@ func (h *Handler) failTerminalStart(ctx context.Context, sessionID, msg string) 
 
 // closeTerminal closes one session and reverts its side effects.
 // Idempotent: a second call for the same id is a no-op.
+//
+// For sessions still in sessionStateStarting, this method only
+// transitions the state to stopping and cancels the start context;
+// the cleanup of partial side effects (shell, temp home) is done by
+// OnTerminalStart on its next state check, because Start owns the
+// list of "what has been applied so far".
 func (h *Handler) closeTerminal(ctx context.Context, sessionID, reason string) {
 	h.mu.Lock()
 	ts, ok := h.terminals[sessionID]
+	h.mu.Unlock()
 	if !ok || ts == nil {
-		h.mu.Unlock()
 		return
 	}
-	delete(h.terminals, sessionID)
-	// Snapshot ttyUser before unlocking to compute the "last session
-	// for this user?" check below.
+
+	ts.mu.Lock()
+	if ts.state == sessionStateStopping {
+		// Already being torn down — nothing to do.
+		ts.mu.Unlock()
+		return
+	}
+	wasStarting := ts.state == sessionStateStarting
+	ts.state = sessionStateStopping
+	if ts.cancel != nil {
+		ts.cancel()
+	}
+	sess := ts.session
+	tempHome := ts.tempHome
 	ttyUser := ts.ttyUser
+	ts.mu.Unlock()
+
+	if wasStarting {
+		// OnTerminalStart will see the stopping state on its next
+		// isStopping() check (or the cancelled context will pop a
+		// sudo call out), and it will clean up its own partial state
+		// and remove the entry from the registry. We deliberately
+		// don't touch the registry here.
+		return
+	}
+
+	// Active session: pull from the registry, then revert side effects.
+	h.mu.Lock()
+	delete(h.terminals, sessionID)
 	stillActiveForUser := false
 	for _, other := range h.terminals {
 		if other != nil && other.ttyUser == ttyUser {
@@ -399,11 +587,8 @@ func (h *Handler) closeTerminal(ctx context.Context, sessionID, reason string) {
 	}
 	h.mu.Unlock()
 
-	if ts.cancel != nil {
-		ts.cancel()
-	}
-	if ts.session != nil {
-		if err := ts.session.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+	if sess != nil {
+		if err := sess.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
 			h.logger.Warn("terminal session close error", "session_id", sessionID, "error", err)
 		}
 	}
@@ -415,13 +600,31 @@ func (h *Handler) closeTerminal(ctx context.Context, sessionID, reason string) {
 		h.deactivateShell(ctx, ttyUser)
 	}
 
-	if ts.tempHome != "" {
-		if err := os.RemoveAll(ts.tempHome); err != nil {
+	if tempHome != "" {
+		if err := os.RemoveAll(tempHome); err != nil {
 			h.logger.Warn("failed to remove terminal temp home",
-				"session_id", sessionID, "path", ts.tempHome, "error", err)
+				"session_id", sessionID, "path", tempHome, "error", err)
 		}
 	}
 	_ = reason
+}
+
+// anySessionForUserExcept reports whether any active session in the
+// registry has the given tty user, ignoring the supplied session id.
+// Used by OnTerminalStart's cleanup path to decide whether reverting
+// the shell would yank it out from under a concurrent session.
+func (h *Handler) anySessionForUserExcept(ttyUser, exceptSessionID string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for id, other := range h.terminals {
+		if id == exceptSessionID || other == nil {
+			continue
+		}
+		if other.ttyUser == ttyUser {
+			return true
+		}
+	}
+	return false
 }
 
 // deactivateShell reverts the TTY user's login shell back to nologin.
@@ -467,6 +670,14 @@ func (h *Handler) sweepIdleTerminals() {
 	var idle []string
 	for id, ts := range h.terminals {
 		if ts == nil {
+			continue
+		}
+		// Skip sessions that aren't fully active yet — they're either
+		// still in setup (no PTY to close) or already stopping.
+		ts.mu.Lock()
+		state := ts.state
+		ts.mu.Unlock()
+		if state != sessionStateActive {
 			continue
 		}
 		if ts.idleSince().Before(cutoff) {

--- a/internal/handler/terminal.go
+++ b/internal/handler/terminal.go
@@ -1,0 +1,482 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	sdk "github.com/manchtools/power-manage/sdk/go"
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/sys/terminal"
+	sysuser "github.com/manchtools/power-manage/sdk/go/sys/user"
+)
+
+// Compile-time assertion that *Handler satisfies sdk.TerminalHandler.
+// If the SDK changes the interface and the handler stops matching, this
+// fails at build time instead of silently disabling terminal support
+// (the SDK Client's type-assert miss is a no-op for the agent).
+var _ sdk.TerminalHandler = (*Handler)(nil)
+
+// Default agent-side limits per the issue spec
+// (manchtools/power-manage-sdk#16 — Security section).
+const (
+	defaultTerminalLimit       = 3
+	defaultTerminalIdleTimeout = 30 * time.Minute
+	terminalSweepInterval      = 30 * time.Second
+	terminalReadChunkBytes     = 32 * 1024 // matches the proto's max=65536 with headroom
+
+	// Activated shell to assign to the TTY user during a session. The
+	// agent reverts to nologin on disconnect; this is intentionally
+	// hard-coded so it cannot be overridden from the gateway side.
+	terminalActivatedShell  = "/bin/bash"
+	terminalDeactivatedShell = "/usr/sbin/nologin"
+)
+
+// TerminalSender is the subset of the SDK Client that the terminal
+// handler needs to push messages back to the gateway. The agent's
+// main.go injects the *sdk.Client which satisfies this interface
+// implicitly so the handler package doesn't depend on the entire
+// client.
+type TerminalSender interface {
+	SendTerminalOutput(ctx context.Context, out *pb.TerminalOutput) error
+	SendTerminalStateChange(ctx context.Context, change *pb.TerminalStateChange) error
+}
+
+// terminalSession is the agent's per-session bookkeeping. It owns the
+// SDK terminal.Session, the activated tty user (so we know what to
+// revert on Stop), and the cancel function for its I/O goroutine.
+type terminalSession struct {
+	id       string
+	ttyUser  string
+	tempHome string
+	session  *terminal.Session
+	cancel   context.CancelFunc
+
+	// lastActivity is updated whenever a frame is read or written;
+	// the sweeper closes sessions whose lastActivity is older than
+	// the configured idle timeout.
+	mu           sync.Mutex
+	lastActivity time.Time
+}
+
+func (ts *terminalSession) touch() {
+	ts.mu.Lock()
+	ts.lastActivity = time.Now()
+	ts.mu.Unlock()
+}
+
+func (ts *terminalSession) idleSince() time.Time {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.lastActivity
+}
+
+// SetTerminalSender wires the SDK Client (or any compatible sender)
+// into the handler. Must be called once after the Client is created
+// and before the stream loop dispatches the first TerminalStart
+// message. Calling it twice replaces the previous sender.
+func (h *Handler) SetTerminalSender(sender TerminalSender) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.terminalSender = sender
+	if h.terminals == nil {
+		h.terminals = make(map[string]*terminalSession)
+	}
+	if h.terminalLimit == 0 {
+		h.terminalLimit = defaultTerminalLimit
+	}
+	if h.terminalIdleTimeout == 0 {
+		h.terminalIdleTimeout = defaultTerminalIdleTimeout
+	}
+	if !h.terminalSweeperStarted {
+		h.terminalSweeperStarted = true
+		go h.terminalSweepLoop()
+	}
+}
+
+// OnTerminalStart implements sdk.TerminalHandler. It validates the
+// dedicated TTY user, activates its shell, allocates the PTY via the
+// SDK terminal package, kicks off the read goroutine that pumps PTY
+// output back to the gateway, and emits a STARTED state change. Any
+// failure surfaces via SendTerminalStateChange with STATE_ERROR
+// instead of returning an error from the dispatch loop, so a single
+// bad request never tears down the agent connection.
+func (h *Handler) OnTerminalStart(ctx context.Context, req *pb.TerminalStart) error {
+	logger := h.logger.With("session_id", req.SessionId, "tty_user", req.TtyUser)
+	logger.Info("opening terminal session")
+
+	if h.terminalSender == nil {
+		// Should not happen — SetTerminalSender is called at startup.
+		// Surface the misconfiguration as a state-change error so the
+		// gateway/web client sees a clean failure.
+		logger.Error("terminal sender not configured; dropping start request")
+		return nil
+	}
+
+	// Refuse anything that doesn't look like a Power Manage TTY user.
+	// The proto layer enforces ulid session IDs, but the username
+	// comes from the control server's resolution and we re-validate
+	// here as defense in depth.
+	if !sysuser.IsValidName(req.TtyUser) {
+		h.failTerminalStart(ctx, req.SessionId, "invalid tty username")
+		return nil
+	}
+
+	// Verify the TTY user actually exists and is not locked. This is
+	// the dedicated pm-tty-* account; failure here means the control
+	// server's TerminalAccess provisioning hasn't run on this device
+	// yet, or the user has been disabled.
+	info, err := sysuser.Get(req.TtyUser)
+	if err != nil {
+		h.failTerminalStart(ctx, req.SessionId, fmt.Sprintf("tty user %q not provisioned: %v", req.TtyUser, err))
+		return nil
+	}
+	if info.Locked {
+		h.failTerminalStart(ctx, req.SessionId, fmt.Sprintf("tty user %q is disabled", req.TtyUser))
+		return nil
+	}
+
+	// Reserve a slot under the lock so concurrent Start requests can't
+	// both pass the limit check.
+	h.mu.Lock()
+	if h.terminals == nil {
+		h.terminals = make(map[string]*terminalSession)
+	}
+	if _, exists := h.terminals[req.SessionId]; exists {
+		h.mu.Unlock()
+		h.failTerminalStart(ctx, req.SessionId, "session already exists")
+		return nil
+	}
+	limit := h.terminalLimit
+	if limit == 0 {
+		limit = defaultTerminalLimit
+	}
+	if len(h.terminals) >= limit {
+		h.mu.Unlock()
+		h.failTerminalStart(ctx, req.SessionId, fmt.Sprintf("device terminal session limit reached (%d)", limit))
+		return nil
+	}
+	h.terminals[req.SessionId] = nil // reserve
+	h.mu.Unlock()
+
+	// Activate the shell. usermod via the SDK helper which already
+	// uses sudo -n.
+	if err := sysuser.Modify(ctx, req.TtyUser, "-s", terminalActivatedShell); err != nil {
+		h.removeTerminal(req.SessionId)
+		h.failTerminalStart(ctx, req.SessionId, fmt.Sprintf("activate shell: %v", err))
+		return nil
+	}
+
+	// Per-session temp home so the activated shell has a writable
+	// CWD without polluting any real user's $HOME. Owned by the TTY
+	// user (chown via the SDK helper) and removed on session stop.
+	//
+	// Use os.Mkdir (NOT MkdirAll) so a pre-existing path causes a
+	// hard failure instead of being followed: a malicious local user
+	// could otherwise plant /tmp/pm-tty-foo.<sessid> as a symlink
+	// pointing at /etc and trick the subsequent chown into rewriting
+	// system file ownership. ULID session ids make accidental
+	// collisions statistically impossible, so EEXIST really does
+	// mean "something is wrong".
+	tempHome := filepath.Join("/tmp", req.TtyUser+"."+req.SessionId)
+	if err := os.Mkdir(tempHome, 0o700); err != nil {
+		h.deactivateShell(ctx, req.TtyUser)
+		h.removeTerminal(req.SessionId)
+		h.failTerminalStart(ctx, req.SessionId, fmt.Sprintf("create temp home: %v", err))
+		return nil
+	}
+	// Belt and braces: confirm the freshly-created path is actually
+	// a directory and not a symlink before chowning anything.
+	if info, err := os.Lstat(tempHome); err != nil || !info.Mode().IsDir() {
+		_ = os.RemoveAll(tempHome)
+		h.deactivateShell(ctx, req.TtyUser)
+		h.removeTerminal(req.SessionId)
+		h.failTerminalStart(ctx, req.SessionId, "temp home is not a regular directory")
+		return nil
+	}
+	if err := sysuser.ChownRecursive(ctx, tempHome, req.TtyUser, req.TtyUser); err != nil {
+		_ = os.RemoveAll(tempHome)
+		h.deactivateShell(ctx, req.TtyUser)
+		h.removeTerminal(req.SessionId)
+		h.failTerminalStart(ctx, req.SessionId, fmt.Sprintf("chown temp home: %v", err))
+		return nil
+	}
+
+	cols := uint16(req.Cols)
+	rows := uint16(req.Rows)
+	cfg := terminal.SessionConfig{
+		User:    req.TtyUser,
+		Shell:   terminalActivatedShell,
+		Cols:    cols,
+		Rows:    rows,
+		WorkDir: tempHome,
+		Env:     []string{"HOME=" + tempHome, "USER=" + req.TtyUser, "LOGNAME=" + req.TtyUser},
+	}
+
+	sess, err := terminal.Start(cfg)
+	if err != nil {
+		_ = os.RemoveAll(tempHome)
+		h.deactivateShell(ctx, req.TtyUser)
+		h.removeTerminal(req.SessionId)
+		h.failTerminalStart(ctx, req.SessionId, fmt.Sprintf("allocate pty: %v", err))
+		return nil
+	}
+
+	// Per-session context for the I/O goroutine. Cancelled by Stop or
+	// by the natural exit reaper.
+	sessionCtx, cancel := context.WithCancel(context.Background())
+	ts := &terminalSession{
+		id:       req.SessionId,
+		ttyUser:  req.TtyUser,
+		tempHome: tempHome,
+		session:  sess,
+		cancel:   cancel,
+	}
+	ts.touch()
+
+	h.mu.Lock()
+	h.terminals[req.SessionId] = ts
+	h.mu.Unlock()
+
+	// Tell the gateway/web client we're live BEFORE starting the
+	// reader, so the first byte of output cannot race ahead of the
+	// STARTED state change.
+	if err := h.terminalSender.SendTerminalStateChange(ctx, &pb.TerminalStateChange{
+		SessionId: req.SessionId,
+		State:     pb.TerminalSessionState_TERMINAL_SESSION_STATE_STARTED,
+	}); err != nil {
+		logger.Warn("failed to send STARTED state change", "error", err)
+	}
+
+	go h.pumpTerminalOutput(sessionCtx, ts)
+	return nil
+}
+
+// OnTerminalInput writes the bytes to the named session's PTY. Unknown
+// sessions are ignored at debug level — the gateway may have already
+// torn down the session and a few in-flight frames are normal.
+func (h *Handler) OnTerminalInput(ctx context.Context, req *pb.TerminalInput) error {
+	ts := h.lookupTerminal(req.SessionId)
+	if ts == nil {
+		h.logger.Debug("terminal input for unknown session", "session_id", req.SessionId)
+		return nil
+	}
+	if _, err := ts.session.Write(req.Data); err != nil {
+		h.logger.Warn("terminal input write failed", "session_id", req.SessionId, "error", err)
+		// Don't tear down the session — the read pump will detect the
+		// PTY going away and emit EXITED.
+		return nil
+	}
+	ts.touch()
+	return nil
+}
+
+// OnTerminalResize forwards a TIOCSWINSZ to the session's PTY.
+func (h *Handler) OnTerminalResize(ctx context.Context, req *pb.TerminalResize) error {
+	ts := h.lookupTerminal(req.SessionId)
+	if ts == nil {
+		h.logger.Debug("terminal resize for unknown session", "session_id", req.SessionId)
+		return nil
+	}
+	if err := ts.session.Resize(uint16(req.Cols), uint16(req.Rows)); err != nil {
+		h.logger.Warn("terminal resize failed", "session_id", req.SessionId, "error", err)
+	}
+	return nil
+}
+
+// OnTerminalStop terminates the named session and reverts side
+// effects: closes the PTY, removes the temp home, and reverts the
+// TTY user's shell to nologin if it was the last active session for
+// that user. Idempotent: unknown sessions are no-ops so the gateway
+// can fire and forget.
+func (h *Handler) OnTerminalStop(ctx context.Context, req *pb.TerminalStop) error {
+	if req.Reason != "" {
+		h.logger.Info("stopping terminal session", "session_id", req.SessionId, "reason", req.Reason)
+	} else {
+		h.logger.Info("stopping terminal session", "session_id", req.SessionId)
+	}
+	h.closeTerminal(ctx, req.SessionId, req.Reason)
+	return nil
+}
+
+// pumpTerminalOutput is the per-session goroutine that copies PTY
+// output to TerminalOutput frames. Exits when the session ends
+// (PTY closed by Stop or natural shell exit) or when sessionCtx is
+// cancelled. Always emits a final state change before returning so
+// the web client knows whether the shell exited cleanly or errored.
+func (h *Handler) pumpTerminalOutput(sessionCtx context.Context, ts *terminalSession) {
+	defer func() {
+		// Wait for the shell to actually exit so we can report the
+		// real exit code; if Wait races with Close the SDK Session
+		// already handles the EIO/EOF in Read.
+		exitCode, _ := ts.session.Wait()
+		state := &pb.TerminalStateChange{
+			SessionId: ts.id,
+			State:     pb.TerminalSessionState_TERMINAL_SESSION_STATE_EXITED,
+			ExitCode:  int32(exitCode),
+		}
+		if err := h.terminalSender.SendTerminalStateChange(context.Background(), state); err != nil {
+			h.logger.Warn("failed to send EXITED state change",
+				"session_id", ts.id, "error", err)
+		}
+		// Make sure all the side effects are gone even if Stop never came.
+		h.closeTerminal(context.Background(), ts.id, "")
+	}()
+
+	buf := make([]byte, terminalReadChunkBytes)
+	for {
+		select {
+		case <-sessionCtx.Done():
+			return
+		default:
+		}
+
+		n, err := ts.session.Read(buf)
+		if n > 0 {
+			ts.touch()
+			out := &pb.TerminalOutput{
+				SessionId: ts.id,
+				Data:      append([]byte(nil), buf[:n]...),
+			}
+			if sendErr := h.terminalSender.SendTerminalOutput(context.Background(), out); sendErr != nil {
+				h.logger.Warn("failed to send terminal output",
+					"session_id", ts.id, "error", sendErr)
+				return
+			}
+		}
+		if err != nil {
+			// io.EOF / os.ErrClosed are expected on shell exit;
+			// anything else still ends the session.
+			return
+		}
+	}
+}
+
+// failTerminalStart sends a STATE_ERROR back to the gateway and gives
+// up on the session. Used during the validation/preparation phase
+// before the I/O goroutine has been started; once the goroutine is
+// running, errors flow through pumpTerminalOutput's deferred
+// EXITED/closeTerminal path.
+func (h *Handler) failTerminalStart(ctx context.Context, sessionID, msg string) {
+	h.logger.Warn("terminal session start failed", "session_id", sessionID, "error", msg)
+	if h.terminalSender == nil {
+		return
+	}
+	change := &pb.TerminalStateChange{
+		SessionId: sessionID,
+		State:     pb.TerminalSessionState_TERMINAL_SESSION_STATE_ERROR,
+		Error:     msg,
+	}
+	if err := h.terminalSender.SendTerminalStateChange(ctx, change); err != nil {
+		h.logger.Warn("failed to send ERROR state change",
+			"session_id", sessionID, "error", err)
+	}
+}
+
+// closeTerminal closes one session and reverts its side effects.
+// Idempotent: a second call for the same id is a no-op.
+func (h *Handler) closeTerminal(ctx context.Context, sessionID, reason string) {
+	h.mu.Lock()
+	ts, ok := h.terminals[sessionID]
+	if !ok || ts == nil {
+		h.mu.Unlock()
+		return
+	}
+	delete(h.terminals, sessionID)
+	// Snapshot ttyUser before unlocking to compute the "last session
+	// for this user?" check below.
+	ttyUser := ts.ttyUser
+	stillActiveForUser := false
+	for _, other := range h.terminals {
+		if other != nil && other.ttyUser == ttyUser {
+			stillActiveForUser = true
+			break
+		}
+	}
+	h.mu.Unlock()
+
+	if ts.cancel != nil {
+		ts.cancel()
+	}
+	if ts.session != nil {
+		if err := ts.session.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+			h.logger.Warn("terminal session close error", "session_id", sessionID, "error", err)
+		}
+	}
+
+	// Revert the TTY user shell only when no other session for the
+	// same user is still running. This handles the (rare but possible)
+	// case where the same TTY user has multiple concurrent sessions.
+	if !stillActiveForUser {
+		h.deactivateShell(ctx, ttyUser)
+	}
+
+	if ts.tempHome != "" {
+		if err := os.RemoveAll(ts.tempHome); err != nil {
+			h.logger.Warn("failed to remove terminal temp home",
+				"session_id", sessionID, "path", ts.tempHome, "error", err)
+		}
+	}
+	_ = reason
+}
+
+// deactivateShell reverts the TTY user's login shell back to nologin.
+// Best-effort: a failure here is logged but does not block the rest
+// of the cleanup.
+func (h *Handler) deactivateShell(ctx context.Context, ttyUser string) {
+	if err := sysuser.Modify(ctx, ttyUser, "-s", terminalDeactivatedShell); err != nil {
+		h.logger.Warn("failed to revert tty user shell",
+			"tty_user", ttyUser, "error", err)
+	}
+}
+
+func (h *Handler) lookupTerminal(sessionID string) *terminalSession {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.terminals[sessionID]
+}
+
+func (h *Handler) removeTerminal(sessionID string) {
+	h.mu.Lock()
+	delete(h.terminals, sessionID)
+	h.mu.Unlock()
+}
+
+// terminalSweepLoop runs forever, closing any session that has been
+// idle longer than the configured timeout. Started lazily on the
+// first SetTerminalSender call.
+func (h *Handler) terminalSweepLoop() {
+	t := time.NewTicker(terminalSweepInterval)
+	defer t.Stop()
+	for range t.C {
+		h.sweepIdleTerminals()
+	}
+}
+
+func (h *Handler) sweepIdleTerminals() {
+	h.mu.Lock()
+	timeout := h.terminalIdleTimeout
+	if timeout == 0 {
+		timeout = defaultTerminalIdleTimeout
+	}
+	cutoff := time.Now().Add(-timeout)
+	var idle []string
+	for id, ts := range h.terminals {
+		if ts == nil {
+			continue
+		}
+		if ts.idleSince().Before(cutoff) {
+			idle = append(idle, id)
+		}
+	}
+	h.mu.Unlock()
+
+	for _, id := range idle {
+		h.logger.Info("closing idle terminal session", "session_id", id, "timeout", timeout)
+		h.closeTerminal(context.Background(), id, "idle timeout")
+	}
+}

--- a/internal/handler/terminal_test.go
+++ b/internal/handler/terminal_test.go
@@ -1,0 +1,237 @@
+package handler
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// fakeSender records every TerminalOutput / TerminalStateChange so
+// the tests can assert against it without an actual SDK Client.
+type fakeSender struct {
+	mu      sync.Mutex
+	outputs []*pb.TerminalOutput
+	states  []*pb.TerminalStateChange
+}
+
+func (f *fakeSender) SendTerminalOutput(ctx context.Context, out *pb.TerminalOutput) error {
+	f.mu.Lock()
+	f.outputs = append(f.outputs, out)
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeSender) SendTerminalStateChange(ctx context.Context, change *pb.TerminalStateChange) error {
+	f.mu.Lock()
+	f.states = append(f.states, change)
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeSender) lastState() *pb.TerminalStateChange {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.states) == 0 {
+		return nil
+	}
+	return f.states[len(f.states)-1]
+}
+
+func newTestHandler(t *testing.T) (*Handler, *fakeSender) {
+	t.Helper()
+	h := &Handler{
+		logger:      slog.Default(),
+		connectedCh: make(chan struct{}),
+	}
+	sender := &fakeSender{}
+	h.SetTerminalSender(sender)
+	return h, sender
+}
+
+// addTestSession injects a fake session into the registry without
+// going through OnTerminalStart, so tests can exercise registry
+// behaviour (limits, lookup, idle sweep, close) without needing
+// real sudo/usermod/PTY access.
+func addTestSession(h *Handler, id, ttyUser string, lastActivity time.Time) *terminalSession {
+	ts := &terminalSession{
+		id:           id,
+		ttyUser:      ttyUser,
+		lastActivity: lastActivity,
+	}
+	h.mu.Lock()
+	h.terminals[id] = ts
+	h.mu.Unlock()
+	return ts
+}
+
+func TestTerminal_LookupUnknown(t *testing.T) {
+	h, _ := newTestHandler(t)
+	if got := h.lookupTerminal("nope"); got != nil {
+		t.Errorf("lookupTerminal(unknown) = %v, want nil", got)
+	}
+}
+
+func TestTerminal_OnInput_UnknownIsNoOp(t *testing.T) {
+	h, _ := newTestHandler(t)
+	err := h.OnTerminalInput(context.Background(), &pb.TerminalInput{
+		SessionId: "01ABC",
+		Data:      []byte("hello"),
+	})
+	if err != nil {
+		t.Errorf("OnTerminalInput(unknown) = %v, want nil", err)
+	}
+}
+
+func TestTerminal_OnResize_UnknownIsNoOp(t *testing.T) {
+	h, _ := newTestHandler(t)
+	err := h.OnTerminalResize(context.Background(), &pb.TerminalResize{
+		SessionId: "01ABC",
+		Cols:      120,
+		Rows:      40,
+	})
+	if err != nil {
+		t.Errorf("OnTerminalResize(unknown) = %v, want nil", err)
+	}
+}
+
+func TestTerminal_OnStop_UnknownIsNoOp(t *testing.T) {
+	h, _ := newTestHandler(t)
+	err := h.OnTerminalStop(context.Background(), &pb.TerminalStop{SessionId: "01ABC"})
+	if err != nil {
+		t.Errorf("OnTerminalStop(unknown) = %v, want nil", err)
+	}
+}
+
+func TestTerminal_CloseRemovesFromRegistry(t *testing.T) {
+	h, _ := newTestHandler(t)
+	addTestSession(h, "01ABC", "pm-tty-test", time.Now())
+
+	if got := len(h.terminals); got != 1 {
+		t.Fatalf("len(terminals) before close = %d, want 1", got)
+	}
+
+	h.closeTerminal(context.Background(), "01ABC", "")
+
+	if got := len(h.terminals); got != 0 {
+		t.Errorf("len(terminals) after close = %d, want 0", got)
+	}
+	if got := h.lookupTerminal("01ABC"); got != nil {
+		t.Error("lookup after close should return nil")
+	}
+}
+
+func TestTerminal_CloseIsIdempotent(t *testing.T) {
+	h, _ := newTestHandler(t)
+	addTestSession(h, "01ABC", "pm-tty-test", time.Now())
+
+	h.closeTerminal(context.Background(), "01ABC", "")
+	// Second close should be a clean no-op (no panic, no error path).
+	h.closeTerminal(context.Background(), "01ABC", "")
+
+	if got := len(h.terminals); got != 0 {
+		t.Errorf("len(terminals) = %d, want 0", got)
+	}
+}
+
+func TestTerminal_SweepIdle_ClosesStaleSessions(t *testing.T) {
+	h, _ := newTestHandler(t)
+	// Force a tight idle window so the test runs without sleeping
+	// for the default 30 minutes.
+	h.mu.Lock()
+	h.terminalIdleTimeout = 50 * time.Millisecond
+	h.mu.Unlock()
+
+	stale := time.Now().Add(-1 * time.Hour)
+	fresh := time.Now()
+	addTestSession(h, "stale", "pm-tty-a", stale)
+	addTestSession(h, "fresh", "pm-tty-b", fresh)
+
+	h.sweepIdleTerminals()
+
+	if h.lookupTerminal("stale") != nil {
+		t.Error("stale session should have been swept")
+	}
+	if h.lookupTerminal("fresh") == nil {
+		t.Error("fresh session should still be present")
+	}
+}
+
+func TestTerminal_SweepIdle_LeavesEverythingWhenNothingIsStale(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.mu.Lock()
+	h.terminalIdleTimeout = 1 * time.Hour
+	h.mu.Unlock()
+
+	addTestSession(h, "a", "pm-tty-a", time.Now())
+	addTestSession(h, "b", "pm-tty-b", time.Now())
+
+	h.sweepIdleTerminals()
+
+	if got := len(h.terminals); got != 2 {
+		t.Errorf("len(terminals) after no-op sweep = %d, want 2", got)
+	}
+}
+
+func TestTerminal_SetTerminalSender_AppliesDefaults(t *testing.T) {
+	h := &Handler{
+		logger:      slog.Default(),
+		connectedCh: make(chan struct{}),
+	}
+	h.SetTerminalSender(&fakeSender{})
+
+	if h.terminalLimit != defaultTerminalLimit {
+		t.Errorf("terminalLimit = %d, want %d", h.terminalLimit, defaultTerminalLimit)
+	}
+	if h.terminalIdleTimeout != defaultTerminalIdleTimeout {
+		t.Errorf("terminalIdleTimeout = %v, want %v", h.terminalIdleTimeout, defaultTerminalIdleTimeout)
+	}
+	if h.terminals == nil {
+		t.Error("terminals map should be initialized")
+	}
+	if !h.terminalSweeperStarted {
+		t.Error("sweeper should have been started")
+	}
+}
+
+func TestTerminal_SetTerminalSender_DoesNotResetExistingValues(t *testing.T) {
+	h := &Handler{
+		logger:              slog.Default(),
+		connectedCh:         make(chan struct{}),
+		terminalLimit:       7,
+		terminalIdleTimeout: 5 * time.Minute,
+	}
+	h.SetTerminalSender(&fakeSender{})
+
+	if h.terminalLimit != 7 {
+		t.Errorf("terminalLimit was reset to %d", h.terminalLimit)
+	}
+	if h.terminalIdleTimeout != 5*time.Minute {
+		t.Errorf("terminalIdleTimeout was reset to %v", h.terminalIdleTimeout)
+	}
+}
+
+// failTerminalStart should send STATE_ERROR via the sender. The
+// validation/limit/duplicate paths in OnTerminalStart all funnel
+// through this helper.
+func TestTerminal_FailStart_EmitsErrorState(t *testing.T) {
+	h, sender := newTestHandler(t)
+	h.failTerminalStart(context.Background(), "01ABC", "test failure")
+
+	last := sender.lastState()
+	if last == nil {
+		t.Fatal("expected a state change to be sent")
+	}
+	if last.SessionId != "01ABC" {
+		t.Errorf("session_id = %q, want 01ABC", last.SessionId)
+	}
+	if last.State != pb.TerminalSessionState_TERMINAL_SESSION_STATE_ERROR {
+		t.Errorf("state = %v, want ERROR", last.State)
+	}
+	if last.Error != "test failure" {
+		t.Errorf("error = %q, want %q", last.Error, "test failure")
+	}
+}

--- a/internal/handler/terminal_test.go
+++ b/internal/handler/terminal_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -52,14 +53,17 @@ func newTestHandler(t *testing.T) (*Handler, *fakeSender) {
 	return h, sender
 }
 
-// addTestSession injects a fake session into the registry without
-// going through OnTerminalStart, so tests can exercise registry
-// behaviour (limits, lookup, idle sweep, close) without needing
-// real sudo/usermod/PTY access.
+// addTestSession injects a fake active session into the registry
+// without going through OnTerminalStart, so tests can exercise
+// registry behaviour (limits, lookup, idle sweep, close) without
+// needing real sudo/usermod/PTY access. The session is created in
+// the active state so the idle sweeper picks it up the same way it
+// would for a real running session.
 func addTestSession(h *Handler, id, ttyUser string, lastActivity time.Time) *terminalSession {
 	ts := &terminalSession{
 		id:           id,
 		ttyUser:      ttyUser,
+		state:        sessionStateActive,
 		lastActivity: lastActivity,
 	}
 	h.mu.Lock()
@@ -214,12 +218,13 @@ func TestTerminal_SetTerminalSender_DoesNotResetExistingValues(t *testing.T) {
 	}
 }
 
-// failTerminalStart should send STATE_ERROR via the sender. The
-// validation/limit/duplicate paths in OnTerminalStart all funnel
-// through this helper.
+// failTerminalStart should send STATE_ERROR via the supplied sender.
+// The validation/limit/duplicate paths in OnTerminalStart all funnel
+// through this helper, passing the sender they snapshotted at the
+// start of the call so the helper never has to re-acquire h.mu.
 func TestTerminal_FailStart_EmitsErrorState(t *testing.T) {
 	h, sender := newTestHandler(t)
-	h.failTerminalStart(context.Background(), "01ABC", "test failure")
+	h.failTerminalStart(context.Background(), sender, "01ABC", "test failure")
 
 	last := sender.lastState()
 	if last == nil {
@@ -233,5 +238,148 @@ func TestTerminal_FailStart_EmitsErrorState(t *testing.T) {
 	}
 	if last.Error != "test failure" {
 		t.Errorf("error = %q, want %q", last.Error, "test failure")
+	}
+}
+
+// OnTerminalStart must reject any TTY username that does not start
+// with the dedicated pm-tty- prefix, even when the username is
+// otherwise syntactically valid. This guards against the agent ever
+// operating on an arbitrary system account if the control server's
+// resolution is buggy or compromised.
+func TestTerminal_Start_RejectsNonPrefixedUsername(t *testing.T) {
+	h, sender := newTestHandler(t)
+	err := h.OnTerminalStart(context.Background(), &pb.TerminalStart{
+		SessionId: "01ABC",
+		TtyUser:   "alice", // valid syntax, NOT a pm-tty-* user
+		Cols:      80,
+		Rows:      24,
+	})
+	if err != nil {
+		t.Fatalf("OnTerminalStart returned %v", err)
+	}
+	last := sender.lastState()
+	if last == nil {
+		t.Fatal("expected STATE_ERROR for non-prefixed username")
+	}
+	if last.State != pb.TerminalSessionState_TERMINAL_SESSION_STATE_ERROR {
+		t.Errorf("state = %v, want ERROR", last.State)
+	}
+	if !strings.Contains(last.Error, "invalid tty username") {
+		t.Errorf("error = %q, want substring 'invalid tty username'", last.Error)
+	}
+	// The session must NOT have been registered, so a subsequent
+	// limit check still has room.
+	if got := len(h.terminals); got != 0 {
+		t.Errorf("registry should be empty, got %d entries", got)
+	}
+}
+
+// closeTerminal on a session that's still in the starting state
+// must transition it to stopping (not delete it from the registry —
+// OnTerminalStart owns cleanup of partial state). The session must
+// have its cancel func invoked so any in-flight sudo call wakes up.
+func TestTerminal_CloseDuringStart_MarksStoppingButLeavesRegistryEntry(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	cancelCalled := make(chan struct{}, 1)
+	_, cancel := context.WithCancel(context.Background())
+	wrappedCancel := func() {
+		cancel()
+		select {
+		case cancelCalled <- struct{}{}:
+		default:
+		}
+	}
+	ts := &terminalSession{
+		id:      "01ABC",
+		ttyUser: "pm-tty-test",
+		state:   sessionStateStarting,
+		cancel:  wrappedCancel,
+	}
+	h.mu.Lock()
+	h.terminals["01ABC"] = ts
+	h.mu.Unlock()
+
+	h.closeTerminal(context.Background(), "01ABC", "user stopped")
+
+	// State must be stopping.
+	if !ts.isStopping() {
+		t.Error("expected session state = stopping after close-during-start")
+	}
+	// Cancel must have been invoked.
+	select {
+	case <-cancelCalled:
+	default:
+		t.Error("expected ts.cancel to have been called")
+	}
+	// Registry entry must still be present so OnTerminalStart can see
+	// the state on its next isStopping() check and clean up.
+	if h.lookupTerminal("01ABC") == nil {
+		t.Error("registry entry must still be present until Start cleans up")
+	}
+}
+
+// closeTerminal on an active session must delete it from the
+// registry and proceed with the full cleanup path. (Mirror of the
+// existing TestTerminal_CloseRemovesFromRegistry test, but explicit
+// about the new state-aware path.)
+func TestTerminal_CloseDuringActive_RemovesFromRegistry(t *testing.T) {
+	h, _ := newTestHandler(t)
+	addTestSession(h, "01ABC", "pm-tty-test", time.Now())
+
+	h.closeTerminal(context.Background(), "01ABC", "")
+
+	if h.lookupTerminal("01ABC") != nil {
+		t.Error("active session should have been removed from registry")
+	}
+}
+
+// SetTerminalSender's race-safe snapshot path must be used by
+// OnTerminalStart. We cannot trivially exercise the race itself in a
+// unit test, but we can confirm that snapshotTerminalSender returns
+// the most recently installed value under the lock.
+func TestTerminal_SnapshotTerminalSender_ReturnsLatest(t *testing.T) {
+	h := &Handler{
+		logger:      slog.Default(),
+		connectedCh: make(chan struct{}),
+	}
+	if got := h.snapshotTerminalSender(); got != nil {
+		t.Errorf("snapshot before SetTerminalSender = %v, want nil", got)
+	}
+
+	first := &fakeSender{}
+	h.SetTerminalSender(first)
+	if got := h.snapshotTerminalSender(); got != first {
+		t.Errorf("snapshot = %v, want first sender", got)
+	}
+
+	second := &fakeSender{}
+	h.SetTerminalSender(second)
+	if got := h.snapshotTerminalSender(); got != second {
+		t.Errorf("snapshot = %v, want second sender (latest wins)", got)
+	}
+}
+
+// anySessionForUserExcept correctly returns true when another active
+// session for the same TTY user exists, and false otherwise. This
+// powers the OnTerminalStart cleanup path's decision about whether
+// to revert the user's shell.
+func TestTerminal_AnySessionForUserExcept(t *testing.T) {
+	h, _ := newTestHandler(t)
+	addTestSession(h, "a", "pm-tty-alice", time.Now())
+	addTestSession(h, "b", "pm-tty-alice", time.Now())
+	addTestSession(h, "c", "pm-tty-bob", time.Now())
+
+	if !h.anySessionForUserExcept("pm-tty-alice", "a") {
+		t.Error("session b for alice should be visible when excluding a")
+	}
+	if h.anySessionForUserExcept("pm-tty-alice", "a") && !h.anySessionForUserExcept("pm-tty-alice", "b") {
+		// trivially true; here for symmetry
+	}
+	if h.anySessionForUserExcept("pm-tty-bob", "c") {
+		t.Error("excluding the only bob session should return false")
+	}
+	if h.anySessionForUserExcept("pm-tty-eve", "any") {
+		t.Error("user with no sessions should return false")
 	}
 }


### PR DESCRIPTION
> ⚠️ **DRAFT — depends on manchtools/power-manage-sdk#26.** This PR cannot merge until that one is in. CI will fail against \`sdk\` main until then because \`sdk.TerminalHandler\` and the \`SendTerminal*\` helpers don't exist there yet.

## Summary

Implements step 3 of manchtools/power-manage-sdk#16 — wires the agent into the SDK terminal session contract so the gateway/web client can open interactive shells on managed devices. The Start RPC dispatches to the agent, the agent allocates a PTY via the merged \`sdk/go/sys/terminal\` package, and stdin/stdout flows back through the existing bidi stream as \`TerminalInput\` / \`TerminalOutput\` frames.

## What's in this PR

### \`internal/handler/terminal.go\` (new, ~340 lines)

\`*Handler\` now implements \`sdk.TerminalHandler\`. A compile-time interface assertion catches future SDK contract drift at build time — without it, a typo in a method signature would silently disable terminal support since the SDK Client's type-assert miss is a no-op.

**\`TerminalSender\` interface.** Lets \`main.go\` inject the \`*sdk.Client\` at startup without the handler package depending on the entire SDK client surface. Just \`SendTerminalOutput\` + \`SendTerminalStateChange\`.

**Per-session bookkeeping.** \`terminalSession\` struct tracks the TTY user, temp home, cancel function for the I/O goroutine, and last-activity timestamp. Registry guarded by the existing \`Handler.mu\`.

**\`OnTerminalStart\`.** The full happy path:
1. Validate the dedicated \`pm-tty-*\` user via \`sysuser.IsValidName\` + \`sysuser.Get\` + \`Locked\` check (the issue's "Verify pm-tty-pdotterer exists locally / not locked" steps).
2. **Reserve a slot under the lock** so concurrent Start requests can't both pass the per-device limit (default 3, per the issue's Security section). Reservation pattern prevents the TOCTOU race the naive "check then add" would have.
3. Activate the user's shell to \`/bin/bash\` via \`sysuser.Modify -s\`.
4. Create a per-session temp home (with hardening, see below).
5. Allocate the PTY via \`terminal.Start\` from the SDK.
6. Send a STARTED state change **before** the I/O reader starts so the first byte of output can't race ahead of the state machine.
7. Kick off \`pumpTerminalOutput\`.

**Every failure path** sends a STATE_ERROR via the sender and unwinds whichever side effects already landed (in reverse order: removeTerminal → deactivateShell → RemoveAll(tempHome)).

**\`OnTerminalInput\` / \`OnTerminalResize\` / \`OnTerminalStop\`.** Lookup-by-id, write/resize/close. Unknown sessions are debug-logged no-ops so in-flight frames after a teardown don't error out the stream.

**\`pumpTerminalOutput\`.** Per-session goroutine that copies PTY output to \`TerminalOutput\` frames in 32 KiB chunks (proto cap is 64 KiB; the headroom leaves room for any framing overhead). Defers an EXITED state change so the web client always learns the final exit code, even on a crash. Always calls \`closeTerminal\` in the deferred path so a crashed shell can't leak the temp home or leave the user's shell activated.

**\`closeTerminal\`.** Idempotent. Removes from the registry, cancels the I/O goroutine, closes the SDK \`terminal.Session\`, removes the temp home, and reverts the user shell to \`nologin\` — but **only when no other session for the same TTY user is still running**, so two concurrent sessions for the same user don't yank each other's shell.

**Idle sweeper.** Lazy goroutine started on the first \`SetTerminalSender\` call. Default 30-min idle timeout per the issue's Security section. Sweeper collects victims under the lock then closes them outside the lock to avoid holding it during sudo calls.

### Hardening

- **Temp home creation uses \`os.Mkdir\` (not \`MkdirAll\`)** so a pre-planted symlink at \`/tmp/pm-tty-foo.<sessid>\` causes a hard \`EEXIST\` instead of being followed. Without this guard, a malicious local user could trick the subsequent \`ChownRecursive\` into rewriting system file ownership. ULID session ids make accidental collisions statistically impossible, so EEXIST really does mean "something is wrong".
- **\`os.Lstat\` check after creation** confirms the path is a regular directory, not a symlink that snuck in between Mkdir and Chown.
- **\`terminalActivatedShell\` and \`terminalDeactivatedShell\` are hard-coded constants** that cannot be overridden from the gateway side, so a compromised gateway cannot pivot the agent into running an arbitrary binary as a privileged user.
- **\`sysuser.IsValidName\`** is the first thing \`OnTerminalStart\` does — guards against \`..\` in usernames before any path construction.

### \`internal/handler/handler.go\`

\`Handler\` struct gains \`terminalSender\`, \`terminals\` map, \`terminalLimit\`, \`terminalIdleTimeout\`, \`terminalSweeperStarted\`. All guarded by the existing \`mu\`.

### \`cmd/power-manage-agent/main.go\`

Calls \`h.SetTerminalSender(client)\` right after the existing \`SetLuksKeyStore\` wiring, so terminal support comes online for every connection session.

### \`internal/handler/terminal_test.go\` (new, 11 tests, race-clean)

Covers the registry-mutation paths that don't need real sudo/PTY:

1. \`lookupTerminal\` of unknown id returns nil.
2-4. \`OnTerminalInput\`/\`Resize\`/\`Stop\` on unknown ids are no-ops.
5. \`closeTerminal\` removes from the registry.
6. \`closeTerminal\` is idempotent.
7. Idle sweeper closes stale sessions, leaves fresh ones alone.
8. Idle sweeper with no stale sessions is a no-op.
9. \`SetTerminalSender\` applies defaults.
10. \`SetTerminalSender\` does not reset pre-existing field values (so test setup can pre-configure).
11. \`failTerminalStart\` emits STATE_ERROR via the sender.

The Start happy path is integration territory (needs real \`usermod\`, real \`sudo\`, real PTY) and is intentionally not unit-tested here. We can revisit if/when the agent grows an integration test harness.

### \`go.mod\` / \`go.sum\`

\`creack/pty\` pulled in transitively via the SDK terminal package. \`go mod tidy\` also reorganized stale direct/indirect entries (\`pressly/goose\` and \`robfig/cron\` promoted to direct since they're used in \`internal/store\`; \`oklog/ulid\` and \`golang.org/x/net\` demoted to indirect since no longer imported directly). Verified by grep that the new layout matches actual usage.

## What's NOT in this PR

- **Gateway WebSocket bridge** (step 4 of the issue) — separate PR in the server repo.
- **Control \`StartTerminal\` real implementation** (step 5) — currently still stubbed via manchtools/power-manage-server#34.
- **Web xterm.js component** (step 6) — separate PR in the web repo.
- **Token validation on the agent side** — the agent trusts the gateway because the connection is mTLS-authenticated. The session token validation is the gateway's job and lands in step 4.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/handler/ -count=1 -race\` — 11 new tests pass
- [x] \`go test ./... -count=1 -race\` — full agent suite green
- [x] Compile-time \`sdk.TerminalHandler\` interface assertion passes
- [ ] **Integration test on a real device** with the gateway PR + control real implementation (deferred until those PRs land)

## Refs

- manchtools/power-manage-sdk#16 — parent feature
- manchtools/power-manage-sdk#26 — **must merge first** (TerminalHandler interface + dispatch)
- manchtools/power-manage-server#6 — server-side parent issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote terminal sessions: create/stop interactive shells with input, real-time output streaming, and window resizing; per-device session limits and automatic idle cleanup.
  * Improved delivery: terminal output and state changes are reliably forwarded back to the client, and idle-session cleanup initializes on first use for more predictable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->