### PR TITLE
refactor: cleanup — wifi→SDK, TTY toggle, validate-before-swap, SDK adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,47 +560,35 @@ journalctl -u power-manage-agent -f
 ├── luks/                # LUKS encryption state (per-action SQLite databases)
 ├── state.json           # Agent state (server URL, device ID, gateway URL)
 ├── update/              # Auto-update working directory
-│   ├── agent.new        # Downloaded new binary (during update)
-│   ├── agent.backup     # Backup of current binary (during update)
-│   ├── state.json       # Update phase tracking (complete/rolled_back)
-│   └── cooldown.json    # Version cooldown after failed update (1 hour)
+│   └── agent-update-*.tmp  # Downloaded new binary (during update, deleted after self-test)
 └── results/             # Pending execution results
 ```
 
 ## Auto-Update
 
-The agent supports server-controlled automatic updates with two complementary paths:
-
-### Path A: Server-Controlled (Welcome-triggered)
-
-During normal operation, the gateway sends a Welcome message containing the latest agent version, download URL, and SHA256 checksum. If the agent detects a newer version, it downloads the binary, verifies the checksum, validates it by running `agent.new version`, and launches a transient systemd service (`pm-agent-update.service`) to perform the self-install.
-
-This path respects the admin's "Auto-update agents" toggle in server settings.
-
-### Path B: Startup Self-Heal
-
-On every startup (before the main loop), the agent checks for updates. It first queries the **control server** via `GetAutoUpdateInfo` (5s timeout, uses mTLS credentials), and if the server is unreachable, falls back to **GitHub Releases** directly. This ensures a buggy agent can be recovered on reboot even when server infrastructure is down.
-
-The startup check never blocks boot — any failure is logged as a warning and the agent continues normally.
+The agent self-updates via the `ACTION_TYPE_AGENT_UPDATE` action. Admins schedule this action on their managed devices; the action payload contains architecture-specific binary URLs and SHA256SUMS URLs.
 
 ### Update Process
 
-1. Download new binary to `/var/lib/power-manage/update/agent.new`
-2. Verify SHA256 checksum
-3. Validate by running `agent.new version`
-4. Write transient systemd service (`pm-agent-update.service`)
-5. New binary runs the `update` subcommand in its own cgroup:
-   - Stop the agent service
-   - Backup current binary
-   - Install new binary
-   - Start the agent service
-   - Health check (poll `systemctl is-active` every 2s for 30s)
-   - If healthy: write `state.json` with `complete`, clean up
-   - If unhealthy: restore backup, restart, write 1-hour cooldown, clean up
+1. Download SHA256SUMS file, extract checksum for this binary's filename
+2. Download binary to `/var/lib/power-manage/update/agent-update-*.tmp`, verify SHA256
+3. Run `./agent-new version` to extract the new version string, compare with running — skip if same
+4. Run `./agent-new self-test` as a subprocess (60s timeout). The self-test:
+   - Loads stored credentials
+   - Establishes an mTLS connection to the gateway
+   - Sends `Hello`, waits for `Welcome` (proves bidirectional stream)
+   - Calls `SyncActions` (proves unary RPC works)
+   - Exits 0 on success, 1 on any failure
+5. If the self-test exits 0: atomically swap the live binary (`cp → chmod → mv`) and trigger graceful shutdown. Systemd restarts with the new binary.
+6. If the self-test fails: report the action as `EXECUTION_STATUS_FAILED` and leave the live binary untouched.
 
-### Cooldown & Rollback
+### Validate-before-swap
 
-If an update fails health checks, the agent rolls back to the previous binary and writes a cooldown entry. The same version will be skipped for 1 hour to prevent update loops. On next startup, the agent reads `state.json` to log the outcome of the previous update cycle.
+The old binary is **never replaced** until the new binary proves it can connect, sync, and handle the protocol. There is no backup/rollback mechanism — there's nothing to roll back because the swap only happens after validation.
+
+### Retry behavior
+
+Failed updates have **no cooldown**. If an admin schedules `AGENT_UPDATE` every 30 minutes and the target version is broken (self-test fails), the agent re-downloads and re-validates every cycle until a fixed release is published. Retry frequency is governed entirely by the admin's action schedule — the agent does not impose its own throttling. The old binary remains on disk, untouched, until a version passes its self-test.
 
 ## Systemd Service
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ URI Parameters:
 | `setup` | Install sudoers configuration |
 | `query` | Query system information via osquery |
 | `luks` | LUKS passphrase management |
-| `update` | Self-install phase for auto-updates (invoked by transient systemd service, not manually) |
+| `tty` | Manage the device-local remote terminal toggle (`enable` / `disable` / `status`) |
+| `self-test` | Connectivity probe used by the self-update flow to validate a new binary before installing |
 
 ## Configuration
 
@@ -539,6 +540,37 @@ The agent prevents actions from modifying its own infrastructure:
 ### Enrollment Rate Limiting
 
 The enrollment socket limits enrollment attempts to 5 per minute using a sliding window. This prevents brute-force token guessing via the local socket.
+
+### Remote Terminal (TTY) — Device-Authoritative Toggle
+
+Remote terminal sessions are **disabled by default** on every device. Before a server can open a PTY on the device, a local admin must explicitly enable the toggle. The server cannot bypass this — any remote action that tries to flip the flag still runs on the device and goes through the same CLI surface that requires local privileges.
+
+**Commands:**
+
+```bash
+sudo power-manage-agent tty enable      # allow remote terminals on this device
+sudo power-manage-agent tty disable     # revoke access; existing sessions must be closed separately
+power-manage-agent tty status           # prints "enabled" or "disabled"; exit 0 / 1
+```
+
+**How it works:**
+
+- State lives in the agent's SQLite database (`tty.enabled` key in the `settings` table)
+- Default is **disabled** — fresh installs and upgrades must explicitly enable
+- The `power-manage` user owns the data directory, so the CLI must run as that user (via `sudo` or equivalent privilege escalation)
+- The terminal handler fails-closed: if the flag is missing, the store is unreachable, or any read error occurs, sessions are refused
+- The rejection message sent to the server is intentionally opaque (`terminal sessions are disabled on this device`) — it never distinguishes "disabled" from other failure modes
+- No agent restart is required; the check runs at every `TerminalStart` request
+
+**Fleet detection:**
+
+The toggle is queryable from the server via a compliance shell action:
+
+```bash
+power-manage-agent tty status
+```
+
+Exit code 0 = enabled, 1 = disabled. Combined with `is_compliance=true` + `compliance_expected_output=enabled` (or `disabled`), admins can report on fleet-wide TTY state without a new action type.
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -604,8 +604,8 @@ The agent self-updates via the `ACTION_TYPE_AGENT_UPDATE` action. Admins schedul
 
 1. Download SHA256SUMS file, extract checksum for this binary's filename
 2. Download binary to `/var/lib/power-manage/update/agent-update-*.tmp`, verify SHA256
-3. Run `./agent-new version` to extract the new version string, compare with running — skip if same
-4. Run `./agent-new self-test` as a subprocess (60s timeout). The self-test:
+3. Run `<tmpPath> version` on the staged binary to extract the new version string, compare with running — skip if same
+4. Run `<tmpPath> self-test` as a subprocess (60s timeout). The self-test:
    - Loads stored credentials
    - Establishes an mTLS connection to the gateway
    - Sends `Hello`, waits for `Welcome` (proves bidirectional stream)

--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -1350,7 +1350,16 @@ func runLuksSetPassphrase(token, dataDir string) {
 //  4. Calls SyncActions (proves unary RPC works)
 //
 // Does NOT start the scheduler, open the enrollment socket, execute actions,
-// or modify any state. Read-only connectivity check.
+// or modify any local state. Read-only connectivity check.
+//
+// Session-conflict caveat: the self-test connects with the same device identity
+// as the live agent, and the gateway's connection manager closes any existing
+// stream on re-register (see server internal/connection/manager.go Register).
+// Consequence: the live agent briefly disconnects during the self-test and
+// reconnects when the subprocess exits — typically 3-5 seconds of offline
+// time. This is an accepted tradeoff; removing it would require either an
+// ephemeral self-test identity (signed by the CA on demand) or a dedicated
+// server endpoint that bypasses the registry.
 func runSelfTest(args []string) int {
 	fs := flag.NewFlagSet("self-test", flag.ExitOnError)
 	dataDir := fs.String("data-dir", credentials.DefaultDataDir, "Agent data directory")

--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -119,6 +119,8 @@ func main() {
 		case "enroll":
 			runEnroll(os.Args[2:])
 			return
+		case "self-test":
+			os.Exit(runSelfTest(os.Args[2:]))
 		}
 	}
 
@@ -129,9 +131,8 @@ func main() {
 	slog.SetDefault(logger)
 	logger.Info("logger initialized", "level", cfg.LogLevel, "format", cfg.LogFormat)
 
-	// Check for completed/rolled-back update FIRST — before any other startup
-	// logic. If the new binary is broken, restore from backup immediately.
-	executor.CheckStartupUpdateState(cfg.DataDir, "/usr/local/bin/power-manage-agent", version, logger)
+	// Clean up stale update state from a previous cycle (if any).
+	executor.CheckStartupUpdateState(cfg.DataDir, logger)
 
 	// Get hostname
 	hostname, err := os.Hostname()
@@ -1334,6 +1335,99 @@ func runLuksSetPassphrase(token, dataDir string) {
 	agentStore.AddLuksPassphraseHash(result.ActionID, sysluks.HashPassphrase(passphrase))
 
 	fmt.Println("LUKS passphrase set successfully.")
+}
+
+// runSelfTest runs a minimal connectivity probe to validate that this binary
+// can function as the agent. Called by the old binary during self-update to
+// verify the new binary before swapping it in. Exits 0 on success, 1 on failure.
+//
+// The probe:
+//  1. Loads credentials from the data directory
+//  2. Establishes an mTLS connection to the gateway
+//  3. Sends Hello, waits for Welcome (proves bidirectional stream)
+//  4. Calls SyncActions (proves unary RPC works)
+//
+// Does NOT start the scheduler, open the enrollment socket, execute actions,
+// or modify any state. Read-only connectivity check.
+func runSelfTest(args []string) int {
+	fs := flag.NewFlagSet("self-test", flag.ExitOnError)
+	dataDir := fs.String("data-dir", credentials.DefaultDataDir, "Agent data directory")
+	timeout := fs.Duration("timeout", 60*time.Second, "Self-test timeout")
+	fs.Parse(args)
+
+	logger := logging.SetupLogger("info", "text", os.Stderr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	// Step 1: Load credentials
+	credStore := credentials.NewStore(*dataDir)
+	if !credStore.Exists() {
+		logger.Error("self-test: no credentials found", "data_dir", *dataDir)
+		return 1
+	}
+	creds, err := credStore.Load()
+	if err != nil {
+		logger.Error("self-test: failed to load credentials", "error", err)
+		return 1
+	}
+	logger.Info("self-test: credentials loaded", "device_id", creds.DeviceID)
+
+	// Step 2: Create mTLS client
+	var client *sdk.Client
+	if strings.HasPrefix(creds.GatewayAddr, "http://") {
+		client = sdk.NewClient(creds.GatewayAddr,
+			sdk.WithH2C(),
+			sdk.WithAuth(creds.DeviceID, ""),
+		)
+	} else {
+		mtlsOpt, err := sdk.WithMTLSFromPEM(creds.Certificate, creds.PrivateKey, creds.CACert)
+		if err != nil {
+			logger.Error("self-test: failed to configure mTLS", "error", err)
+			return 1
+		}
+		client = sdk.NewClient(creds.GatewayAddr,
+			mtlsOpt,
+			sdk.WithAuth(creds.DeviceID, ""),
+		)
+	}
+
+	// Step 3: Connect and send Hello, wait for Welcome
+	if err := client.Connect(ctx); err != nil {
+		logger.Error("self-test: failed to connect to gateway", "error", err)
+		return 1
+	}
+	defer client.Close()
+
+	hostname, _ := os.Hostname()
+	if err := client.SendHello(ctx, hostname, version); err != nil {
+		logger.Error("self-test: failed to send hello", "error", err)
+		return 1
+	}
+
+	// Wait for Welcome message (proves bidirectional stream works)
+	msg, err := client.Receive(ctx)
+	if err != nil {
+		logger.Error("self-test: failed to receive welcome", "error", err)
+		return 1
+	}
+	if msg.GetWelcome() == nil {
+		logger.Error("self-test: expected welcome message, got something else")
+		return 1
+	}
+	logger.Info("self-test: stream connected, welcome received",
+		"server_version", msg.GetWelcome().ServerVersion)
+
+	// Step 4: Call SyncActions (proves unary RPC path works)
+	_, err = client.SyncActions(ctx)
+	if err != nil {
+		logger.Error("self-test: sync actions failed", "error", err)
+		return 1
+	}
+	logger.Info("self-test: sync actions succeeded")
+
+	logger.Info("self-test: all checks passed")
+	return 0
 }
 
 // runEnroll handles the "enroll" subcommand.

--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -1469,6 +1469,25 @@ func runTTY(args []string) int {
 		return 1
 	}
 
+	// Device-authoritative guard for mutating subcommands. `enable`/`disable`
+	// must be invoked by a human with root privileges attached to a real
+	// terminal. Without this gate the server could flip the flag remotely
+	// by dispatching `ACTION_TYPE_SHELL { script: "power-manage-agent tty enable" }` —
+	// that shell runs as the power-manage user which owns the SQLite DB,
+	// so it would otherwise succeed. Status stays readable without a
+	// terminal so operators can `if power-manage-agent tty status` in
+	// shell scripts.
+	if sub == "enable" || sub == "disable" {
+		if os.Geteuid() != 0 {
+			fmt.Fprintf(os.Stderr, "Error: tty %s must be run as root (try: sudo power-manage-agent tty %s)\n", sub, sub)
+			return 1
+		}
+		if !term.IsTerminal(int(os.Stdin.Fd())) {
+			fmt.Fprintf(os.Stderr, "Error: tty %s must be run interactively from a local terminal\n", sub)
+			return 1
+		}
+	}
+
 	st, err := store.New(*dataDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: open agent store: %v\n", err)

--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -121,6 +121,8 @@ func main() {
 			return
 		case "self-test":
 			os.Exit(runSelfTest(os.Args[2:]))
+		case "tty":
+			os.Exit(runTTY(os.Args[2:]))
 		}
 	}
 
@@ -258,7 +260,7 @@ func main() {
 	syncTrigger := make(chan struct{}, 1)
 
 	// Create handler with scheduler integration
-	h := handler.NewHandler(logger, exec, sched, syncTrigger)
+	h := handler.NewHandler(logger, exec, sched, actionStore, syncTrigger)
 
 	// Enable action-based agent self-update.
 	exec.SetUpdateConfig(&executor.AgentUpdateConfig{
@@ -1428,6 +1430,85 @@ func runSelfTest(args []string) int {
 
 	logger.Info("self-test: all checks passed")
 	return 0
+}
+
+// runTTY manages the device-local TTY enable/disable toggle.
+// Usage:
+//
+//	power-manage-agent tty enable
+//	power-manage-agent tty disable
+//	power-manage-agent tty status
+//
+// The toggle is stored in the agent's SQLite database. The CLI must be
+// run as the power-manage user (the owner of the agent's data dir) or
+// as root via sudo — a regular user cannot escalate into the toggle
+// without first escalating to one of those identities.
+func runTTY(args []string) int {
+	fs := flag.NewFlagSet("tty", flag.ExitOnError)
+	dataDir := fs.String("data-dir", credentials.DefaultDataDir, "Agent data directory")
+
+	if len(args) == 0 {
+		printTTYUsage()
+		return 1
+	}
+
+	sub := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		return 1
+	}
+
+	switch sub {
+	case "-h", "--help", "help":
+		printTTYUsage()
+		return 0
+	case "enable", "disable", "status":
+		// handled below
+	default:
+		fmt.Fprintf(os.Stderr, "unknown tty subcommand: %s\n", sub)
+		printTTYUsage()
+		return 1
+	}
+
+	st, err := store.New(*dataDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: open agent store: %v\n", err)
+		return 1
+	}
+	defer st.Close()
+
+	switch sub {
+	case "enable":
+		if err := st.SetTTYEnabled(true); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+		fmt.Println("TTY enabled.")
+		return 0
+	case "disable":
+		if err := st.SetTTYEnabled(false); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+		fmt.Println("TTY disabled.")
+		return 0
+	case "status":
+		enabled, err := st.IsTTYEnabled()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+		if enabled {
+			fmt.Println("enabled")
+			return 0
+		}
+		fmt.Println("disabled")
+		return 1
+	}
+	return 1
+}
+
+func printTTYUsage() {
+	fmt.Fprintln(os.Stderr, "usage: power-manage-agent tty {enable|disable|status} [--data-dir=PATH]")
 }
 
 // runEnroll handles the "enroll" subcommand.

--- a/internal/executor/agent_update.go
+++ b/internal/executor/agent_update.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -19,6 +18,7 @@ import (
 	"time"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
 // AgentUpdateConfig holds configuration for the agent self-update executor.
@@ -169,21 +169,25 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 	defer selfTestCancel()
 
 	e.logger.Info("running self-test on new binary", "path", tmpPath)
-	selfTestCmd := exec.CommandContext(selfTestCtx, tmpPath, "self-test",
+	selfTestResult, selfTestErr := sysexec.Run(selfTestCtx, tmpPath, "self-test",
 		"--data-dir="+cfg.DataDir,
 		"--timeout=55s",
 	)
-	selfTestOut, selfTestErr := selfTestCmd.CombinedOutput()
 	if selfTestErr != nil {
+		var combined string
+		if selfTestResult != nil {
+			combined = strings.TrimSpace(selfTestResult.Stdout + "\n" + selfTestResult.Stderr)
+		}
 		e.logger.Error("self-test failed, keeping current binary",
 			"error", selfTestErr,
-			"output", string(selfTestOut))
-		return &pb.CommandOutput{
+			"output", combined)
+		out := &pb.CommandOutput{
 			Stdout: fmt.Sprintf("Self-test failed for version %s: %v", newVersion, selfTestErr),
-			Stderr: string(selfTestOut),
-		}, false, fmt.Errorf("self-test failed: %w", selfTestErr)
+			Stderr: combined,
+		}
+		return out, false, fmt.Errorf("self-test failed: %w", selfTestErr)
 	}
-	e.logger.Info("self-test passed", "output", string(selfTestOut))
+	e.logger.Info("self-test passed", "output", selfTestResult.Stdout)
 
 	// Step 9: Self-test passed — swap the binary. The old binary is
 	// still running in memory, so this is safe. Use atomic
@@ -345,11 +349,13 @@ func downloadToFile(ctx context.Context, client *http.Client, downloadURL string
 
 // getBinaryVersion runs the binary with "version" subcommand and returns the trimmed output.
 func getBinaryVersion(binaryPath string) (string, error) {
-	out, err := exec.Command(binaryPath, "version").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	result, err := sysexec.Run(ctx, binaryPath, "version")
 	if err != nil {
 		return "", fmt.Errorf("run %s version: %w", binaryPath, err)
 	}
-	v := strings.TrimSpace(string(out))
+	v := strings.TrimSpace(result.Stdout)
 	if v == "" {
 		return "", fmt.Errorf("binary returned empty version")
 	}

--- a/internal/executor/agent_update.go
+++ b/internal/executor/agent_update.go
@@ -24,7 +24,7 @@ import (
 // AgentUpdateConfig holds configuration for the agent self-update executor.
 type AgentUpdateConfig struct {
 	Version    string       // Current running agent version
-	DataDir    string       // Data directory for state/cooldown files
+	DataDir    string       // Data directory for update staging
 	BinaryPath string       // Path to the installed agent binary (e.g., /usr/local/bin/power-manage-agent)
 	Shutdown   func()       // Called after a successful update to trigger graceful agent shutdown
 }
@@ -65,15 +65,21 @@ func markAgentUpdateExecuted() bool {
 //  4. Validate URLs are HTTPS
 //  5. Download checksum file, extract checksum for binary filename
 //  6. Download binary to temp file, verify SHA256
-//  7. Run ./agent.new version → extract version string
+//  7. Run ./agent-new version → extract version string
 //  8. Compare with running version → skip if same
-//  9. Backup current binary for rollback
+//  9. Run ./agent-new self-test → subprocess validates connectivity
+//     (credentials load, mTLS, stream, SyncActions). If it fails,
+//     the old binary stays untouched.
 //  10. Atomically swap binary (cp → chmod → mv)
-//  11. Write state.json with {"phase":"staged","version":"..."}
-//  12. Signal graceful shutdown (systemd restarts with new binary)
+//  11. Signal graceful shutdown (systemd restarts with new binary)
 //
-// On next startup, CheckStartupUpdateState verifies the update succeeded
-// (running version matches staged version). If not, it restores from backup.
+// Retry behavior: if the self-test fails, the update is reported as
+// EXECUTION_STATUS_FAILED and the old binary continues running. There is no
+// cooldown between retries — if the admin schedules AGENT_UPDATE to run
+// every 30 minutes and the target version is broken, the agent will
+// re-download and re-test it every 30 minutes until a fixed release is
+// published. This is an intentional trade-off: retry frequency is governed
+// entirely by the admin's schedule, the old binary is never replaced.
 func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdateParams) (*pb.CommandOutput, bool, error) {
 	cfg := e.updateCfg
 	if cfg == nil {
@@ -153,59 +159,54 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 		return &pb.CommandOutput{Stdout: fmt.Sprintf("Already at version %s", cfg.Version)}, false, nil
 	}
 
-	// Check cooldown for this specific version
-	if isCoolingDown(cfg.DataDir, newVersion) {
-		e.logger.Warn("version is in cooldown period, skipping", "version", newVersion)
-		return &pb.CommandOutput{Stdout: fmt.Sprintf("Version %s is in cooldown (recent failure), skipping", newVersion)}, false, nil
-	}
-
 	e.logger.Info("updating agent", "from", cfg.Version, "to", newVersion)
 
-	// Step 8: Backup current binary for rollback.
-	backupPath := cfg.BinaryPath + ".bak"
-	if _, err := runSudoCmd(ctx, "cp", cfg.BinaryPath, backupPath); err != nil {
-		writeCooldown(cfg.DataDir, newVersion, 1*time.Hour)
-		return nil, false, fmt.Errorf("backup current binary: %w", err)
-	}
+	// Step 8: Run the new binary in self-test mode. This validates
+	// connectivity (mTLS, stream, SyncActions) WITHOUT replacing the
+	// live binary. If the self-test fails, the old binary continues
+	// running unchanged. See the function doc comment for retry semantics.
+	selfTestCtx, selfTestCancel := context.WithTimeout(ctx, 60*time.Second)
+	defer selfTestCancel()
 
-	// Step 9: Atomic staged install via sudo (target dir is root-owned).
-	// Copy to a sibling temp, chmod, then mv — the live binary is only
-	// replaced after the new one is fully written and executable.
+	e.logger.Info("running self-test on new binary", "path", tmpPath)
+	selfTestCmd := exec.CommandContext(selfTestCtx, tmpPath, "self-test",
+		"--data-dir="+cfg.DataDir,
+		"--timeout=55s",
+	)
+	selfTestOut, selfTestErr := selfTestCmd.CombinedOutput()
+	if selfTestErr != nil {
+		e.logger.Error("self-test failed, keeping current binary",
+			"error", selfTestErr,
+			"output", string(selfTestOut))
+		return &pb.CommandOutput{
+			Stdout: fmt.Sprintf("Self-test failed for version %s: %v", newVersion, selfTestErr),
+			Stderr: string(selfTestOut),
+		}, false, fmt.Errorf("self-test failed: %w", selfTestErr)
+	}
+	e.logger.Info("self-test passed", "output", string(selfTestOut))
+
+	// Step 9: Self-test passed — swap the binary. The old binary is
+	// still running in memory, so this is safe. Use atomic
+	// cp → chmod → mv so the live path is only updated after the
+	// new file is fully written and executable.
 	stagePath := cfg.BinaryPath + ".new"
 	if _, err := runSudoCmd(ctx, "cp", tmpPath, stagePath); err != nil {
-		writeCooldown(cfg.DataDir, newVersion, 1*time.Hour)
 		return nil, false, fmt.Errorf("stage binary: %w", err)
 	}
 	if _, err := runSudoCmd(ctx, "chmod", "+x", stagePath); err != nil {
 		runSudoCmd(ctx, "rm", "-f", stagePath)
-		writeCooldown(cfg.DataDir, newVersion, 1*time.Hour)
 		return nil, false, fmt.Errorf("chmod staged binary: %w", err)
 	}
 	if _, err := runSudoCmd(ctx, "mv", stagePath, cfg.BinaryPath); err != nil {
 		runSudoCmd(ctx, "rm", "-f", stagePath)
-		writeCooldown(cfg.DataDir, newVersion, 1*time.Hour)
 		return nil, false, fmt.Errorf("swap binary: %w", err)
 	}
 
-	// Step 10: Write state.json with version for startup verification.
-	// This must succeed before shutdown — otherwise the new binary starts
-	// without a state marker and may trigger a false rollback.
-	if err := writeUpdateState(cfg.DataDir, "staged", newVersion); err != nil {
-		e.logger.Error("failed to write update state, rolling back binary", "error", err)
-		if _, mvErr := runSudoCmd(ctx, "mv", backupPath, cfg.BinaryPath); mvErr != nil {
-			e.logger.Error("rollback failed, system may be in inconsistent state", "error", mvErr)
-		}
-		writeCooldown(cfg.DataDir, newVersion, 1*time.Hour)
-		return nil, false, fmt.Errorf("write update state: %w", err)
-	}
-
-	// Step 11: Signal graceful shutdown — systemd restarts with new binary
+	// Step 10: Signal graceful shutdown — systemd restarts with new binary
 	stdout := fmt.Sprintf("Updated from %s to %s. Restarting.", cfg.Version, newVersion)
 	e.logger.Info(stdout)
 
 	// Delay shutdown to allow the result to be recorded and sent to the server.
-	// The scheduler checks ctx.Err() after Execute returns — if we cancel
-	// immediately, the result is dropped.
 	if cfg.Shutdown != nil {
 		go func() {
 			time.Sleep(3 * time.Second)
@@ -410,119 +411,26 @@ func clearUpdateState(dataDir string) {
 	os.Remove(filepath.Join(dataDir, "update", "state.json"))
 }
 
-// writeCooldown writes a cooldown entry for a failed version.
-func writeCooldown(dataDir, version string, duration time.Duration) error {
-	dir := filepath.Join(dataDir, "update")
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return err
-	}
 
-	data := fmt.Sprintf(`{"version":%q,"until":%q}`, version, time.Now().Add(duration).Format(time.RFC3339))
-
-	tmp, err := os.CreateTemp(dir, ".cooldown-*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-
-	if _, err := tmp.WriteString(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	tmp.Close()
-
-	return os.Rename(tmpPath, filepath.Join(dir, "cooldown.json"))
-}
-
-// isCoolingDown checks if a version is in cooldown (recent failure).
-func isCoolingDown(dataDir, version string) bool {
-	data, err := os.ReadFile(filepath.Join(dataDir, "update", "cooldown.json"))
-	if err != nil {
-		return false
-	}
-
-	type cooldown struct {
-		Version string `json:"version"`
-		Until   string `json:"until"`
-	}
-	var c cooldown
-	if err := json.Unmarshal(data, &c); err != nil {
-		return true // corrupted → be conservative
-	}
-
-	if c.Version != version {
-		return false
-	}
-
-	until, err := time.Parse(time.RFC3339, c.Until)
-	if err != nil {
-		return true
-	}
-
-	return time.Now().Before(until)
-}
-
-// CheckStartupUpdateState checks for a completed or rolled-back update from a previous cycle.
-// If state is "staged" but the running version doesn't match, the update failed —
-// restore from backup and write cooldown to prevent retry loops.
+// CheckStartupUpdateState cleans up stale update state from a previous cycle.
+// With the self-test approach, updates are validated before swapping the binary,
+// so there is no rollback logic needed at startup. This function only cleans up
+// state files left behind by interrupted updates.
 //
 // Parameters:
 //   - dataDir: agent data directory containing update/state.json
-//   - binaryPath: path to the installed agent binary (for rollback)
-//   - runningVersion: the current binary's version string
 //   - logger: structured logger
-func CheckStartupUpdateState(dataDir, binaryPath, runningVersion string, logger interface {
+func CheckStartupUpdateState(dataDir string, logger interface {
 	Info(string, ...any)
 	Warn(string, ...any)
-	Error(string, ...any)
 }) {
-	ctx := context.Background()
-	backupPath := binaryPath + ".bak"
-
-	phase, stagedVersion, err := readUpdateState(dataDir)
+	phase, _, err := readUpdateState(dataDir)
 	if err != nil {
 		logger.Warn("failed to read update state", "error", err)
 		return
 	}
-	if phase == "" {
-		// No pending update — leave .bak alone (may be needed if state was
-		// lost due to crash before state file was written).
-		return
-	}
-
-	switch phase {
-	case "staged":
-		if runningVersion == stagedVersion {
-			// Running the new version — update succeeded.
-			logger.Info("agent update completed successfully", "version", stagedVersion)
-			// Clean up backup and state only after confirmed success.
-			clearUpdateState(dataDir)
-			runSudoCmd(ctx, "rm", "-f", backupPath)
-		} else {
-			// Running the old version — the new binary failed to start.
-			logger.Error("agent update failed — running version does not match staged version",
-				"running", runningVersion, "staged", stagedVersion)
-
-			if _, statErr := os.Stat(backupPath); statErr == nil {
-				logger.Warn("restoring previous binary from backup", "backup", backupPath)
-				if _, mvErr := runSudoCmd(ctx, "mv", backupPath, binaryPath); mvErr != nil {
-					logger.Error("failed to restore backup", "error", mvErr)
-				} else {
-					logger.Info("backup restored successfully")
-				}
-			} else {
-				logger.Error("no backup available for rollback", "backup", backupPath)
-			}
-
-			// Write cooldown so the agent doesn't immediately retry the bad version.
-			if err := writeCooldown(dataDir, stagedVersion, 1*time.Hour); err != nil {
-				logger.Warn("failed to write cooldown after failed update", "error", err)
-			}
-			clearUpdateState(dataDir)
-		}
-	default:
-		logger.Warn("stale update state found, cleaning up", "phase", phase)
+	if phase != "" {
+		logger.Info("cleaning up stale update state", "phase", phase)
 		clearUpdateState(dataDir)
 	}
 }

--- a/internal/executor/agent_update_test.go
+++ b/internal/executor/agent_update_test.go
@@ -8,9 +8,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
-	"time"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 )
@@ -156,45 +157,6 @@ func TestClearUpdateState(t *testing.T) {
 	}
 }
 
-func TestCooldown(t *testing.T) {
-	dir := t.TempDir()
-
-	// No cooldown file → not cooling down
-	if isCoolingDown(dir, "v1.0") {
-		t.Error("expected no cooldown initially")
-	}
-
-	// Write cooldown for v1.0
-	err := writeCooldown(dir, "v1.0", 1*time.Hour)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Same version → cooling down
-	if !isCoolingDown(dir, "v1.0") {
-		t.Error("expected v1.0 to be cooling down")
-	}
-
-	// Different version → not cooling down
-	if isCoolingDown(dir, "v2.0") {
-		t.Error("expected v2.0 to not be cooling down")
-	}
-}
-
-func TestCooldown_Expired(t *testing.T) {
-	dir := t.TempDir()
-
-	// Write cooldown that expired 1 second ago
-	err := writeCooldown(dir, "v1.0", -1*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if isCoolingDown(dir, "v1.0") {
-		t.Error("expected expired cooldown to not be active")
-	}
-}
-
 func TestMarkAgentUpdateExecuted(t *testing.T) {
 	// Reset first
 	ResetAgentUpdateCycle()
@@ -216,19 +178,12 @@ func TestMarkAgentUpdateExecuted(t *testing.T) {
 	}
 }
 
-func TestCheckStartupUpdateState_Success(t *testing.T) {
+func TestCheckStartupUpdateState_CleansStaleState(t *testing.T) {
 	dir := t.TempDir()
-	binDir := t.TempDir()
-	binaryPath := filepath.Join(binDir, "agent")
-	backupPath := binaryPath + ".bak"
-
-	os.WriteFile(binaryPath, []byte("new-binary"), 0755)
-	os.WriteFile(backupPath, []byte("old-binary"), 0755)
-
 	writeUpdateState(dir, "staged", "2026.04.01")
 
 	logger := &testLogger{}
-	CheckStartupUpdateState(dir, binaryPath, "2026.04.01", logger)
+	CheckStartupUpdateState(dir, logger)
 
 	// State should be cleared
 	phase, _, _ := readUpdateState(dir)
@@ -237,60 +192,19 @@ func TestCheckStartupUpdateState_Success(t *testing.T) {
 	}
 
 	if len(logger.infos) == 0 {
-		t.Error("expected at least one info log for successful update")
-	}
-}
-
-func TestCheckStartupUpdateState_FailedUpdate(t *testing.T) {
-	dir := t.TempDir()
-	binDir := t.TempDir()
-	binaryPath := filepath.Join(binDir, "agent")
-	backupPath := binaryPath + ".bak"
-
-	os.WriteFile(binaryPath, []byte("broken-binary"), 0755)
-	os.WriteFile(backupPath, []byte("good-binary"), 0755)
-
-	writeUpdateState(dir, "staged", "2026.04.02")
-
-	logger := &testLogger{}
-	CheckStartupUpdateState(dir, binaryPath, "2026.04.01", logger)
-
-	// State should be cleared
-	phase, _, _ := readUpdateState(dir)
-	if phase != "" {
-		t.Errorf("expected state to be cleared, got phase=%q", phase)
-	}
-
-	if len(logger.errors) == 0 {
-		t.Error("expected error log for failed update")
-	}
-
-	// Should have written cooldown for the failed version
-	if !isCoolingDown(dir, "2026.04.02") {
-		t.Error("expected cooldown for failed version")
+		t.Error("expected info log for stale state cleanup")
 	}
 }
 
 func TestCheckStartupUpdateState_NoState(t *testing.T) {
 	dir := t.TempDir()
-	binDir := t.TempDir()
-	binaryPath := filepath.Join(binDir, "agent")
-	backupPath := binaryPath + ".bak"
-
-	// Create a leftover backup — should NOT be deleted when there's no state
-	os.WriteFile(backupPath, []byte("backup"), 0755)
 
 	logger := &testLogger{}
-	CheckStartupUpdateState(dir, binaryPath, "2026.04.01", logger)
+	CheckStartupUpdateState(dir, logger)
 
 	// No logs expected
-	if len(logger.infos) > 0 || len(logger.warns) > 0 || len(logger.errors) > 0 {
+	if len(logger.infos) > 0 || len(logger.warns) > 0 {
 		t.Error("expected no logs for clean startup without state file")
-	}
-
-	// Backup must still exist — not prematurely deleted
-	if _, err := os.Stat(backupPath); os.IsNotExist(err) {
-		t.Error("backup should not be deleted when there's no state file")
 	}
 }
 
@@ -373,6 +287,38 @@ func TestExtractFilename(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("extractFilename(%q) = %q, want %q", tt.url, got, tt.want)
 		}
+	}
+}
+
+func TestSelfTestScript_ExitCode(t *testing.T) {
+	// Test that a shell script returning exit 0 vs exit 1 is correctly detected.
+	// This validates the exec.CommandContext pattern used in executeAgentUpdate.
+	dir := t.TempDir()
+
+	// Create a "binary" that exits 0
+	successScript := filepath.Join(dir, "success")
+	os.WriteFile(successScript, []byte("#!/bin/sh\nexit 0\n"), 0755)
+
+	// Create a "binary" that exits 1
+	failScript := filepath.Join(dir, "fail")
+	os.WriteFile(failScript, []byte("#!/bin/sh\necho 'connection failed' >&2\nexit 1\n"), 0755)
+
+	ctx := context.Background()
+
+	// Success case
+	cmd := exec.CommandContext(ctx, successScript)
+	if err := cmd.Run(); err != nil {
+		t.Errorf("expected exit 0 script to succeed, got: %v", err)
+	}
+
+	// Failure case
+	cmd = exec.CommandContext(ctx, failScript)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Error("expected exit 1 script to fail")
+	}
+	if !strings.Contains(string(out), "connection failed") {
+		t.Errorf("expected error output, got: %s", string(out))
 	}
 }
 

--- a/internal/executor/cmd.go
+++ b/internal/executor/cmd.go
@@ -85,3 +85,17 @@ func formatCmdError(err error, output *pb.CommandOutput) string {
 	}
 	return err.Error()
 }
+
+// stderrSuffix returns " (<stderr>)" if the result has stderr content, or "".
+// Used to enrich human-readable error messages with the underlying command's
+// stderr — important for surfacing things like "user 'foo' already exists".
+func stderrSuffix(r *sysexec.Result) string {
+	if r == nil {
+		return ""
+	}
+	stderr := strings.TrimSpace(r.Stderr)
+	if stderr == "" {
+		return ""
+	}
+	return " (" + stderr + ")"
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3327,8 +3327,12 @@ func (e *Executor) setupSSHKeys(ctx context.Context, params *pb.UserParams, outp
 		return false, fmt.Errorf("failed to create .ssh directory: %w", err)
 	}
 
-	// Set ownership and permissions on .ssh directory
-	if _, err := runSudoCmd(ctx, "chown", params.Username+":"+params.Username, sshDir); err != nil {
+	// Set ownership and permissions on .ssh directory. Use the configured
+	// primary group (same preference order as home-directory repair) so
+	// users created with Gid / PrimaryGroup don't end up with the wrong
+	// group on .ssh and fail authorized_keys writes.
+	ownership := params.Username + ":" + homeGroupFor(params)
+	if _, err := runSudoCmd(ctx, "chown", ownership, sshDir); err != nil {
 		return false, fmt.Errorf("failed to set .ssh ownership: %w", err)
 	}
 	if _, err := runSudoCmd(ctx, "chmod", "700", sshDir); err != nil {
@@ -3341,7 +3345,7 @@ func (e *Executor) setupSSHKeys(ctx context.Context, params *pb.UserParams, outp
 	}
 
 	// Set ownership and permissions on authorized_keys
-	if _, err := runSudoCmd(ctx, "chown", params.Username+":"+params.Username, authKeysFile); err != nil {
+	if _, err := runSudoCmd(ctx, "chown", ownership, authKeysFile); err != nil {
 		return false, fmt.Errorf("failed to set authorized_keys ownership: %w", err)
 	}
 	if _, err := runSudoCmd(ctx, "chmod", "600", authKeysFile); err != nil {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -2857,6 +2857,21 @@ func (e *Executor) executeUser(ctx context.Context, params *pb.UserParams, state
 
 // createOrUpdateUser creates a new user or updates an existing one.
 // Returns the command output, whether changes were made, metadata, and any error.
+// homeGroupFor returns the group name/id to use when repairing home
+// directory ownership for a user. Preference order mirrors the group
+// selection used at user creation time: explicit numeric GID (accepted
+// by `chown` as a number), named primary group, else fall back to the
+// username (matches the default "useradd creates matching group" case).
+func homeGroupFor(params *pb.UserParams) string {
+	if params.Gid > 0 {
+		return fmt.Sprintf("%d", params.Gid)
+	}
+	if params.PrimaryGroup != "" {
+		return params.PrimaryGroup
+	}
+	return params.Username
+}
+
 func (e *Executor) createOrUpdateUser(ctx context.Context, params *pb.UserParams) (*pb.CommandOutput, bool, map[string]string, error) {
 	var output strings.Builder
 	exists := userExists(params.Username)
@@ -2957,7 +2972,7 @@ func (e *Executor) createUser(ctx context.Context, params *pb.UserParams, output
 
 	// If home directory already existed, fix ownership
 	if homeExists && createHome {
-		if chownResult, chownErr := sysuser.ChownRecursive(ctx, homeDir, params.Username, params.Username); chownErr != nil {
+		if chownResult, chownErr := sysuser.ChownRecursive(ctx, homeDir, params.Username, homeGroupFor(params)); chownErr != nil {
 			output.WriteString(fmt.Sprintf("warning: failed to fix home directory ownership: %v\n", chownErr))
 			if chownResult != nil {
 				output.WriteString(chownResult.Stderr)
@@ -3112,7 +3127,12 @@ func (e *Executor) updateUser(ctx context.Context, params *pb.UserParams, output
 				output.WriteString(fmt.Sprintf("warning: failed to create home directory: %v\n", mkErr))
 			} else {
 				runSudoCmd(ctx, "cp", "-a", "/etc/skel/.", homeDir)
-				sysuser.ChownRecursive(ctx, homeDir, params.Username, params.Username)
+				if chownResult, chownErr := sysuser.ChownRecursive(ctx, homeDir, params.Username, homeGroupFor(params)); chownErr != nil {
+					output.WriteString(fmt.Sprintf("warning: failed to chown home directory: %v\n", chownErr))
+					if chownResult != nil {
+						output.WriteString(chownResult.Stderr)
+					}
+				}
 				runSudoCmd(ctx, "chmod", "0700", homeDir)
 				output.WriteString(fmt.Sprintf("created missing home directory: %s\n", homeDir))
 				changed = true

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -156,19 +156,9 @@ func (e *Executor) ExecuteWithStreaming(ctx context.Context, action *pb.Action, 
 	}
 
 	// Verify action signature before execution (skip for instant actions — they have no params to sign)
-	if e.verifier != nil && !isInstantAction(action.Type) {
+	if e.verifier != nil && !IsInstantAction(action.Type) {
 		actionID := getActionID(action)
-		verifyErr := e.verifier.Verify(actionID, int32(action.Type), action.ParamsCanonical, action.Signature)
-		if verifyErr != nil {
-			// Shell scripts and sudo policies: hard reject unsigned/tampered actions
-			if action.Type == pb.ActionType_ACTION_TYPE_SHELL || action.Type == pb.ActionType_ACTION_TYPE_SUDO || action.Type == pb.ActionType_ACTION_TYPE_LPS {
-				result.Status = pb.ExecutionStatus_EXECUTION_STATUS_FAILED
-				result.Error = fmt.Sprintf("refusing to execute unsigned/tampered shell script: %v", verifyErr)
-				result.CompletedAt = timestamppb.Now()
-				result.DurationMs = time.Since(start).Milliseconds()
-				return result
-			}
-			// All other types: also hard reject unsigned/tampered actions
+		if verifyErr := e.verifier.Verify(actionID, int32(action.Type), action.ParamsCanonical, action.Signature); verifyErr != nil {
 			result.Status = pb.ExecutionStatus_EXECUTION_STATUS_FAILED
 			result.Error = fmt.Sprintf("refusing to execute unsigned/tampered action: %v", verifyErr)
 			result.CompletedAt = timestamppb.Now()
@@ -2808,14 +2798,9 @@ func (e *Executor) executeZypperRepository(ctx context.Context, name string, rep
 	}
 }
 
-// isInstantAction returns true if the action type is an instant action (agent-builtin, no parameters).
-func isInstantAction(t pb.ActionType) bool {
-	return t == pb.ActionType_ACTION_TYPE_REBOOT || t == pb.ActionType_ACTION_TYPE_SYNC
-}
-
-// IsInstantAction is the exported version for use by the handler.
+// IsInstantAction returns true if the action type is an instant action (agent-builtin, no parameters).
 func IsInstantAction(t pb.ActionType) bool {
-	return isInstantAction(t)
+	return t == pb.ActionType_ACTION_TYPE_REBOOT || t == pb.ActionType_ACTION_TYPE_SYNC
 }
 
 // executeReboot schedules a system reboot in 5 minutes.

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1002,8 +1002,8 @@ func (e *Executor) executeSystemd(ctx context.Context, params *pb.SystemdParams)
 			changed = true
 
 			// Reload systemd
-			if _, err := runSudoCmd(ctx, "systemctl", "daemon-reload"); err != nil {
-				return nil, changed, fmt.Errorf("daemon-reload failed")
+			if err := syssystemd.DaemonReload(ctx); err != nil {
+				return nil, changed, fmt.Errorf("daemon-reload failed: %w", err)
 			}
 			output.WriteString("reloaded systemd daemon\n")
 		}
@@ -1016,13 +1016,13 @@ func (e *Executor) executeSystemd(ctx context.Context, params *pb.SystemdParams)
 		if e.isUnitMasked(params.UnitName) {
 			return nil, changed, fmt.Errorf("enable: unit %s is masked (run 'systemctl unmask %s' first)", params.UnitName, params.UnitName)
 		}
-		if _, err := runSudoCmd(ctx, "systemctl", "enable", params.UnitName); err != nil {
-			return nil, changed, fmt.Errorf("enable: %v", err)
+		if err := syssystemd.Enable(ctx, params.UnitName); err != nil {
+			return nil, changed, fmt.Errorf("enable: %w", err)
 		}
 		output.WriteString("enabled unit\n")
 		changed = true
 	} else if !params.Enable && isEnabled {
-		if _, err := runSudoCmd(ctx, "systemctl", "disable", params.UnitName); err != nil {
+		if err := syssystemd.Disable(ctx, params.UnitName); err != nil {
 			// Ignore errors for disable (unit might not exist)
 			output.WriteString("disable failed (unit may not exist)\n")
 		} else {
@@ -1036,8 +1036,8 @@ func (e *Executor) executeSystemd(ctx context.Context, params *pb.SystemdParams)
 	switch params.DesiredState {
 	case pb.SystemdUnitState_SYSTEMD_UNIT_STATE_STARTED:
 		if !isActive {
-			if _, err := runSudoCmd(ctx, "systemctl", "start", params.UnitName); err != nil {
-				return nil, changed, fmt.Errorf("start: %v", err)
+			if err := syssystemd.Start(ctx, params.UnitName); err != nil {
+				return nil, changed, fmt.Errorf("start: %w", err)
 			}
 			output.WriteString("started unit\n")
 			changed = true
@@ -1046,8 +1046,8 @@ func (e *Executor) executeSystemd(ctx context.Context, params *pb.SystemdParams)
 		}
 	case pb.SystemdUnitState_SYSTEMD_UNIT_STATE_STOPPED:
 		if isActive {
-			if _, err := runSudoCmd(ctx, "systemctl", "stop", params.UnitName); err != nil {
-				return nil, changed, fmt.Errorf("stop: %v", err)
+			if err := syssystemd.Stop(ctx, params.UnitName); err != nil {
+				return nil, changed, fmt.Errorf("stop: %w", err)
 			}
 			output.WriteString("stopped unit\n")
 			changed = true
@@ -1056,8 +1056,8 @@ func (e *Executor) executeSystemd(ctx context.Context, params *pb.SystemdParams)
 		}
 	case pb.SystemdUnitState_SYSTEMD_UNIT_STATE_RESTARTED:
 		// Restart always runs (not idempotent by design)
-		if _, err := runSudoCmd(ctx, "systemctl", "restart", params.UnitName); err != nil {
-			return nil, changed, fmt.Errorf("restart: %v", err)
+		if err := syssystemd.Restart(ctx, params.UnitName); err != nil {
+			return nil, changed, fmt.Errorf("restart: %w", err)
 		}
 		output.WriteString("restarted unit\n")
 		changed = true

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -2960,14 +2960,11 @@ func (e *Executor) createUser(ctx context.Context, params *pb.UserParams, output
 		args = append(args, "-c", params.Comment)
 	}
 
-	// Add username as last argument
-	args = append(args, params.Username)
-
-	// Create the user
-	cmdOutput, err := runSudoCmd(ctx, "useradd", args...)
+	// Create the user via SDK
+	result, err := sysuser.Create(ctx, params.Username, args...)
 	if err != nil {
-		if cmdOutput != nil {
-			output.WriteString(cmdOutput.Stderr)
+		if result != nil {
+			output.WriteString(result.Stderr)
 		}
 		return &pb.CommandOutput{ExitCode: 1, Stderr: output.String()}, nil, fmt.Errorf("failed to create user: %w", err)
 	}
@@ -2975,10 +2972,10 @@ func (e *Executor) createUser(ctx context.Context, params *pb.UserParams, output
 
 	// If home directory already existed, fix ownership
 	if homeExists && createHome {
-		if chownOutput, chownErr := runSudoCmd(ctx, "chown", "-R", params.Username+":"+params.Username, homeDir); chownErr != nil {
+		if chownResult, chownErr := sysuser.ChownRecursive(ctx, homeDir, params.Username, params.Username); chownErr != nil {
 			output.WriteString(fmt.Sprintf("warning: failed to fix home directory ownership: %v\n", chownErr))
-			if chownOutput != nil {
-				output.WriteString(chownOutput.Stderr)
+			if chownResult != nil {
+				output.WriteString(chownResult.Stderr)
 			}
 		} else {
 			output.WriteString(fmt.Sprintf("fixed ownership of existing home directory: %s\n", homeDir))
@@ -2992,15 +2989,15 @@ func (e *Executor) createUser(ctx context.Context, params *pb.UserParams, output
 		if err != nil {
 			output.WriteString(fmt.Sprintf("warning: failed to generate temporary password: %v\n", err))
 		} else {
-			// Set password using chpasswd
-			if chpasswdOutput, chpasswdErr := runSudoCmdWithStdin(ctx, strings.NewReader(fmt.Sprintf("%s:%s", params.Username, tempPassword)), "chpasswd"); chpasswdErr != nil {
+			// Set password
+			if chpasswdResult, chpasswdErr := sysuser.SetPassword(ctx, params.Username, tempPassword); chpasswdErr != nil {
 				output.WriteString(fmt.Sprintf("warning: failed to set temporary password: %v\n", chpasswdErr))
-				if chpasswdOutput != nil {
-					output.WriteString(chpasswdOutput.Stderr)
+				if chpasswdResult != nil {
+					output.WriteString(chpasswdResult.Stderr)
 				}
 			} else {
 				// Force password change on first login
-				if _, chageErr := runSudoCmd(ctx, "chage", "-d", "0", params.Username); chageErr != nil {
+				if _, chageErr := sysuser.ExpirePassword(ctx, params.Username); chageErr != nil {
 					output.WriteString(fmt.Sprintf("warning: failed to expire password: %v\n", chageErr))
 				}
 				output.WriteString(fmt.Sprintf("temporary password set for %s (must be changed on first login)\n", params.Username))
@@ -3031,10 +3028,10 @@ func (e *Executor) createUser(ctx context.Context, params *pb.UserParams, output
 
 	// Handle disabled state (lock the account)
 	if params.Disabled {
-		if lockOutput, lockErr := runSudoCmd(ctx, "usermod", "-L", params.Username); lockErr != nil {
+		if lockResult, lockErr := sysuser.Lock(ctx, params.Username); lockErr != nil {
 			output.WriteString(fmt.Sprintf("warning: failed to lock user account: %v\n", lockErr))
-			if lockOutput != nil {
-				output.WriteString(lockOutput.Stderr)
+			if lockResult != nil {
+				output.WriteString(lockResult.Stderr)
 			}
 		} else {
 			output.WriteString("account locked (disabled)\n")
@@ -3102,11 +3099,10 @@ func (e *Executor) updateUser(ctx context.Context, params *pb.UserParams, output
 
 	// Apply usermod if we have changes
 	if len(args) > 0 {
-		args = append(args, params.Username)
-		cmdOutput, err := runSudoCmd(ctx, "usermod", args...)
+		result, err := sysuser.Modify(ctx, params.Username, args...)
 		if err != nil {
-			if cmdOutput != nil {
-				output.WriteString(cmdOutput.Stderr)
+			if result != nil {
+				output.WriteString(result.Stderr)
 			}
 			return &pb.CommandOutput{ExitCode: 1, Stderr: output.String()}, false, fmt.Errorf("failed to update user: %w", err)
 		}
@@ -3131,7 +3127,7 @@ func (e *Executor) updateUser(ctx context.Context, params *pb.UserParams, output
 				output.WriteString(fmt.Sprintf("warning: failed to create home directory: %v\n", mkErr))
 			} else {
 				runSudoCmd(ctx, "cp", "-a", "/etc/skel/.", homeDir)
-				runSudoCmd(ctx, "chown", "-R", params.Username+":"+params.Username, homeDir)
+				sysuser.ChownRecursive(ctx, homeDir, params.Username, params.Username)
 				runSudoCmd(ctx, "chmod", "0700", homeDir)
 				output.WriteString(fmt.Sprintf("created missing home directory: %s\n", homeDir))
 				changed = true
@@ -3143,20 +3139,20 @@ func (e *Executor) updateUser(ctx context.Context, params *pb.UserParams, output
 	desiredLocked := params.Disabled
 	if desiredLocked != currentInfo.Locked {
 		if desiredLocked {
-			if lockOutput, err := runSudoCmd(ctx, "usermod", "-L", params.Username); err != nil {
+			if lockResult, err := sysuser.Lock(ctx, params.Username); err != nil {
 				output.WriteString(fmt.Sprintf("warning: failed to lock user: %v\n", err))
-				if lockOutput != nil {
-					output.WriteString(lockOutput.Stderr)
+				if lockResult != nil {
+					output.WriteString(lockResult.Stderr)
 				}
 			} else {
 				output.WriteString("account locked (disabled)\n")
 				changed = true
 			}
 		} else {
-			if unlockOutput, err := runSudoCmd(ctx, "usermod", "-U", params.Username); err != nil {
+			if unlockResult, err := sysuser.Unlock(ctx, params.Username); err != nil {
 				output.WriteString(fmt.Sprintf("warning: failed to unlock user: %v\n", err))
-				if unlockOutput != nil {
-					output.WriteString(unlockOutput.Stderr)
+				if unlockResult != nil {
+					output.WriteString(unlockResult.Stderr)
 				}
 			} else {
 				output.WriteString("account unlocked\n")
@@ -3212,18 +3208,18 @@ func (e *Executor) removeUser(ctx context.Context, username string) (*pb.Command
 	removeAccountsServiceFile(ctx, username)
 
 	// Remove user and their home directory
-	output, err := runSudoCmd(ctx, "userdel", "-r", username)
+	result, err := sysuser.Delete(ctx, username, true)
 	if err != nil {
 		// If home directory doesn't exist, userdel -r may still succeed
 		// but report an error. Check if user is actually removed.
-		if !userExists(username) {
+		if !sysuser.Exists(username) {
 			return &pb.CommandOutput{
 				ExitCode: 0,
 				Stdout:   fmt.Sprintf("removed user: %s (home directory may not have existed)\n", username),
 			}, true, nil
 		}
-		if output != nil {
-			return &pb.CommandOutput{ExitCode: 1, Stderr: output.Stderr}, false, fmt.Errorf("failed to remove user: %w", err)
+		if result != nil {
+			return &pb.CommandOutput{ExitCode: 1, Stderr: result.Stderr}, false, fmt.Errorf("failed to remove user: %w", err)
 		}
 		return nil, false, fmt.Errorf("failed to remove user: %w", err)
 	}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -28,6 +28,7 @@ import (
 	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
 	sysfs "github.com/manchtools/power-manage/sdk/go/sys/fs"
 	sysnotify "github.com/manchtools/power-manage/sdk/go/sys/notify"
+	sysreboot "github.com/manchtools/power-manage/sdk/go/sys/reboot"
 	syssystemd "github.com/manchtools/power-manage/sdk/go/sys/systemd"
 	sysuser "github.com/manchtools/power-manage/sdk/go/sys/user"
 	"github.com/manchtools/power-manage/sdk/go/verify"
@@ -2821,15 +2822,10 @@ func IsInstantAction(t pb.ActionType) bool {
 func (e *Executor) executeReboot(ctx context.Context) (*pb.CommandOutput, error) {
 	sysnotify.NotifyAll(ctx, "System Reboot", "This system will reboot in 5 minutes. Please save your work.")
 
-	output, err := runSudoCmd(ctx, "shutdown", "-r", "+5", "Power Manage: scheduled reboot")
-	if err != nil {
-		return output, fmt.Errorf("failed to schedule reboot: %w", err)
+	if err := sysreboot.Schedule(ctx, "+5", "Power Manage: scheduled reboot"); err != nil {
+		return nil, fmt.Errorf("failed to schedule reboot: %w", err)
 	}
-	if output == nil {
-		output = &pb.CommandOutput{}
-	}
-	output.Stdout = "Reboot scheduled in 5 minutes\n" + output.Stdout
-	return output, nil
+	return &pb.CommandOutput{Stdout: "Reboot scheduled in 5 minutes\n"}, nil
 }
 
 // executeUser manages user accounts (create, update, disable, remove).

--- a/internal/executor/lps.go
+++ b/internal/executor/lps.go
@@ -102,9 +102,9 @@ func (e *Executor) setupLpsPasswords(ctx context.Context, params *pb.LpsParams, 
 		}
 
 		// Set the password
-		if err := sysuser.SetPassword(ctx, username, password); err != nil {
+		if result, err := sysuser.SetPassword(ctx, username, password); err != nil {
 			anyError = fmt.Errorf("set password for %s: %w", username, err)
-			output.WriteString(fmt.Sprintf("LPS: %s — failed to set password: %v\n", username, err))
+			output.WriteString(fmt.Sprintf("LPS: %s — failed to set password: %v%s\n", username, err, stderrSuffix(result)))
 			continue
 		}
 

--- a/internal/executor/lps.go
+++ b/internal/executor/lps.go
@@ -2,13 +2,11 @@ package executor
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"math/big"
 	"strings"
 	"time"
 
@@ -17,11 +15,6 @@ import (
 	sysuser "github.com/manchtools/power-manage/sdk/go/sys/user"
 
 	"github.com/manchtools/power-manage/agent/internal/store"
-)
-
-const (
-	alphanumericChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	complexChars      = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{}|;:,.<>?"
 )
 
 // lpsRotationEntry is the JSON structure reported in action result metadata.
@@ -68,10 +61,7 @@ func (e *Executor) setupLpsPasswords(ctx context.Context, params *pb.LpsParams, 
 		userStates = make(map[string]*store.LpsUserState)
 	}
 
-	charset := alphanumericChars
-	if params.Complexity == pb.LpsPasswordComplexity_LPS_PASSWORD_COMPLEXITY_COMPLEX {
-		charset = complexChars
-	}
+	complex := params.Complexity == pb.LpsPasswordComplexity_LPS_PASSWORD_COMPLEXITY_COMPLEX
 
 	var rotations []lpsRotationEntry
 	var rotatedUsers []string
@@ -95,8 +85,16 @@ func (e *Executor) setupLpsPasswords(ctx context.Context, params *pb.LpsParams, 
 			continue
 		}
 
-		// Generate new password
-		password, err := generatePassword(int(params.PasswordLength), charset)
+		// Generate new password. Clamp the length to the SDK's accepted
+		// range so out-of-bounds proto values don't fail the rotation.
+		length := int(params.PasswordLength)
+		if length < sysuser.MinPasswordLength {
+			length = sysuser.MinPasswordLength
+		}
+		if length > sysuser.MaxPasswordLength {
+			length = sysuser.MaxPasswordLength
+		}
+		password, err := sysuser.GeneratePassword(length, complex)
 		if err != nil {
 			anyError = fmt.Errorf("generate password for %s: %w", username, err)
 			output.WriteString(fmt.Sprintf("LPS: %s — failed to generate password: %v\n", username, err))
@@ -239,29 +237,6 @@ func killUserSessions(ctx context.Context, username string) {
 	runSudoCmd(ctx, "pkill", "-KILL", "-u", username)
 	// Brief wait for processes to fully exit
 	time.Sleep(500 * time.Millisecond)
-}
-
-// generatePassword creates a cryptographically random password from the given character set.
-func generatePassword(length int, charset string) (string, error) {
-	if length < 8 {
-		length = 8
-	}
-	if length > 128 {
-		length = 128
-	}
-
-	result := make([]byte, length)
-	charsetLen := big.NewInt(int64(len(charset)))
-
-	for i := range result {
-		idx, err := rand.Int(rand.Reader, charsetLen)
-		if err != nil {
-			return "", fmt.Errorf("crypto/rand: %w", err)
-		}
-		result[i] = charset[idx.Int64()]
-	}
-
-	return string(result), nil
 }
 
 // getLastAuthTime returns the most recent login time for a user by parsing `last -1 -F <username>`.

--- a/internal/executor/lps.go
+++ b/internal/executor/lps.go
@@ -61,6 +61,15 @@ func (e *Executor) setupLpsPasswords(ctx context.Context, params *pb.LpsParams, 
 		userStates = make(map[string]*store.LpsUserState)
 	}
 
+	// Map the complexity enum to the SDK's boolean flag. COMPLEX enables
+	// special characters; ALPHANUMERIC uses letters and digits only.
+	// UNSPECIFIED falls back to ALPHANUMERIC for compatibility with older
+	// server versions that didn't set the field — logged so operators can
+	// spot misconfigured policies.
+	if params.Complexity == pb.LpsPasswordComplexity_LPS_PASSWORD_COMPLEXITY_UNSPECIFIED {
+		e.logger.Warn("LPS policy has no complexity set, defaulting to alphanumeric",
+			"action_id", actionID)
+	}
 	complex := params.Complexity == pb.LpsPasswordComplexity_LPS_PASSWORD_COMPLEXITY_COMPLEX
 
 	var rotations []lpsRotationEntry
@@ -87,12 +96,19 @@ func (e *Executor) setupLpsPasswords(ctx context.Context, params *pb.LpsParams, 
 
 		// Generate new password. Clamp the length to the SDK's accepted
 		// range so out-of-bounds proto values don't fail the rotation.
-		length := int(params.PasswordLength)
+		requested := int(params.PasswordLength)
+		length := requested
 		if length < sysuser.MinPasswordLength {
 			length = sysuser.MinPasswordLength
 		}
 		if length > sysuser.MaxPasswordLength {
 			length = sysuser.MaxPasswordLength
+		}
+		if length != requested {
+			e.logger.Warn("LPS password length clamped to SDK bounds",
+				"action_id", actionID, "username", username,
+				"requested", requested, "effective", length,
+				"min", sysuser.MinPasswordLength, "max", sysuser.MaxPasswordLength)
 		}
 		password, err := sysuser.GeneratePassword(length, complex)
 		if err != nil {

--- a/internal/executor/wifi.go
+++ b/internal/executor/wifi.go
@@ -3,28 +3,26 @@ package executor
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 	"path/filepath"
-	"strings"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/sys/network"
 )
 
-const wifiCertDir = "/var/lib/power-manage/wifi"
-
 // wifiConnectionName returns the managed connection name for an action.
+// All Power Manage WiFi profiles are prefixed so they're distinguishable
+// from user-managed NetworkManager connections.
 func wifiConnectionName(actionID string) string {
 	return "pm-wifi-" + actionID
 }
 
-// wifiCertPath returns the directory for EAP-TLS certificates.
+// wifiCertPath returns the directory for EAP-TLS certificates for an action.
 func wifiCertPath(actionID string) string {
-	return filepath.Join(wifiCertDir, actionID)
+	return filepath.Join(network.CertBaseDir, actionID)
 }
 
-// executeWifi manages WiFi connection profiles via NetworkManager (nmcli).
-// PRESENT: creates or updates the connection profile.
+// executeWifi manages WiFi connection profiles via NetworkManager.
+// PRESENT: creates or updates the connection profile (delegated to the SDK).
 // ABSENT: deletes the connection profile and any certificate files.
 func (e *Executor) executeWifi(ctx context.Context, params *pb.WifiParams, state pb.DesiredState, actionID string) (*pb.CommandOutput, bool, error) {
 	if params == nil {
@@ -35,287 +33,52 @@ func (e *Executor) executeWifi(ctx context.Context, params *pb.WifiParams, state
 	}
 
 	conName := wifiConnectionName(actionID)
+	certDir := wifiCertPath(actionID)
 
 	if state == pb.DesiredState_DESIRED_STATE_ABSENT {
-		return e.removeWifi(ctx, conName, actionID)
-	}
-
-	return e.ensureWifi(ctx, params, conName, actionID)
-}
-
-// removeWifi deletes a managed WiFi connection and its certificate files.
-func (e *Executor) removeWifi(ctx context.Context, conName, actionID string) (*pb.CommandOutput, bool, error) {
-	var output strings.Builder
-
-	exists := wifiConnectionExists(conName)
-	if !exists {
-		output.WriteString(fmt.Sprintf("connection %s does not exist, nothing to remove\n", conName))
-		// Also clean up cert dir if it exists
-		certDir := wifiCertPath(actionID)
-		if err := os.RemoveAll(certDir); err != nil {
-			slog.Warn("failed to remove wifi cert directory", "path", certDir, "error", err)
+		if err := network.Delete(ctx, conName, certDir); err != nil {
+			return nil, false, fmt.Errorf("delete connection: %w", err)
 		}
-		return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, false, nil
+		return &pb.CommandOutput{
+			ExitCode: 0,
+			Stdout:   fmt.Sprintf("removed connection %s\n", conName),
+		}, true, nil
 	}
 
-	// Delete the connection
-	out, err := runSudoCmd(ctx, "nmcli", "con", "delete", conName)
+	profile := network.WiFiProfile{
+		Name:        conName,
+		SSID:        params.Ssid,
+		AuthType:    wifiAuthFromProto(params.AuthType),
+		PSK:         params.Psk,
+		CACert:      params.CaCert,
+		ClientCert:  params.ClientCert,
+		ClientKey:   params.ClientKey,
+		Identity:    params.Identity,
+		AutoConnect: params.AutoConnect,
+		Hidden:      params.Hidden,
+		Priority:    int(params.Priority),
+		CertDir:     certDir,
+	}
+
+	changed, err := network.CreateOrUpdate(ctx, profile)
 	if err != nil {
-		return out, false, fmt.Errorf("failed to delete connection %s: %w", conName, err)
-	}
-	if out.ExitCode != 0 {
-		return out, false, fmt.Errorf("nmcli con delete failed: %s", out.Stderr)
-	}
-	output.WriteString(fmt.Sprintf("deleted connection %s\n", conName))
-
-	// Remove certificate directory
-	certDir := wifiCertPath(actionID)
-	if _, err := os.Stat(certDir); err == nil {
-		if rmErr := os.RemoveAll(certDir); rmErr != nil {
-			slog.Warn("failed to remove wifi cert directory", "path", certDir, "error", rmErr)
-		} else {
-			output.WriteString(fmt.Sprintf("removed certificate directory %s\n", certDir))
-		}
+		return nil, false, err
 	}
 
-	return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, true, nil
+	stdout := fmt.Sprintf("connection %s already configured correctly\n", conName)
+	if changed {
+		stdout = fmt.Sprintf("configured connection %s for SSID %s\n", conName, params.Ssid)
+	}
+	return &pb.CommandOutput{ExitCode: 0, Stdout: stdout}, changed, nil
 }
 
-// ensureWifi creates or updates a WiFi connection profile.
-func (e *Executor) ensureWifi(ctx context.Context, params *pb.WifiParams, conName, actionID string) (*pb.CommandOutput, bool, error) {
-	var output strings.Builder
-
-	// Write certificate files for EAP-TLS before configuring the connection
-	if params.AuthType == pb.WifiAuthType_WIFI_AUTH_TYPE_EAP_TLS {
-		if err := e.writeWifiCerts(actionID, params); err != nil {
-			return nil, false, fmt.Errorf("failed to write certificates: %w", err)
-		}
-		output.WriteString("wrote EAP-TLS certificate files\n")
-	}
-
-	exists := wifiConnectionExists(conName)
-
-	if exists {
-		// Connection exists — check if modification is needed
-		changed, err := e.modifyWifiIfNeeded(ctx, params, conName, actionID)
-		if err != nil {
-			return nil, false, err
-		}
-		if changed {
-			output.WriteString(fmt.Sprintf("updated connection %s\n", conName))
-		} else {
-			output.WriteString(fmt.Sprintf("connection %s already configured correctly\n", conName))
-		}
-		return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, changed, nil
-	}
-
-	// Create new connection
-	args := e.buildNmcliAddArgs(params, conName, actionID)
-	out, err := runSudoCmd(ctx, "nmcli", args...)
-	if err != nil {
-		return out, false, fmt.Errorf("failed to create connection: %w", err)
-	}
-	if out.ExitCode != 0 {
-		return out, false, fmt.Errorf("nmcli con add failed: %s", out.Stderr)
-	}
-
-	output.WriteString(fmt.Sprintf("created connection %s for SSID %s\n", conName, params.Ssid))
-	return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, true, nil
-}
-
-// buildNmcliAddArgs builds the nmcli arguments for creating a WiFi connection.
-func (e *Executor) buildNmcliAddArgs(params *pb.WifiParams, conName, actionID string) []string {
-	args := []string{
-		"con", "add",
-		"con-name", conName,
-		"type", "wifi",
-		"ssid", params.Ssid,
-	}
-
-	switch params.AuthType {
+// wifiAuthFromProto maps the proto auth type enum to the SDK enum.
+func wifiAuthFromProto(t pb.WifiAuthType) network.WiFiAuthType {
+	switch t {
 	case pb.WifiAuthType_WIFI_AUTH_TYPE_PSK:
-		args = append(args,
-			"wifi-sec.key-mgmt", "wpa-psk",
-			"wifi-sec.psk", params.Psk,
-		)
+		return network.WiFiAuthPSK
 	case pb.WifiAuthType_WIFI_AUTH_TYPE_EAP_TLS:
-		certDir := wifiCertPath(actionID)
-		args = append(args,
-			"wifi-sec.key-mgmt", "wpa-eap",
-			"802-1x.eap", "tls",
-			"802-1x.identity", params.Identity,
-			"802-1x.ca-cert", filepath.Join(certDir, "ca.pem"),
-			"802-1x.client-cert", filepath.Join(certDir, "client.pem"),
-			"802-1x.private-key", filepath.Join(certDir, "client-key.pem"),
-		)
+		return network.WiFiAuthEAPTLS
 	}
-
-	// Connection settings
-	if params.AutoConnect {
-		args = append(args, "connection.autoconnect", "yes")
-	} else {
-		args = append(args, "connection.autoconnect", "no")
-	}
-
-	if params.Priority != 0 {
-		args = append(args, "connection.autoconnect-priority", fmt.Sprintf("%d", params.Priority))
-	}
-
-	if params.Hidden {
-		args = append(args, "wifi.hidden", "yes")
-	}
-
-	return args
-}
-
-// modifyWifiIfNeeded checks current settings and modifies only if different.
-func (e *Executor) modifyWifiIfNeeded(ctx context.Context, params *pb.WifiParams, conName, actionID string) (bool, error) {
-	// Get current connection settings
-	currentSettings, err := getConnectionSettings(ctx, conName)
-	if err != nil {
-		// Can't read settings — just modify to be safe
-		return e.modifyWifi(ctx, params, conName, actionID)
-	}
-
-	// Build desired settings map
-	desired := map[string]string{
-		"wifi.ssid": params.Ssid,
-	}
-
-	switch params.AuthType {
-	case pb.WifiAuthType_WIFI_AUTH_TYPE_PSK:
-		desired["wifi-sec.key-mgmt"] = "wpa-psk"
-		desired["wifi-sec.psk"] = params.Psk
-	case pb.WifiAuthType_WIFI_AUTH_TYPE_EAP_TLS:
-		desired["wifi-sec.key-mgmt"] = "wpa-eap"
-		desired["802-1x.eap"] = "tls"
-		desired["802-1x.identity"] = params.Identity
-	}
-
-	if params.AutoConnect {
-		desired["connection.autoconnect"] = "yes"
-	} else {
-		desired["connection.autoconnect"] = "no"
-	}
-	desired["connection.autoconnect-priority"] = fmt.Sprintf("%d", params.Priority)
-	if params.Hidden {
-		desired["wifi.hidden"] = "yes"
-	} else {
-		desired["wifi.hidden"] = "no"
-	}
-
-	// Compare current vs desired
-	needsUpdate := false
-	for key, want := range desired {
-		got := currentSettings[key]
-		if got != want {
-			needsUpdate = true
-			break
-		}
-	}
-
-	if !needsUpdate {
-		return false, nil
-	}
-
-	return e.modifyWifi(ctx, params, conName, actionID)
-}
-
-// modifyWifi applies changes to an existing connection.
-func (e *Executor) modifyWifi(ctx context.Context, params *pb.WifiParams, conName, actionID string) (bool, error) {
-	args := []string{"con", "mod", conName, "wifi.ssid", params.Ssid}
-
-	switch params.AuthType {
-	case pb.WifiAuthType_WIFI_AUTH_TYPE_PSK:
-		args = append(args,
-			"wifi-sec.key-mgmt", "wpa-psk",
-			"wifi-sec.psk", params.Psk,
-		)
-	case pb.WifiAuthType_WIFI_AUTH_TYPE_EAP_TLS:
-		certDir := wifiCertPath(actionID)
-		args = append(args,
-			"wifi-sec.key-mgmt", "wpa-eap",
-			"802-1x.eap", "tls",
-			"802-1x.identity", params.Identity,
-			"802-1x.ca-cert", filepath.Join(certDir, "ca.pem"),
-			"802-1x.client-cert", filepath.Join(certDir, "client.pem"),
-			"802-1x.private-key", filepath.Join(certDir, "client-key.pem"),
-		)
-	}
-
-	if params.AutoConnect {
-		args = append(args, "connection.autoconnect", "yes")
-	} else {
-		args = append(args, "connection.autoconnect", "no")
-	}
-	args = append(args, "connection.autoconnect-priority", fmt.Sprintf("%d", params.Priority))
-	if params.Hidden {
-		args = append(args, "wifi.hidden", "yes")
-	} else {
-		args = append(args, "wifi.hidden", "no")
-	}
-
-	out, err := runSudoCmd(ctx, "nmcli", args...)
-	if err != nil {
-		return false, fmt.Errorf("failed to modify connection: %w", err)
-	}
-	if out.ExitCode != 0 {
-		return false, fmt.Errorf("nmcli con mod failed: %s", out.Stderr)
-	}
-
-	return true, nil
-}
-
-// writeWifiCerts writes EAP-TLS certificate files to disk.
-func (e *Executor) writeWifiCerts(actionID string, params *pb.WifiParams) error {
-	certDir := wifiCertPath(actionID)
-	if err := os.MkdirAll(certDir, 0750); err != nil {
-		return fmt.Errorf("create cert directory: %w", err)
-	}
-
-	files := map[string]struct {
-		content string
-		mode    os.FileMode
-	}{
-		"ca.pem":         {content: params.CaCert, mode: 0640},
-		"client.pem":     {content: params.ClientCert, mode: 0640},
-		"client-key.pem": {content: params.ClientKey, mode: 0600},
-	}
-
-	for name, f := range files {
-		if f.content == "" {
-			continue
-		}
-		path := filepath.Join(certDir, name)
-		if err := os.WriteFile(path, []byte(f.content), f.mode); err != nil {
-			return fmt.Errorf("write %s: %w", name, err)
-		}
-	}
-
-	return nil
-}
-
-// wifiConnectionExists checks if a named NetworkManager connection exists.
-func wifiConnectionExists(conName string) bool {
-	return checkCmdSuccess("nmcli", "-t", "-f", "NAME", "con", "show", conName)
-}
-
-// getConnectionSettings retrieves the current settings for a connection as a map.
-func getConnectionSettings(ctx context.Context, conName string) (map[string]string, error) {
-	out, err := runCmd(ctx, "nmcli", "-t", "-f", "all", "con", "show", conName)
-	if err != nil {
-		return nil, err
-	}
-	if out.ExitCode != 0 {
-		return nil, fmt.Errorf("nmcli show failed: %s", out.Stderr)
-	}
-
-	settings := map[string]string{}
-	for _, line := range strings.Split(out.Stdout, "\n") {
-		parts := strings.SplitN(line, ":", 2)
-		if len(parts) == 2 {
-			settings[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
-		}
-	}
-	return settings, nil
+	return 0
 }

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -4,7 +4,6 @@ package handler
 import (
 	"context"
 	"log/slog"
-	"os/exec"
 	"strconv"
 	"strings"
 	"sync"
@@ -17,6 +16,7 @@ import (
 	"github.com/manchtools/power-manage/agent/internal/scheduler"
 	"github.com/manchtools/power-manage/agent/internal/store"
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
 	"github.com/manchtools/power-manage/sdk/go/sys/inventory"
 	"github.com/manchtools/power-manage/sdk/go/sys/osquery"
 )
@@ -347,9 +347,14 @@ func (h *Handler) OnLogQuery(ctx context.Context, query *pb.LogQuery) (*pb.LogQu
 		args = append(args, "-k")
 	}
 
-	out, err := exec.CommandContext(ctx, "journalctl", args...).CombinedOutput()
+	result, err := sysexec.Run(ctx, "journalctl", args...)
 	if err != nil {
-		errMsg := strings.TrimSpace(string(out))
+		// journalctl's human-readable failure message is on stderr;
+		// surface that to the caller rather than the bare Go error.
+		errMsg := ""
+		if result != nil {
+			errMsg = strings.TrimSpace(result.Stderr)
+		}
 		if errMsg == "" {
 			errMsg = err.Error()
 		}
@@ -361,7 +366,7 @@ func (h *Handler) OnLogQuery(ctx context.Context, query *pb.LogQuery) (*pb.LogQu
 		}, nil
 	}
 
-	logs := string(out)
+	logs := result.Stdout
 	// Truncate to 1MB if needed (keep the tail)
 	if len(logs) > 1<<20 {
 		logs = logs[len(logs)-(1<<20):]

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/manchtools/power-manage/agent/internal/executor"
 	"github.com/manchtools/power-manage/agent/internal/scheduler"
+	"github.com/manchtools/power-manage/agent/internal/store"
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/go/sys/inventory"
 	"github.com/manchtools/power-manage/sdk/go/sys/osquery"
@@ -26,6 +27,7 @@ type Handler struct {
 	executor     *executor.Executor
 	osquery      *osquery.Registry // nil if osquery is not installed
 	scheduler    *scheduler.Scheduler
+	store        *store.Store
 	syncTrigger  chan<- struct{} // triggers an immediate action sync (for SYNC instant action)
 	mu           sync.Mutex     // protects connectedCh, connectedSet and the terminal* fields below
 	connectedCh  chan struct{}   // closed when welcome is received and connection is ready
@@ -45,11 +47,12 @@ type Handler struct {
 }
 
 // NewHandler creates a new stream handler.
-func NewHandler(logger *slog.Logger, exec *executor.Executor, sched *scheduler.Scheduler, syncTrigger chan<- struct{}) *Handler {
+func NewHandler(logger *slog.Logger, exec *executor.Executor, sched *scheduler.Scheduler, st *store.Store, syncTrigger chan<- struct{}) *Handler {
 	return &Handler{
 		logger:      logger,
 		executor:    exec,
 		scheduler:   sched,
+		store:       st,
 		syncTrigger: syncTrigger,
 		connectedCh: make(chan struct{}),
 	}

--- a/internal/handler/terminal.go
+++ b/internal/handler/terminal.go
@@ -312,7 +312,7 @@ func (h *Handler) OnTerminalStart(ctx context.Context, req *pb.TerminalStart) er
 		abortStopped()
 		return nil
 	}
-	if err := sysuser.Modify(sessionCtx, req.TtyUser, "-s", terminalActivatedShell); err != nil {
+	if _, err := sysuser.Modify(sessionCtx, req.TtyUser, "-s", terminalActivatedShell); err != nil {
 		abortFail(fmt.Sprintf("activate shell: %v", err))
 		return nil
 	}
@@ -345,7 +345,7 @@ func (h *Handler) OnTerminalStart(ctx context.Context, req *pb.TerminalStart) er
 		abortFail("temp home is not a regular directory")
 		return nil
 	}
-	if err := sysuser.ChownRecursive(sessionCtx, tempHome, req.TtyUser, req.TtyUser); err != nil {
+	if _, err := sysuser.ChownRecursive(sessionCtx, tempHome, req.TtyUser, req.TtyUser); err != nil {
 		abortFail(fmt.Sprintf("chown temp home: %v", err))
 		return nil
 	}
@@ -659,7 +659,7 @@ func (h *Handler) anySessionForUserExcept(ttyUser, exceptSessionID string) bool 
 // Best-effort: a failure here is logged but does not block the rest
 // of the cleanup.
 func (h *Handler) deactivateShell(ctx context.Context, ttyUser string) {
-	if err := sysuser.Modify(ctx, ttyUser, "-s", terminalDeactivatedShell); err != nil {
+	if _, err := sysuser.Modify(ctx, ttyUser, "-s", terminalDeactivatedShell); err != nil {
 		h.logger.Warn("failed to revert tty user shell",
 			"tty_user", ttyUser, "error", err)
 	}

--- a/internal/handler/terminal.go
+++ b/internal/handler/terminal.go
@@ -186,6 +186,34 @@ func (h *Handler) OnTerminalStart(ctx context.Context, req *pb.TerminalStart) er
 		return nil
 	}
 
+	// Device-authoritative TTY gate. The toggle lives in the agent's
+	// SQLite database and defaults to off. Only the power-manage user
+	// (via the CLI) or root can flip it — the server cannot bypass
+	// this by pushing an action because the action still runs on the
+	// device and goes through the same CLI surface.
+	//
+	// Fail-closed: a nil store or any read error means the gate is
+	// closed, never the other way around. This runs before the user
+	// lookup so a disabled device does zero syscalls on each rejected
+	// request and the error message doesn't leak whether the pm-tty-*
+	// user happens to exist.
+	if h.store == nil {
+		logger.Warn("terminal start rejected: no store wired for tty gate")
+		h.failTerminalStart(ctx, sender, req.SessionId, "terminal sessions are disabled on this device")
+		return nil
+	}
+	enabled, err := h.store.IsTTYEnabled()
+	if err != nil {
+		logger.Warn("failed to read tty toggle state; refusing session", "error", err)
+		h.failTerminalStart(ctx, sender, req.SessionId, "terminal sessions are disabled on this device")
+		return nil
+	}
+	if !enabled {
+		logger.Info("terminal start rejected: tty disabled on device")
+		h.failTerminalStart(ctx, sender, req.SessionId, "terminal sessions are disabled on this device")
+		return nil
+	}
+
 	// Verify the TTY user actually exists and is not locked. This is
 	// the dedicated pm-tty-* account; failure here means the control
 	// server's TerminalAccess provisioning hasn't run on this device

--- a/internal/handler/terminal_test.go
+++ b/internal/handler/terminal_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/manchtools/power-manage/agent/internal/store"
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 )
 
@@ -44,9 +45,26 @@ func (f *fakeSender) lastState() *pb.TerminalStateChange {
 
 func newTestHandler(t *testing.T) (*Handler, *fakeSender) {
 	t.Helper()
+	// Default to a TTY-enabled store so existing tests exercise the
+	// full start path without being blocked by the toggle gate. Tests
+	// that want to exercise the gate itself use newTestHandlerWithTTY.
+	return newTestHandlerWithTTY(t, true)
+}
+
+func newTestHandlerWithTTY(t *testing.T, ttyEnabled bool) (*Handler, *fakeSender) {
+	t.Helper()
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+	if err := st.SetTTYEnabled(ttyEnabled); err != nil {
+		t.Fatalf("set tty toggle: %v", err)
+	}
 	h := &Handler{
 		logger:      slog.Default(),
 		connectedCh: make(chan struct{}),
+		store:       st,
 	}
 	sender := &fakeSender{}
 	h.SetTerminalSender(sender)
@@ -271,6 +289,68 @@ func TestTerminal_Start_RejectsNonPrefixedUsername(t *testing.T) {
 	// limit check still has room.
 	if got := len(h.terminals); got != 0 {
 		t.Errorf("registry should be empty, got %d entries", got)
+	}
+}
+
+// OnTerminalStart must reject all sessions when the device-local TTY
+// toggle is off. The rejection uses an opaque error message so the
+// server cannot distinguish "disabled" from other failure modes.
+func TestTerminal_Start_RejectsWhenTTYDisabled(t *testing.T) {
+	h, sender := newTestHandlerWithTTY(t, false)
+	err := h.OnTerminalStart(context.Background(), &pb.TerminalStart{
+		SessionId: "01ABC",
+		TtyUser:   "pm-tty-test",
+		Cols:      80,
+		Rows:      24,
+	})
+	if err != nil {
+		t.Fatalf("OnTerminalStart returned %v", err)
+	}
+	last := sender.lastState()
+	if last == nil {
+		t.Fatal("expected STATE_ERROR when TTY is disabled")
+	}
+	if last.State != pb.TerminalSessionState_TERMINAL_SESSION_STATE_ERROR {
+		t.Errorf("state = %v, want ERROR", last.State)
+	}
+	if !strings.Contains(last.Error, "disabled on this device") {
+		t.Errorf("error = %q, want opaque disabled message", last.Error)
+	}
+	if got := len(h.terminals); got != 0 {
+		t.Errorf("registry should be empty, got %d entries", got)
+	}
+}
+
+// A handler constructed without a store must fail-closed — any
+// TerminalStart request is rejected. This protects against a wiring
+// regression where the handler is created before the store.
+func TestTerminal_Start_RejectsWhenStoreMissing(t *testing.T) {
+	h := &Handler{
+		logger:      slog.Default(),
+		connectedCh: make(chan struct{}),
+		// intentionally no store
+	}
+	sender := &fakeSender{}
+	h.SetTerminalSender(sender)
+
+	err := h.OnTerminalStart(context.Background(), &pb.TerminalStart{
+		SessionId: "01ABC",
+		TtyUser:   "pm-tty-test",
+		Cols:      80,
+		Rows:      24,
+	})
+	if err != nil {
+		t.Fatalf("OnTerminalStart returned %v", err)
+	}
+	last := sender.lastState()
+	if last == nil {
+		t.Fatal("expected STATE_ERROR when store is missing")
+	}
+	if last.State != pb.TerminalSessionState_TERMINAL_SESSION_STATE_ERROR {
+		t.Errorf("state = %v, want ERROR", last.State)
+	}
+	if !strings.Contains(last.Error, "disabled on this device") {
+		t.Errorf("error = %q, want opaque disabled message", last.Error)
 	}
 }
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -2,12 +2,15 @@
 package setup
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"text/template"
+	"time"
+
+	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
 // validUsername matches safe Unix usernames (lowercase, digits, underscore, dash).
@@ -60,9 +63,17 @@ func InstallSudoers(user string) error {
 		return fmt.Errorf("close temp sudoers file: %w", err)
 	}
 
+	// Short deadline on these: visudo/chown are millisecond-scale but
+	// should never hang if something is wrong with the host.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	// Validate syntax with visudo
-	if err := exec.Command("visudo", "-c", "-f", tmpFile).Run(); err != nil {
+	if result, err := sysexec.Run(ctx, "visudo", "-c", "-f", tmpFile); err != nil {
 		os.Remove(tmpFile)
+		if result != nil && result.Stderr != "" {
+			return fmt.Errorf("sudoers validation failed: %w: %s", err, result.Stderr)
+		}
 		return fmt.Errorf("sudoers validation failed: %w", err)
 	}
 
@@ -73,7 +84,10 @@ func InstallSudoers(user string) error {
 	}
 
 	// Ensure correct ownership
-	if err := exec.Command("chown", "root:root", dest).Run(); err != nil {
+	if result, err := sysexec.Run(ctx, "chown", "root:root", dest); err != nil {
+		if result != nil && result.Stderr != "" {
+			return fmt.Errorf("set sudoers ownership: %w: %s", err, result.Stderr)
+		}
 		return fmt.Errorf("set sudoers ownership: %w", err)
 	}
 

--- a/internal/store/migrations/002_settings.sql
+++ b/internal/store/migrations/002_settings.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+
+-- settings holds device-local configuration toggles that the admin controls
+-- via the agent CLI. Key-value schema keeps it trivially extensible.
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS settings;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -817,3 +817,41 @@ func (s *Store) DeleteLpsState(actionID string) error {
 	_, err := s.db.Exec("DELETE FROM lps_state WHERE action_id = ?", actionID)
 	return err
 }
+
+// =============================================================================
+// Settings
+// =============================================================================
+
+// GetSetting returns the value of a setting, or empty string if unset.
+func (s *Store) GetSetting(key string) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var value string
+	err := s.db.QueryRow("SELECT value FROM settings WHERE key = ?", key).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	return value, err
+}
+
+// SetSetting stores a setting, overwriting any existing value for the key.
+func (s *Store) SetSetting(key, value string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, err := s.db.Exec(`
+		INSERT INTO settings (key, value) VALUES (?, ?)
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value
+	`, key, value)
+	return err
+}
+
+// DeleteSetting removes a setting.
+func (s *Store) DeleteSetting(key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, err := s.db.Exec("DELETE FROM settings WHERE key = ?", key)
+	return err
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -12,7 +12,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -94,75 +93,7 @@ func New(dataDir string) (*Store, error) {
 		return nil, fmt.Errorf("run migrations: %w", err)
 	}
 
-	store := &Store{db: db}
-
-	// Migrate legacy LPS JSON files into SQLite (one-time, idempotent).
-	store.migrateLpsJsonFiles(dataDir)
-
-	return store, nil
-}
-
-// migrateLpsJsonFiles imports legacy /var/lib/power-manage/lps/lps-*.json files
-// into the lps_state table and removes the files afterwards.
-func (s *Store) migrateLpsJsonFiles(dataDir string) {
-	lpsDir := filepath.Join(dataDir, "lps")
-	entries, err := os.ReadDir(lpsDir)
-	if err != nil {
-		return // directory doesn't exist — nothing to migrate
-	}
-
-	type legacyUserState struct {
-		LastRotatedAt time.Time `json:"last_rotated_at"`
-		PasswordHash  string    `json:"password_hash"`
-	}
-	type legacyState struct {
-		Users map[string]legacyUserState `json:"users"`
-	}
-
-	migrated := 0
-	for _, entry := range entries {
-		name := entry.Name()
-		if entry.IsDir() || !strings.HasPrefix(name, "lps-") || !strings.HasSuffix(name, ".json") {
-			continue
-		}
-
-		actionID := strings.ToUpper(strings.TrimSuffix(strings.TrimPrefix(name, "lps-"), ".json"))
-		filePath := filepath.Join(lpsDir, name)
-
-		data, err := os.ReadFile(filePath)
-		if err != nil {
-			slog.Warn("migration: failed to read LPS JSON file", "path", filePath, "error", err)
-			continue
-		}
-
-		var state legacyState
-		if err := json.Unmarshal(data, &state); err != nil {
-			slog.Warn("migration: failed to parse LPS JSON file", "path", filePath, "error", err)
-			continue
-		}
-
-		for username, us := range state.Users {
-			_, err := s.db.Exec(`
-				INSERT OR IGNORE INTO lps_state (action_id, username, last_rotated_at, password_hash)
-				VALUES (?, ?, ?, ?)
-			`, actionID, username, us.LastRotatedAt.UTC().Format(time.RFC3339), us.PasswordHash)
-			if err != nil {
-				slog.Warn("migration: failed to insert LPS state", "action_id", actionID, "username", username, "error", err)
-			}
-		}
-
-		if err := os.Remove(filePath); err != nil {
-			slog.Warn("migration: failed to remove LPS JSON file", "path", filePath, "error", err)
-		} else {
-			migrated++
-		}
-	}
-
-	if migrated > 0 {
-		slog.Info("migration: migrated LPS state from JSON files to SQLite", "count", migrated)
-		// Remove empty lps directory
-		os.Remove(lpsDir)
-	}
+	return &Store{db: db}, nil
 }
 
 // Close closes the database connection.

--- a/internal/store/tty.go
+++ b/internal/store/tty.go
@@ -1,0 +1,32 @@
+package store
+
+// TTYSettingKey is the settings row key storing the local TTY toggle state.
+// Value is "1" when enabled, any other value (including absent) means disabled.
+//
+// The toggle is device-local — only the agent process (running as
+// power-manage) can write it, so enable/disable is invoked via the
+// power-manage-agent CLI which requires sudo or equivalent privilege
+// escalation to the power-manage user. The server cannot flip this flag
+// directly; it can only request the flip via a shell action, which still
+// runs as the agent user on the device.
+const TTYSettingKey = "tty.enabled"
+
+// IsTTYEnabled returns true if remote terminal sessions are enabled on
+// this device. Default (no row set) is false — terminals are off until
+// a local admin explicitly enables them.
+func (s *Store) IsTTYEnabled() (bool, error) {
+	v, err := s.GetSetting(TTYSettingKey)
+	if err != nil {
+		return false, err
+	}
+	return v == "1", nil
+}
+
+// SetTTYEnabled toggles the TTY state. Passing true enables, false disables.
+func (s *Store) SetTTYEnabled(enabled bool) error {
+	v := "0"
+	if enabled {
+		v = "1"
+	}
+	return s.SetSetting(TTYSettingKey, v)
+}

--- a/internal/store/tty_test.go
+++ b/internal/store/tty_test.go
@@ -1,0 +1,138 @@
+package store
+
+import (
+	"testing"
+)
+
+func TestTTYDefault_Disabled(t *testing.T) {
+	st, err := New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	enabled, err := st.IsTTYEnabled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if enabled {
+		t.Error("expected TTY to be disabled by default")
+	}
+}
+
+func TestTTY_EnableDisableRoundtrip(t *testing.T) {
+	st, err := New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	// Enable
+	if err := st.SetTTYEnabled(true); err != nil {
+		t.Fatal(err)
+	}
+	enabled, err := st.IsTTYEnabled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !enabled {
+		t.Error("expected enabled after SetTTYEnabled(true)")
+	}
+
+	// Idempotent enable
+	if err := st.SetTTYEnabled(true); err != nil {
+		t.Fatal(err)
+	}
+	enabled, _ = st.IsTTYEnabled()
+	if !enabled {
+		t.Error("expected enabled after second SetTTYEnabled(true)")
+	}
+
+	// Disable
+	if err := st.SetTTYEnabled(false); err != nil {
+		t.Fatal(err)
+	}
+	enabled, err = st.IsTTYEnabled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if enabled {
+		t.Error("expected disabled after SetTTYEnabled(false)")
+	}
+
+	// Idempotent disable
+	if err := st.SetTTYEnabled(false); err != nil {
+		t.Fatal(err)
+	}
+	enabled, _ = st.IsTTYEnabled()
+	if enabled {
+		t.Error("expected still disabled after second SetTTYEnabled(false)")
+	}
+}
+
+func TestTTY_PersistsAcrossReopen(t *testing.T) {
+	dir := t.TempDir()
+
+	// Open, enable, close
+	st, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.SetTTYEnabled(true); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen, verify still enabled
+	st2, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st2.Close()
+
+	enabled, err := st2.IsTTYEnabled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !enabled {
+		t.Error("expected TTY state to persist across reopen")
+	}
+}
+
+func TestSettings_GetMissingReturnsEmpty(t *testing.T) {
+	st, err := New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	value, err := st.GetSetting("nonexistent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value != "" {
+		t.Errorf("expected empty string for missing setting, got %q", value)
+	}
+}
+
+func TestSettings_SetOverwrites(t *testing.T) {
+	st, err := New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	if err := st.SetSetting("key", "v1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.SetSetting("key", "v2"); err != nil {
+		t.Fatal(err)
+	}
+
+	value, _ := st.GetSetting("key")
+	if value != "v2" {
+		t.Errorf("expected %q, got %q", "v2", value)
+	}
+}


### PR DESCRIPTION
## Summary

Multi-commit cleanup of agent internals. Each commit is scoped and independently reviewable.

### Removals / legacy
- **`32c3ea0`** — Remove legacy LPS JSON-to-SQLite migration. The field was never shipped to production; deleting the migration path removes a dead branch.

### Self-update robustness
- **`c67308b`** — Replace the backup/rollback flow with validate-before-swap. The new binary runs a `self-test` subprocess that exercises basic connectivity before the swap; failure leaves the current binary untouched. No cooldown — admin scheduling controls retry frequency (documented explicitly).

### Device-authoritative security gates
- **`be7a202`** — Add a device-authoritative TTY toggle stored in the agent SQLite DB, default off. A remote server cannot enable TTY by pushing an action alone — the CLI (requires root/power-manage-agent uid) is the only path to flip the flag.

### SDK adoption (behaviour-preserving refactors riding on sdk PR #29)
- **`56a749f`** — Delegate the WiFi executor to `sdk/go/sys/network` (drops 235 LOC of duplication).
- **`bc32e7d`** — Use `sysuser.GeneratePassword` for LPS rotation (removes local charset/math-big code).
- **`f53f125`** — Use `sysreboot.Schedule` for `executeReboot`.
- **`bf5414e`** — Use `syssystemd.{Enable,Disable,Start,Stop,Restart,DaemonReload}` for `executeSystemd` mutations.
- **`1779f73`** — Adapt the 4 sysuser callers to the new `(*Result, error)` signatures merged in sdk PR #29.
- **`cced54b`** — Use the `sysuser` package for `createUser`/`updateUser`/`removeUser` in the executor.

### Discovered-while-reviewing
- **`e21b727`** — Collapse duplicate signature-verification error branches in `ExecuteWithStreaming`. Both paths produced identical FAILED+return results; the type-based split was dead branching. Also removed the pointless `IsInstantAction`/`isInstantAction` wrapper pair.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages pass
- [ ] Manual: verify agent update end-to-end on a test device (validate-before-swap path)
- [ ] Manual: `sudo power-manage-agent tty {enable,disable,status}` cycle
- [ ] Manual: LPS rotation against a pm-test user

## Depends on

- Merged: manchtools/power-manage-sdk#29 (sysuser result-returning signatures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `tty` command (`enable`/`disable`/`status`) for device-local remote terminal control with device-side gating
  * Added `self-test` command for connectivity and update validation

* **Refactor**
  * Streamlined update flow: pre-swap validation, no agent-side cooldown or automatic rollback; failed updates leave the running binary unchanged
  * Data directory layout updated to use temporary download artifacts

* **Documentation**
  * Updated CLI and Auto-Update documentation and data-directory description

* **Tests**
  * Added tests for TTY settings and self-test behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->