### PR TITLE
feat: auto-revert USER and GROUP actions on unassign (#25)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see agent/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.1.0
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.1.1-0.20260418095439-7209ded0c948
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.1.0 h1:qNOZWXWlX7J2GMYSDIfE5txH5+OI4/L0GTm5STYf4LQ=
-github.com/manchtools/power-manage-sdk v0.1.0/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.1.1-0.20260418095439-7209ded0c948 h1:vHDKLAwc7huCSCShhfhYg8KziGsAhOPUuSxtD0bABg8=
+github.com/manchtools/power-manage-sdk v0.1.1-0.20260418095439-7209ded0c948/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1502,7 +1502,15 @@ func (e *Executor) downloadFile(ctx context.Context, url, dest, expectedChecksum
 		}
 	}
 
-	return file.Close()
+	if err := file.Close(); err != nil {
+		// A late Close() error (fsync failure on a full disk, network
+		// FS hiccup) means the on-disk file is potentially partial.
+		// Remove it so the next run re-downloads instead of silently
+		// treating a truncated file as a valid artifact.
+		os.Remove(dest)
+		return fmt.Errorf("close downloaded file %s: %w", dest, err)
+	}
+	return nil
 }
 
 // =============================================================================

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -428,13 +428,18 @@ func (s *Scheduler) SyncActions(ctx context.Context, actions []*pb.Action, first
 }
 
 // shouldRevertOnUnassign returns true for action types whose effects should
-// be cleaned up when the action is unassigned from a device.
+// be cleaned up when the action is unassigned from a device. USER and GROUP
+// join the policy-style reverters because a user or group created by an
+// assignment should not outlive it — leaving the account on disk after a
+// scope change is an access-leak.
 func shouldRevertOnUnassign(actionType pb.ActionType) bool {
 	switch actionType {
 	case pb.ActionType_ACTION_TYPE_SSH,
 		pb.ActionType_ACTION_TYPE_SSHD,
 		pb.ActionType_ACTION_TYPE_SUDO,
-		pb.ActionType_ACTION_TYPE_LPS:
+		pb.ActionType_ACTION_TYPE_LPS,
+		pb.ActionType_ACTION_TYPE_USER,
+		pb.ActionType_ACTION_TYPE_GROUP:
 		return true
 	default:
 		return false

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -75,6 +75,8 @@ func TestShouldRevertOnUnassign(t *testing.T) {
 		pb.ActionType_ACTION_TYPE_SSHD,
 		pb.ActionType_ACTION_TYPE_SUDO,
 		pb.ActionType_ACTION_TYPE_LPS,
+		pb.ActionType_ACTION_TYPE_USER,
+		pb.ActionType_ACTION_TYPE_GROUP,
 	}
 	for _, at := range revertible {
 		if !shouldRevertOnUnassign(at) {
@@ -87,7 +89,6 @@ func TestShouldRevertOnUnassign(t *testing.T) {
 		pb.ActionType_ACTION_TYPE_SHELL,
 		pb.ActionType_ACTION_TYPE_FILE,
 		pb.ActionType_ACTION_TYPE_SYSTEMD,
-		pb.ActionType_ACTION_TYPE_USER,
 		pb.ActionType_ACTION_TYPE_APP_IMAGE,
 		pb.ActionType_ACTION_TYPE_FLATPAK,
 		pb.ActionType_ACTION_TYPE_REPOSITORY,


### PR DESCRIPTION
Closes manchtools/power-manage-agent#25.

## Summary

- USER and GROUP actions now auto-revert when their assignment is removed from a device — same behaviour as SSH, SSHD, SUDO, and LPS. Prevents user/group accounts leaking across scope changes.
- `shouldRevertOnUnassign` picks up the two new types; `TestShouldRevertOnUnassign` updated.
- Piggybacked an SDK pin bump: agent main had adopted the 2-return `sysuser` API (SDK PR #29) but still pinned to `v0.1.0` which predates that API. The resulting compile error blocked every builder. Moved to a pseudo-version on SDK main so the pin matches the API the code uses.

## Test plan

- [x] `go build ./...` green
- [x] `go test ./internal/scheduler/... -run TestRemoveAction -v` green
- [x] `go test ./internal/scheduler/... -run TestShouldRevertOnUnassign -v` green
- [x] Full `go test ./...` on agent green
- [ ] Manual: assign a `User` action, wait for it to apply (`id pm-test`), unassign, confirm the user is removed on next SyncActions tick