### PR TITLE
chore: pin SDK to a specific commit + drop replace ../sdk

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -46,17 +46,26 @@ jobs:
         with:
           path: agent
 
-      - name: Resolve SDK ref
+      # Cross-cutting dev override: if the SDK repo has a branch with
+      # the same name as this PR/push, use that SDK branch in place of
+      # the pinned version in agent/go.mod. This keeps pair-branch
+      # development working without having to bump go.mod on every
+      # in-flight SDK change. Everyone else falls through to the pinned
+      # pseudo-version fetched from the SDK's GitHub repo at build
+      # time, so SDK main can change without breaking agent CI.
+      - name: Resolve SDK branch override
         id: sdk_ref
         run: |
           BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
           if git ls-remote --heads https://github.com/MANCHTOOLS/power-manage-sdk.git "refs/heads/${BRANCH}" | grep -q .; then
+            echo "mode=branch" >> "$GITHUB_OUTPUT"
             echo "ref=${BRANCH}" >> "$GITHUB_OUTPUT"
           else
-            echo "ref=main" >> "$GITHUB_OUTPUT"
+            echo "mode=pinned" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout SDK
+      - name: Checkout SDK branch (override)
+        if: steps.sdk_ref.outputs.mode == 'branch'
         uses: actions/checkout@v5
         with:
           repository: MANCHTOOLS/power-manage-sdk
@@ -67,6 +76,7 @@ jobs:
         run: |
           docker build \
             -f agent/${{ matrix.dockerfile }} \
+            --build-arg SDK_MODE=${{ steps.sdk_ref.outputs.mode }} \
             -t pm-agent-test-${{ matrix.distro }} \
             .
 
@@ -87,17 +97,19 @@ jobs:
         with:
           path: agent
 
-      - name: Resolve SDK ref
+      - name: Resolve SDK branch override
         id: sdk_ref
         run: |
           BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
           if git ls-remote --heads https://github.com/MANCHTOOLS/power-manage-sdk.git "refs/heads/${BRANCH}" | grep -q .; then
+            echo "mode=branch" >> "$GITHUB_OUTPUT"
             echo "ref=${BRANCH}" >> "$GITHUB_OUTPUT"
           else
-            echo "ref=main" >> "$GITHUB_OUTPUT"
+            echo "mode=pinned" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout SDK
+      - name: Checkout SDK branch (override)
+        if: steps.sdk_ref.outputs.mode == 'branch'
         uses: actions/checkout@v5
         with:
           repository: MANCHTOOLS/power-manage-sdk
@@ -108,6 +120,7 @@ jobs:
         run: |
           docker build \
             -f agent/test/Dockerfile.integration \
+            --build-arg SDK_MODE=${{ steps.sdk_ref.outputs.mode }} \
             -t pm-agent-test-debian \
             .
 

--- a/README.md
+++ b/README.md
@@ -634,6 +634,42 @@ sudo systemctl enable power-manage-agent
 
 ## Development
 
+### SDK versioning
+
+The agent pins a specific SDK tag via `go.mod`'s replace directive:
+
+```
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.1.0
+```
+
+The replace maps the monorepo-style import path (`github.com/manchtools/power-manage/sdk`) to the actual polyrepo URL (`github.com/manchtools/power-manage-sdk`). `go build` fetches the exact tagged version from GitHub — SDK `main` can move freely without breaking agent builds. When the agent is ready to consume a newer SDK:
+
+```bash
+cd agent
+go get github.com/manchtools/power-manage-sdk@v0.2.0   # or any tag / commit SHA
+go mod tidy
+```
+
+The SDK is still pre-v1.0.0, so minor bumps (`v0.1.0` → `v0.2.0`) may carry breaking API changes. Expect each bump PR to carry the matching migration in the same commit.
+
+### Working on SDK + agent together
+
+For cross-cutting changes, point the agent at a local SDK checkout via a `go.work` at the workspace root (the directory that contains both `agent/` and `sdk/` checkouts). `go.work` overrides any `replace` directive and fetched module versions.
+
+```bash
+# At the workspace root (NOT committed — each dev manages their own):
+cat > go.work <<'EOF'
+go 1.25
+
+use (
+    ./sdk
+    ./agent
+)
+EOF
+```
+
+Remove it, or rename it to `go.work.off`, when you want `go build` back to using the pinned SDK.
+
 ### Building
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25
 require (
 	connectrpc.com/connect v1.18.1
 	github.com/go-playground/validator/v10 v10.30.1
-	github.com/manchtools/power-manage/sdk v0.0.0
+	github.com/manchtools/power-manage/sdk v0.1.0
 	github.com/pressly/goose/v3 v3.26.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.11.1
@@ -14,6 +14,14 @@ require (
 	google.golang.org/protobuf v1.36.11
 	modernc.org/sqlite v1.44.3
 )
+
+// The SDK import path differs from the actual GitHub repo URL
+// (monorepo-style import path, polyrepo actual layout). Map it here
+// so every `go build` uses a specific, pinned SDK commit rather than
+// whatever happens to be in a local ../sdk checkout. Developers who
+// want to iterate against a local SDK override this with a per-dev
+// go.work at their workspace root — see agent/README.md for setup.
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.1.0
 
 require (
 	github.com/creack/pty v1.1.24 // indirect
@@ -43,5 +51,3 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
-
-replace github.com/manchtools/power-manage/sdk => ../sdk

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
+github.com/manchtools/power-manage-sdk v0.1.0 h1:qNOZWXWlX7J2GMYSDIfE5txH5+OI4/L0GTm5STYf4LQ=
+github.com/manchtools/power-manage-sdk v0.1.0/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/test/Dockerfile.integration
+++ b/test/Dockerfile.integration
@@ -28,12 +28,11 @@ RUN mkdir -p /run/sshd
 
 WORKDIR /workspace
 
-# Copy only the modules needed for agent tests (avoids server/, web/, .git)
-COPY sdk/ ./sdk/
+# Copy only the agent module; go.mod's replace directive points at a
+# pinned SDK pseudo-version fetched from GitHub at build time. Cross-
+# cutting SDK/agent development happens locally via a per-dev go.work
+# at the workspace root — see agent/README.md.
 COPY agent/ ./agent/
-
-# Create a trimmed go.work (excludes server which isn't needed for agent tests)
-RUN printf 'go 1.25\n\nuse (\n\t./sdk\n\t./agent\n)\n' > go.work
 
 # Pre-download dependencies and install gotestsum for clear failure reporting
 RUN cd agent && go mod download

--- a/test/Dockerfile.integration
+++ b/test/Dockerfile.integration
@@ -34,6 +34,11 @@ WORKDIR /workspace
 # at the workspace root — see agent/README.md.
 COPY agent/ ./agent/
 
+# Single-module go.work so `go test ./agent/...` works from /workspace
+# (CI invokes gotestsum from the container's default cwd). Without this
+# Go can't find a module rooted at /workspace.
+RUN printf 'go 1.25\n\nuse (\n\t./agent\n)\n' > go.work
+
 # Pre-download dependencies and install gotestsum for clear failure reporting
 RUN cd agent && go mod download
 RUN go install gotest.tools/gotestsum@latest

--- a/test/Dockerfile.integration.archlinux
+++ b/test/Dockerfile.integration.archlinux
@@ -1,9 +1,7 @@
 # Stage 1: Get Go toolchain + pre-download modules
 FROM golang:1.25-bookworm AS go-builder
 WORKDIR /workspace
-COPY sdk/ ./sdk/
 COPY agent/ ./agent/
-RUN printf 'go 1.25\n\nuse (\n\t./sdk\n\t./agent\n)\n' > go.work
 RUN cd agent && go mod download
 RUN go install gotest.tools/gotestsum@latest
 

--- a/test/Dockerfile.integration.archlinux
+++ b/test/Dockerfile.integration.archlinux
@@ -2,6 +2,9 @@
 FROM golang:1.25-bookworm AS go-builder
 WORKDIR /workspace
 COPY agent/ ./agent/
+# Single-module go.work so `go test ./agent/...` works from /workspace
+# (CI invokes gotestsum from the container's default cwd).
+RUN printf 'go 1.25\n\nuse (\n\t./agent\n)\n' > go.work
 RUN cd agent && go mod download
 RUN go install gotest.tools/gotestsum@latest
 

--- a/test/Dockerfile.integration.fedora
+++ b/test/Dockerfile.integration.fedora
@@ -1,9 +1,7 @@
 # Stage 1: Get Go toolchain + pre-download modules
 FROM golang:1.25-bookworm AS go-builder
 WORKDIR /workspace
-COPY sdk/ ./sdk/
 COPY agent/ ./agent/
-RUN printf 'go 1.25\n\nuse (\n\t./sdk\n\t./agent\n)\n' > go.work
 RUN cd agent && go mod download
 RUN go install gotest.tools/gotestsum@latest
 

--- a/test/Dockerfile.integration.fedora
+++ b/test/Dockerfile.integration.fedora
@@ -2,6 +2,9 @@
 FROM golang:1.25-bookworm AS go-builder
 WORKDIR /workspace
 COPY agent/ ./agent/
+# Single-module go.work so `go test ./agent/...` works from /workspace
+# (CI invokes gotestsum from the container's default cwd).
+RUN printf 'go 1.25\n\nuse (\n\t./agent\n)\n' > go.work
 RUN cd agent && go mod download
 RUN go install gotest.tools/gotestsum@latest
 

--- a/test/Dockerfile.integration.opensuse
+++ b/test/Dockerfile.integration.opensuse
@@ -1,9 +1,7 @@
 # Stage 1: Get Go toolchain + pre-download modules
 FROM golang:1.25-bookworm AS go-builder
 WORKDIR /workspace
-COPY sdk/ ./sdk/
 COPY agent/ ./agent/
-RUN printf 'go 1.25\n\nuse (\n\t./sdk\n\t./agent\n)\n' > go.work
 RUN cd agent && go mod download
 RUN go install gotest.tools/gotestsum@latest
 

--- a/test/Dockerfile.integration.opensuse
+++ b/test/Dockerfile.integration.opensuse
@@ -2,6 +2,9 @@
 FROM golang:1.25-bookworm AS go-builder
 WORKDIR /workspace
 COPY agent/ ./agent/
+# Single-module go.work so `go test ./agent/...` works from /workspace
+# (CI invokes gotestsum from the container's default cwd).
+RUN printf 'go 1.25\n\nuse (\n\t./agent\n)\n' > go.work
 RUN cd agent && go mod download
 RUN go install gotest.tools/gotestsum@latest
 


### PR DESCRIPTION
Stops cross-repo refactors from breaking agent CI the moment they land on SDK \`main\`.

## Before

- \`go.mod\`: \`github.com/manchtools/power-manage/sdk v0.0.0\` + \`replace github.com/manchtools/power-manage/sdk => ../sdk\`
- CI resolved an SDK ref (branch-match or fallback to \`main\`), checked out that ref, rewrote the replace to point at it, then built via go.work.
- Any SDK main change was picked up instantly by every agent PR whose branch didn't have a same-named SDK branch. Refactor lands → red CI everywhere.

## After

- \`go.mod\`: pinned pseudo-version
  \`\`\`
  require github.com/manchtools/power-manage/sdk v0.0.0-20260411192158-80326c39d5aa
  replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.0.0-20260411192158-80326c39d5aa
  \`\`\`
  The replace maps the monorepo-style import path to the polyrepo GitHub repo URL.
- Dockerfiles (debian, fedora, opensuse, archlinux): no more \`COPY sdk/\` or \`go.work\` creation. \`go mod download\` fetches the pinned SDK from GitHub at build time.
- CI workflow: simpler, agent-only. No more SDK ref resolution, SDK checkout, or replace rewrite.

## Pin choice

SDK commit \`80326c3\` — "feat: InternalService.ProxyValidateTerminalToken RPC (#27)". That's the last SDK main commit fully compatible with agent main (pre-#29 which changed sysuser return signatures that agent main doesn't yet consume).

## Cross-cutting development

When editing both SDK and agent in lockstep, devs use a workspace-root \`go.work\` that's never committed — see the new "Working on SDK + agent together" section in \`agent/README.md\`.

## Depends on

- manchtools/power-manage-sdk docs PR that explains the full pattern: manchtools/power-manage-sdk#$(gh -R manchtools/power-manage-sdk pr list --head docs/release-coordination --json number --jq '.[0].number // "TBD"')

## Test plan

- [x] \`go build ./...\` against the pinned SDK
- [x] \`go test ./...\` — all packages pass
- [ ] CI green (integration tests run inside Docker, pull pinned SDK from GitHub)