### PR TITLE
feat: migrate agent to SDK v0.2.0 privilege-backend API (#41)

### DIFF
--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -77,9 +77,11 @@ func applyBackendOverrides(logger *slog.Logger) {
 		logger.Info("privilege backend set", "backend", "doas")
 	case "sudo", "":
 		sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendSudo)
+		logger.Info("privilege backend set", "backend", "sudo")
 	default:
 		logger.Warn("unknown POWER_MANAGE_PRIVILEGE_BACKEND, staying on sudo",
 			"value", os.Getenv("POWER_MANAGE_PRIVILEGE_BACKEND"))
+		sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendSudo)
 	}
 
 	// Service manager. Only systemd has a concrete implementation
@@ -97,9 +99,11 @@ func applyBackendOverrides(logger *slog.Logger) {
 		logger.Info("service backend set", "backend", "s6")
 	case "systemd", "":
 		sysservice.SetServiceBackend(sysservice.ServiceBackendSystemd)
+		logger.Info("service backend set", "backend", "systemd")
 	default:
 		logger.Warn("unknown POWER_MANAGE_SERVICE_BACKEND, staying on systemd",
 			"value", os.Getenv("POWER_MANAGE_SERVICE_BACKEND"))
+		sysservice.SetServiceBackend(sysservice.ServiceBackendSystemd)
 	}
 
 	// Disk-encryption tooling. Only LUKS is implemented today.
@@ -112,9 +116,11 @@ func applyBackendOverrides(logger *slog.Logger) {
 		logger.Info("encryption backend set", "backend", "cgd")
 	case "luks", "":
 		sysenc.SetBackend(sysenc.BackendLUKS)
+		logger.Info("encryption backend set", "backend", "luks")
 	default:
 		logger.Warn("unknown POWER_MANAGE_ENCRYPTION_BACKEND, staying on luks",
 			"value", os.Getenv("POWER_MANAGE_ENCRYPTION_BACKEND"))
+		sysenc.SetBackend(sysenc.BackendLUKS)
 	}
 }
 

--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -34,8 +34,10 @@ import (
 	sdk "github.com/manchtools/power-manage/sdk/go"
 	pmcrypto "github.com/manchtools/power-manage/sdk/go/crypto"
 	"github.com/manchtools/power-manage/sdk/go/logging"
-	sysluks "github.com/manchtools/power-manage/sdk/go/sys/luks"
+	sysenc "github.com/manchtools/power-manage/sdk/go/sys/encryption"
+	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
 	"github.com/manchtools/power-manage/sdk/go/sys/osquery"
+	sysservice "github.com/manchtools/power-manage/sdk/go/sys/service"
 	"github.com/manchtools/power-manage/sdk/go/verify"
 
 	"golang.org/x/term"
@@ -59,6 +61,61 @@ const (
 func randomBackoff() time.Duration {
 	jitter := rand.Int64N(int64(maxInitialBackoff - minInitialBackoff))
 	return minInitialBackoff + time.Duration(jitter)
+}
+
+// applyBackendOverrides maps POWER_MANAGE_* env vars onto the SDK's
+// pluggable backend selectors. Called once at startup before any
+// privileged helper runs. Unknown or empty values leave the SDK
+// default in place (sudo / systemd / luks).
+func applyBackendOverrides(logger *slog.Logger) {
+	// Privilege-escalation tool. sudo remains the default because
+	// every mainstream Linux distro ships it; doas is for OpenBSD-
+	// style setups and some BSD-influenced Linux deployments.
+	switch strings.ToLower(os.Getenv("POWER_MANAGE_PRIVILEGE_BACKEND")) {
+	case "doas":
+		sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendDoas)
+		logger.Info("privilege backend set", "backend", "doas")
+	case "sudo", "":
+		sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendSudo)
+	default:
+		logger.Warn("unknown POWER_MANAGE_PRIVILEGE_BACKEND, staying on sudo",
+			"value", os.Getenv("POWER_MANAGE_PRIVILEGE_BACKEND"))
+	}
+
+	// Service manager. Only systemd has a concrete implementation
+	// today; the other backends are scaffolded so the agent picks
+	// up support as the SDK adds it.
+	switch strings.ToLower(os.Getenv("POWER_MANAGE_SERVICE_BACKEND")) {
+	case "openrc":
+		sysservice.SetServiceBackend(sysservice.ServiceBackendOpenRC)
+		logger.Info("service backend set", "backend", "openrc")
+	case "runit":
+		sysservice.SetServiceBackend(sysservice.ServiceBackendRunit)
+		logger.Info("service backend set", "backend", "runit")
+	case "s6":
+		sysservice.SetServiceBackend(sysservice.ServiceBackendS6)
+		logger.Info("service backend set", "backend", "s6")
+	case "systemd", "":
+		sysservice.SetServiceBackend(sysservice.ServiceBackendSystemd)
+	default:
+		logger.Warn("unknown POWER_MANAGE_SERVICE_BACKEND, staying on systemd",
+			"value", os.Getenv("POWER_MANAGE_SERVICE_BACKEND"))
+	}
+
+	// Disk-encryption tooling. Only LUKS is implemented today.
+	switch strings.ToLower(os.Getenv("POWER_MANAGE_ENCRYPTION_BACKEND")) {
+	case "geli":
+		sysenc.SetBackend(sysenc.BackendGELI)
+		logger.Info("encryption backend set", "backend", "geli")
+	case "cgd":
+		sysenc.SetBackend(sysenc.BackendCGD)
+		logger.Info("encryption backend set", "backend", "cgd")
+	case "luks", "":
+		sysenc.SetBackend(sysenc.BackendLUKS)
+	default:
+		logger.Warn("unknown POWER_MANAGE_ENCRYPTION_BACKEND, staying on luks",
+			"value", os.Getenv("POWER_MANAGE_ENCRYPTION_BACKEND"))
+	}
 }
 
 // Config holds the agent configuration.
@@ -132,6 +189,13 @@ func main() {
 	logger := logging.SetupLogger(cfg.LogLevel, cfg.LogFormat, os.Stdout)
 	slog.SetDefault(logger)
 	logger.Info("logger initialized", "level", cfg.LogLevel, "format", cfg.LogFormat)
+
+	// Select SDK pluggable backends BEFORE any privileged call fires.
+	// Defaults stay at sudo / systemd / luks so every existing
+	// Linux-systemd-sudo deployment continues working with no
+	// configuration; operators on OpenBSD-style doas or OpenRC-flavoured
+	// systems flip the backend once via env var.
+	applyBackendOverrides(logger)
 
 	// Clean up stale update state from a previous cycle (if any).
 	executor.CheckStartupUpdateState(cfg.DataDir, logger)
@@ -1192,14 +1256,14 @@ func runLuksSetPassphrase(token, dataDir string) {
 	}
 
 	// Map proto complexity to SDK complexity
-	var complexity sysluks.Complexity
+	var complexity sysenc.Complexity
 	switch result.Complexity {
 	case pm.LpsPasswordComplexity_LPS_PASSWORD_COMPLEXITY_ALPHANUMERIC:
-		complexity = sysluks.ComplexityAlphanumeric
+		complexity = sysenc.ComplexityAlphanumeric
 	case pm.LpsPasswordComplexity_LPS_PASSWORD_COMPLEXITY_COMPLEX:
-		complexity = sysluks.ComplexityComplex
+		complexity = sysenc.ComplexityComplex
 	default:
-		complexity = sysluks.ComplexityNone
+		complexity = sysenc.ComplexityNone
 	}
 
 	minLength := int(result.MinLength)
@@ -1253,7 +1317,7 @@ func runLuksSetPassphrase(token, dataDir string) {
 		candidate := string(pw1)
 
 		// Validate complexity
-		if validationErr := sysluks.ValidatePassphrase(candidate, minLength, complexity); validationErr != "" {
+		if validationErr := sysenc.ValidatePassphrase(candidate, minLength, complexity); validationErr != "" {
 			if remaining > 0 {
 				fmt.Printf("%s %d attempt(s) remaining.\n", validationErr, remaining)
 			}
@@ -1261,7 +1325,7 @@ func runLuksSetPassphrase(token, dataDir string) {
 		}
 
 		// Check reuse
-		if sysluks.IsRecentlyUsed(candidate, recentHashes) {
+		if sysenc.IsRecentlyUsed(candidate, recentHashes) {
 			if remaining > 0 {
 				fmt.Printf("This passphrase was used recently. Choose a different one. %d attempt(s) remaining.\n", remaining)
 			}
@@ -1311,12 +1375,12 @@ func runLuksSetPassphrase(token, dataDir string) {
 		fmt.Println("Revoking current device-bound key...")
 		switch localState.DeviceKeyType {
 		case "tpm":
-			if err := sysluks.WipeTPM(ctx, devicePath, managedKey); err != nil {
+			if err := sysenc.WipeTPM(ctx, devicePath, managedKey); err != nil {
 				fmt.Fprintf(os.Stderr, "error: failed to wipe TPM key: %v\n", err)
 				os.Exit(1)
 			}
 		case "user_passphrase":
-			if err := sysluks.KillSlot(ctx, devicePath, 7, managedKey); err != nil {
+			if err := sysenc.KillSlot(ctx, devicePath, 7, managedKey); err != nil {
 				fmt.Fprintf(os.Stderr, "error: failed to remove existing passphrase: %v\n", err)
 				os.Exit(1)
 			}
@@ -1325,7 +1389,7 @@ func runLuksSetPassphrase(token, dataDir string) {
 
 	// Add user passphrase to slot 7
 	fmt.Println("Setting LUKS passphrase...")
-	if err := sysluks.AddKeyToSlot(ctx, devicePath, 7, managedKey, passphrase); err != nil {
+	if err := sysenc.AddKeyToSlot(ctx, devicePath, 7, managedKey, passphrase); err != nil {
 		fmt.Fprintf(os.Stderr, "error: failed to set passphrase: %v\nManaged key may have been rotated.\n", err)
 		os.Exit(1)
 	}
@@ -1334,7 +1398,7 @@ func runLuksSetPassphrase(token, dataDir string) {
 	agentStore.SetLuksDeviceKeyType(result.ActionID, "user_passphrase")
 
 	// Store passphrase hash for reuse prevention (keeps last 3)
-	agentStore.AddLuksPassphraseHash(result.ActionID, sysluks.HashPassphrase(passphrase))
+	agentStore.AddLuksPassphraseHash(result.ActionID, sysenc.HashPassphrase(passphrase))
 
 	fmt.Println("LUKS passphrase set successfully.")
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25
 require (
 	connectrpc.com/connect v1.18.1
 	github.com/go-playground/validator/v10 v10.30.1
-	github.com/manchtools/power-manage/sdk v0.1.0
+	github.com/manchtools/power-manage/sdk v0.2.0
 	github.com/pressly/goose/v3 v3.26.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.11.1
@@ -21,7 +21,7 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see agent/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.1.1-0.20260418095439-7209ded0c948
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.2.0
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.1.1-0.20260418095439-7209ded0c948 h1:vHDKLAwc7huCSCShhfhYg8KziGsAhOPUuSxtD0bABg8=
-github.com/manchtools/power-manage-sdk v0.1.1-0.20260418095439-7209ded0c948/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.2.0 h1:M28+5EmjAI33xmeLEAYkw2/9XAQT7t744iP76L+HC9c=
+github.com/manchtools/power-manage-sdk v0.2.0/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/executor/cmd.go
+++ b/internal/executor/cmd.go
@@ -47,13 +47,13 @@ func runCmdWithStdin(ctx context.Context, stdin io.Reader, name string, args ...
 
 // runSudoCmd wraps a command with sudo for privileged operations.
 func runSudoCmd(ctx context.Context, name string, args ...string) (*pb.CommandOutput, error) {
-	r, err := sysexec.Sudo(ctx, name, args...)
+	r, err := sysexec.Privileged(ctx, name, args...)
 	return toOutput(r), err
 }
 
 // runSudoCmdWithStdin wraps a command with sudo and provides stdin input.
 func runSudoCmdWithStdin(ctx context.Context, stdin io.Reader, name string, args ...string) (*pb.CommandOutput, error) {
-	r, err := sysexec.SudoWithStdin(ctx, stdin, name, args...)
+	r, err := sysexec.PrivilegedWithStdin(ctx, stdin, name, args...)
 	return toOutput(r), err
 }
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -29,7 +29,7 @@ import (
 	sysfs "github.com/manchtools/power-manage/sdk/go/sys/fs"
 	sysnotify "github.com/manchtools/power-manage/sdk/go/sys/notify"
 	sysreboot "github.com/manchtools/power-manage/sdk/go/sys/reboot"
-	syssystemd "github.com/manchtools/power-manage/sdk/go/sys/systemd"
+	sysservice "github.com/manchtools/power-manage/sdk/go/sys/service"
 	sysuser "github.com/manchtools/power-manage/sdk/go/sys/user"
 	"github.com/manchtools/power-manage/sdk/go/verify"
 )
@@ -204,9 +204,9 @@ func (e *Executor) ExecuteWithStreaming(ctx context.Context, action *pb.Action, 
 		if action.GetShell().GetIsCompliance() {
 			result.Compliant = detectionOutput != nil && detectionOutput.ExitCode == 0 && execErr == nil
 		}
-	case pb.ActionType_ACTION_TYPE_SYSTEMD:
+	case pb.ActionType_ACTION_TYPE_SERVICE:
 		var changed bool
-		output, changed, execErr = e.executeSystemd(ctx, action.GetSystemd())
+		output, changed, execErr = e.executeSystemd(ctx, action.GetService())
 		result.Changed = changed
 	case pb.ActionType_ACTION_TYPE_FILE:
 		var changed bool
@@ -240,9 +240,9 @@ func (e *Executor) ExecuteWithStreaming(ctx context.Context, action *pb.Action, 
 		var changed bool
 		output, changed, execErr = e.executeSshd(ctx, action.GetSshd(), action.DesiredState, getActionID(action))
 		result.Changed = changed
-	case pb.ActionType_ACTION_TYPE_SUDO:
+	case pb.ActionType_ACTION_TYPE_ADMIN_POLICY:
 		var changed bool
-		output, changed, execErr = e.executeSudo(ctx, action.GetSudo(), action.DesiredState, getActionID(action))
+		output, changed, execErr = e.executeSudo(ctx, action.GetAdminPolicy(), action.DesiredState, getActionID(action))
 		result.Changed = changed
 	case pb.ActionType_ACTION_TYPE_LPS:
 		var changed bool
@@ -252,10 +252,10 @@ func (e *Executor) ExecuteWithStreaming(ctx context.Context, action *pb.Action, 
 		if len(metadata) > 0 {
 			result.Metadata = metadata
 		}
-	case pb.ActionType_ACTION_TYPE_LUKS:
+	case pb.ActionType_ACTION_TYPE_ENCRYPTION:
 		var changed bool
 		var metadata map[string]string
-		output, changed, metadata, execErr = e.executeLuks(ctx, action.GetLuks(), action.DesiredState, getActionID(action))
+		output, changed, metadata, execErr = e.executeLuks(ctx, action.GetEncryption(), action.DesiredState, getActionID(action))
 		result.Changed = changed
 		if len(metadata) > 0 {
 			result.Metadata = metadata
@@ -938,7 +938,7 @@ func (e *Executor) executeShellStreaming(ctx context.Context, params *pb.ShellPa
 	return execOutput, verifyOutput, true, nil
 }
 
-func (e *Executor) executeSystemd(ctx context.Context, params *pb.SystemdParams) (*pb.CommandOutput, bool, error) {
+func (e *Executor) executeSystemd(ctx context.Context, params *pb.ServiceParams) (*pb.CommandOutput, bool, error) {
 	if params == nil {
 		return nil, false, fmt.Errorf("systemd params required")
 	}
@@ -992,7 +992,7 @@ func (e *Executor) executeSystemd(ctx context.Context, params *pb.SystemdParams)
 			changed = true
 
 			// Reload systemd
-			if err := syssystemd.DaemonReload(ctx); err != nil {
+			if err := sysservice.DaemonReload(ctx); err != nil {
 				return nil, changed, fmt.Errorf("daemon-reload failed: %w", err)
 			}
 			output.WriteString("reloaded systemd daemon\n")
@@ -1006,13 +1006,13 @@ func (e *Executor) executeSystemd(ctx context.Context, params *pb.SystemdParams)
 		if e.isUnitMasked(params.UnitName) {
 			return nil, changed, fmt.Errorf("enable: unit %s is masked (run 'systemctl unmask %s' first)", params.UnitName, params.UnitName)
 		}
-		if err := syssystemd.Enable(ctx, params.UnitName); err != nil {
+		if err := sysservice.Enable(ctx, params.UnitName); err != nil {
 			return nil, changed, fmt.Errorf("enable: %w", err)
 		}
 		output.WriteString("enabled unit\n")
 		changed = true
 	} else if !params.Enable && isEnabled {
-		if err := syssystemd.Disable(ctx, params.UnitName); err != nil {
+		if err := sysservice.Disable(ctx, params.UnitName); err != nil {
 			// Ignore errors for disable (unit might not exist)
 			output.WriteString("disable failed (unit may not exist)\n")
 		} else {
@@ -1024,9 +1024,9 @@ func (e *Executor) executeSystemd(ctx context.Context, params *pb.SystemdParams)
 	// Handle running state
 	isActive := e.isUnitActive(params.UnitName)
 	switch params.DesiredState {
-	case pb.SystemdUnitState_SYSTEMD_UNIT_STATE_STARTED:
+	case pb.ServiceUnitState_SERVICE_UNIT_STATE_STARTED:
 		if !isActive {
-			if err := syssystemd.Start(ctx, params.UnitName); err != nil {
+			if err := sysservice.Start(ctx, params.UnitName); err != nil {
 				return nil, changed, fmt.Errorf("start: %w", err)
 			}
 			output.WriteString("started unit\n")
@@ -1034,9 +1034,9 @@ func (e *Executor) executeSystemd(ctx context.Context, params *pb.SystemdParams)
 		} else {
 			output.WriteString("unit is already running\n")
 		}
-	case pb.SystemdUnitState_SYSTEMD_UNIT_STATE_STOPPED:
+	case pb.ServiceUnitState_SERVICE_UNIT_STATE_STOPPED:
 		if isActive {
-			if err := syssystemd.Stop(ctx, params.UnitName); err != nil {
+			if err := sysservice.Stop(ctx, params.UnitName); err != nil {
 				return nil, changed, fmt.Errorf("stop: %w", err)
 			}
 			output.WriteString("stopped unit\n")
@@ -1044,9 +1044,9 @@ func (e *Executor) executeSystemd(ctx context.Context, params *pb.SystemdParams)
 		} else {
 			output.WriteString("unit is already stopped\n")
 		}
-	case pb.SystemdUnitState_SYSTEMD_UNIT_STATE_RESTARTED:
+	case pb.ServiceUnitState_SERVICE_UNIT_STATE_RESTARTED:
 		// Restart always runs (not idempotent by design)
-		if err := syssystemd.Restart(ctx, params.UnitName); err != nil {
+		if err := sysservice.Restart(ctx, params.UnitName); err != nil {
 			return nil, changed, fmt.Errorf("restart: %w", err)
 		}
 		output.WriteString("restarted unit\n")
@@ -1060,20 +1060,26 @@ func (e *Executor) executeSystemd(ctx context.Context, params *pb.SystemdParams)
 	return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, changed, nil
 }
 
-// isUnitEnabled checks if a systemd unit is enabled or in a state where
-// enabling is not needed (static, indirect, generated units).
+// isUnitEnabled checks if a systemd unit is enabled. The SDK's
+// sysservice.IsEnabled returns (bool, error); callers of this agent
+// helper just want the bool. Any error is logged at the call path
+// that matters (status reporting) rather than here — treating an
+// error as "not enabled" keeps the previous behaviour.
 func (e *Executor) isUnitEnabled(unitName string) bool {
-	return syssystemd.IsEnabled(unitName)
+	enabled, _ := sysservice.IsEnabled(unitName)
+	return enabled
 }
 
 // isUnitMasked checks if a systemd unit is masked.
 func (e *Executor) isUnitMasked(unitName string) bool {
-	return syssystemd.IsMasked(unitName)
+	masked, _ := sysservice.IsMasked(unitName)
+	return masked
 }
 
 // isUnitActive checks if a systemd unit is currently active (running).
 func (e *Executor) isUnitActive(unitName string) bool {
-	return syssystemd.IsActive(unitName)
+	active, _ := sysservice.IsActive(unitName)
+	return active
 }
 
 func (e *Executor) executeFile(ctx context.Context, params *pb.FileParams, state pb.DesiredState) (*pb.CommandOutput, bool, error) {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -940,7 +940,7 @@ func (e *Executor) executeShellStreaming(ctx context.Context, params *pb.ShellPa
 
 func (e *Executor) executeSystemd(ctx context.Context, params *pb.ServiceParams) (*pb.CommandOutput, bool, error) {
 	if params == nil {
-		return nil, false, fmt.Errorf("systemd params required")
+		return nil, false, fmt.Errorf("service params required")
 	}
 
 	// Never allow managing the agent's own service

--- a/internal/executor/integration_test.go
+++ b/internal/executor/integration_test.go
@@ -885,7 +885,7 @@ func TestIntegration_Sudo(t *testing.T) {
 			Id:           &pb.ActionId{Value: actionID},
 			Type:         pb.ActionType_ACTION_TYPE_ADMIN_POLICY,
 			DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
-			Params: &pb.Action_Sudo{Sudo: &pb.AdminPolicyParams{
+			Params: &pb.Action_AdminPolicy{AdminPolicy: &pb.AdminPolicyParams{
 				AccessLevel: pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_FULL,
 				Users:       []string{"pmsudouser"},
 			}},
@@ -910,7 +910,7 @@ func TestIntegration_Sudo(t *testing.T) {
 			Id:           &pb.ActionId{Value: actionID},
 			Type:         pb.ActionType_ACTION_TYPE_ADMIN_POLICY,
 			DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
-			Params: &pb.Action_Sudo{Sudo: &pb.AdminPolicyParams{
+			Params: &pb.Action_AdminPolicy{AdminPolicy: &pb.AdminPolicyParams{
 				AccessLevel: pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_FULL,
 				Users:       []string{"pmsudouser"},
 			}},
@@ -925,7 +925,7 @@ func TestIntegration_Sudo(t *testing.T) {
 			Id:           &pb.ActionId{Value: actionID},
 			Type:         pb.ActionType_ACTION_TYPE_ADMIN_POLICY,
 			DesiredState: pb.DesiredState_DESIRED_STATE_ABSENT,
-			Params: &pb.Action_Sudo{Sudo: &pb.AdminPolicyParams{
+			Params: &pb.Action_AdminPolicy{AdminPolicy: &pb.AdminPolicyParams{
 				AccessLevel: pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_FULL,
 				Users:       []string{"pmsudouser"},
 			}},
@@ -1096,7 +1096,7 @@ func TestIntegration_Systemd(t *testing.T) {
 
 	t.Run("ProtectAgent", func(t *testing.T) {
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_SERVICE, pb.DesiredState_DESIRED_STATE_PRESENT)
-		action.Params = &pb.Action_Systemd{Systemd: &pb.ServiceParams{
+		action.Params = &pb.Action_Service{Service: &pb.ServiceParams{
 			UnitName:     "power-manage-agent",
 			DesiredState: pb.ServiceUnitState_SERVICE_UNIT_STATE_STOPPED,
 		}}
@@ -1119,7 +1119,7 @@ WantedBy=multi-user.target
 		t.Cleanup(func() { sudoRemove(unitPath) })
 
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_SERVICE, pb.DesiredState_DESIRED_STATE_PRESENT)
-		action.Params = &pb.Action_Systemd{Systemd: &pb.ServiceParams{
+		action.Params = &pb.Action_Service{Service: &pb.ServiceParams{
 			UnitName:    unitName,
 			UnitContent: unitContent,
 		}}
@@ -2105,7 +2105,7 @@ func TestIntegration_EdgeCase_MissingSudoersDir(t *testing.T) {
 		Id:           &pb.ActionId{Value: actionID},
 		Type:         pb.ActionType_ACTION_TYPE_ADMIN_POLICY,
 		DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
-		Params: &pb.Action_Sudo{Sudo: &pb.AdminPolicyParams{
+		Params: &pb.Action_AdminPolicy{AdminPolicy: &pb.AdminPolicyParams{
 			AccessLevel: pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_FULL,
 			Users:       []string{"pmsudoedge"},
 		}},
@@ -3035,7 +3035,7 @@ func TestIntegration_EdgeCase_BrokenSudoersFile(t *testing.T) {
 		Id:           &pb.ActionId{Value: actionID},
 		Type:         pb.ActionType_ACTION_TYPE_ADMIN_POLICY,
 		DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
-		Params: &pb.Action_Sudo{Sudo: &pb.AdminPolicyParams{
+		Params: &pb.Action_AdminPolicy{AdminPolicy: &pb.AdminPolicyParams{
 			AccessLevel: pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_FULL,
 			Users:       []string{"pmedgesudo"},
 		}},
@@ -3235,7 +3235,7 @@ func TestIntegration_EdgeCase_SystemdInvalidUnit(t *testing.T) {
 	t.Run("InvalidSyntax", func(t *testing.T) {
 		// Unit file with completely invalid content
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_SERVICE, pb.DesiredState_DESIRED_STATE_PRESENT)
-		action.Params = &pb.Action_Systemd{Systemd: &pb.ServiceParams{
+		action.Params = &pb.Action_Service{Service: &pb.ServiceParams{
 			UnitName:    unitName,
 			UnitContent: "THIS IS NOT VALID SYSTEMD UNIT CONTENT\n[[[invalid\n",
 		}}
@@ -3254,7 +3254,7 @@ func TestIntegration_EdgeCase_SystemdInvalidUnit(t *testing.T) {
 	t.Run("EmptyUnitContent", func(t *testing.T) {
 		// Empty unit content — executor should still write it
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_SERVICE, pb.DesiredState_DESIRED_STATE_PRESENT)
-		action.Params = &pb.Action_Systemd{Systemd: &pb.ServiceParams{
+		action.Params = &pb.Action_Service{Service: &pb.ServiceParams{
 			UnitName:    unitName,
 			UnitContent: "",
 		}}

--- a/internal/executor/integration_test.go
+++ b/internal/executor/integration_test.go
@@ -883,10 +883,10 @@ func TestIntegration_Sudo(t *testing.T) {
 	t.Run("SetupFullAccess", func(t *testing.T) {
 		action := &pb.Action{
 			Id:           &pb.ActionId{Value: actionID},
-			Type:         pb.ActionType_ACTION_TYPE_SUDO,
+			Type:         pb.ActionType_ACTION_TYPE_ADMIN_POLICY,
 			DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
-			Params: &pb.Action_Sudo{Sudo: &pb.SudoParams{
-				AccessLevel: pb.SudoAccessLevel_SUDO_ACCESS_LEVEL_FULL,
+			Params: &pb.Action_Sudo{Sudo: &pb.AdminPolicyParams{
+				AccessLevel: pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_FULL,
 				Users:       []string{"pmsudouser"},
 			}},
 		}
@@ -908,10 +908,10 @@ func TestIntegration_Sudo(t *testing.T) {
 	t.Run("SetupIdempotent", func(t *testing.T) {
 		action := &pb.Action{
 			Id:           &pb.ActionId{Value: actionID},
-			Type:         pb.ActionType_ACTION_TYPE_SUDO,
+			Type:         pb.ActionType_ACTION_TYPE_ADMIN_POLICY,
 			DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
-			Params: &pb.Action_Sudo{Sudo: &pb.SudoParams{
-				AccessLevel: pb.SudoAccessLevel_SUDO_ACCESS_LEVEL_FULL,
+			Params: &pb.Action_Sudo{Sudo: &pb.AdminPolicyParams{
+				AccessLevel: pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_FULL,
 				Users:       []string{"pmsudouser"},
 			}},
 		}
@@ -923,10 +923,10 @@ func TestIntegration_Sudo(t *testing.T) {
 	t.Run("Remove", func(t *testing.T) {
 		action := &pb.Action{
 			Id:           &pb.ActionId{Value: actionID},
-			Type:         pb.ActionType_ACTION_TYPE_SUDO,
+			Type:         pb.ActionType_ACTION_TYPE_ADMIN_POLICY,
 			DesiredState: pb.DesiredState_DESIRED_STATE_ABSENT,
-			Params: &pb.Action_Sudo{Sudo: &pb.SudoParams{
-				AccessLevel: pb.SudoAccessLevel_SUDO_ACCESS_LEVEL_FULL,
+			Params: &pb.Action_Sudo{Sudo: &pb.AdminPolicyParams{
+				AccessLevel: pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_FULL,
 				Users:       []string{"pmsudouser"},
 			}},
 		}
@@ -1095,10 +1095,10 @@ func TestIntegration_Systemd(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("ProtectAgent", func(t *testing.T) {
-		action := makeAction(t, pb.ActionType_ACTION_TYPE_SYSTEMD, pb.DesiredState_DESIRED_STATE_PRESENT)
-		action.Params = &pb.Action_Systemd{Systemd: &pb.SystemdParams{
+		action := makeAction(t, pb.ActionType_ACTION_TYPE_SERVICE, pb.DesiredState_DESIRED_STATE_PRESENT)
+		action.Params = &pb.Action_Systemd{Systemd: &pb.ServiceParams{
 			UnitName:     "power-manage-agent",
-			DesiredState: pb.SystemdUnitState_SYSTEMD_UNIT_STATE_STOPPED,
+			DesiredState: pb.ServiceUnitState_SERVICE_UNIT_STATE_STOPPED,
 		}}
 		result := e.Execute(ctx, action)
 		assertFailed(t, result)
@@ -1118,8 +1118,8 @@ WantedBy=multi-user.target
 		unitPath := "/etc/systemd/system/" + unitName
 		t.Cleanup(func() { sudoRemove(unitPath) })
 
-		action := makeAction(t, pb.ActionType_ACTION_TYPE_SYSTEMD, pb.DesiredState_DESIRED_STATE_PRESENT)
-		action.Params = &pb.Action_Systemd{Systemd: &pb.SystemdParams{
+		action := makeAction(t, pb.ActionType_ACTION_TYPE_SERVICE, pb.DesiredState_DESIRED_STATE_PRESENT)
+		action.Params = &pb.Action_Systemd{Systemd: &pb.ServiceParams{
 			UnitName:    unitName,
 			UnitContent: unitContent,
 		}}
@@ -2103,10 +2103,10 @@ func TestIntegration_EdgeCase_MissingSudoersDir(t *testing.T) {
 
 	action := &pb.Action{
 		Id:           &pb.ActionId{Value: actionID},
-		Type:         pb.ActionType_ACTION_TYPE_SUDO,
+		Type:         pb.ActionType_ACTION_TYPE_ADMIN_POLICY,
 		DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
-		Params: &pb.Action_Sudo{Sudo: &pb.SudoParams{
-			AccessLevel: pb.SudoAccessLevel_SUDO_ACCESS_LEVEL_FULL,
+		Params: &pb.Action_Sudo{Sudo: &pb.AdminPolicyParams{
+			AccessLevel: pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_FULL,
 			Users:       []string{"pmsudoedge"},
 		}},
 	}
@@ -2329,10 +2329,10 @@ func TestIntegration_EdgeCase_NilParams(t *testing.T) {
 		{"DEB", pb.ActionType_ACTION_TYPE_DEB},
 		{"User", pb.ActionType_ACTION_TYPE_USER},
 		{"Group", pb.ActionType_ACTION_TYPE_GROUP},
-		{"Sudo", pb.ActionType_ACTION_TYPE_SUDO},
+		{"Sudo", pb.ActionType_ACTION_TYPE_ADMIN_POLICY},
 		{"SSH", pb.ActionType_ACTION_TYPE_SSH},
 		{"SSHD", pb.ActionType_ACTION_TYPE_SSHD},
-		{"Systemd", pb.ActionType_ACTION_TYPE_SYSTEMD},
+		{"Systemd", pb.ActionType_ACTION_TYPE_SERVICE},
 		{"Repository", pb.ActionType_ACTION_TYPE_REPOSITORY},
 	}
 
@@ -3033,10 +3033,10 @@ func TestIntegration_EdgeCase_BrokenSudoersFile(t *testing.T) {
 	// The executor should still be able to write its own valid sudoers file
 	action := &pb.Action{
 		Id:           &pb.ActionId{Value: actionID},
-		Type:         pb.ActionType_ACTION_TYPE_SUDO,
+		Type:         pb.ActionType_ACTION_TYPE_ADMIN_POLICY,
 		DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
-		Params: &pb.Action_Sudo{Sudo: &pb.SudoParams{
-			AccessLevel: pb.SudoAccessLevel_SUDO_ACCESS_LEVEL_FULL,
+		Params: &pb.Action_Sudo{Sudo: &pb.AdminPolicyParams{
+			AccessLevel: pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_FULL,
 			Users:       []string{"pmedgesudo"},
 		}},
 	}
@@ -3234,8 +3234,8 @@ func TestIntegration_EdgeCase_SystemdInvalidUnit(t *testing.T) {
 
 	t.Run("InvalidSyntax", func(t *testing.T) {
 		// Unit file with completely invalid content
-		action := makeAction(t, pb.ActionType_ACTION_TYPE_SYSTEMD, pb.DesiredState_DESIRED_STATE_PRESENT)
-		action.Params = &pb.Action_Systemd{Systemd: &pb.SystemdParams{
+		action := makeAction(t, pb.ActionType_ACTION_TYPE_SERVICE, pb.DesiredState_DESIRED_STATE_PRESENT)
+		action.Params = &pb.Action_Systemd{Systemd: &pb.ServiceParams{
 			UnitName:    unitName,
 			UnitContent: "THIS IS NOT VALID SYSTEMD UNIT CONTENT\n[[[invalid\n",
 		}}
@@ -3253,8 +3253,8 @@ func TestIntegration_EdgeCase_SystemdInvalidUnit(t *testing.T) {
 
 	t.Run("EmptyUnitContent", func(t *testing.T) {
 		// Empty unit content — executor should still write it
-		action := makeAction(t, pb.ActionType_ACTION_TYPE_SYSTEMD, pb.DesiredState_DESIRED_STATE_PRESENT)
-		action.Params = &pb.Action_Systemd{Systemd: &pb.SystemdParams{
+		action := makeAction(t, pb.ActionType_ACTION_TYPE_SERVICE, pb.DesiredState_DESIRED_STATE_PRESENT)
+		action.Params = &pb.Action_Systemd{Systemd: &pb.ServiceParams{
 			UnitName:    unitName,
 			UnitContent: "",
 		}}

--- a/internal/executor/luks.go
+++ b/internal/executor/luks.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
-	sysluks "github.com/manchtools/power-manage/sdk/go/sys/luks"
+	sysenc "github.com/manchtools/power-manage/sdk/go/sys/encryption"
 
 	"github.com/manchtools/power-manage/agent/internal/store"
 )
@@ -19,7 +19,7 @@ type LuksKeyStore interface {
 }
 
 // executeLuks manages LUKS disk encryption.
-func (e *Executor) executeLuks(ctx context.Context, params *pb.LuksParams, state pb.DesiredState, actionID string) (*pb.CommandOutput, bool, map[string]string, error) {
+func (e *Executor) executeLuks(ctx context.Context, params *pb.EncryptionParams, state pb.DesiredState, actionID string) (*pb.CommandOutput, bool, map[string]string, error) {
 	if params == nil {
 		return nil, false, nil, fmt.Errorf("luks params required")
 	}
@@ -59,7 +59,7 @@ func (e *Executor) removeLuksManagement(actionID string) (*pb.CommandOutput, boo
 }
 
 // setupLuks handles PRESENT state — detect volume, check conflicts, take ownership, rotate, reconcile device key.
-func (e *Executor) setupLuks(ctx context.Context, params *pb.LuksParams, actionID string) (*pb.CommandOutput, bool, map[string]string, error) {
+func (e *Executor) setupLuks(ctx context.Context, params *pb.EncryptionParams, actionID string) (*pb.CommandOutput, bool, map[string]string, error) {
 	var output strings.Builder
 
 	// Load local state
@@ -70,7 +70,7 @@ func (e *Executor) setupLuks(ctx context.Context, params *pb.LuksParams, actionI
 	if localState != nil && localState.OwnershipTaken && localState.DevicePath != "" {
 		// Subsequent run — use stored device path
 		devicePath = localState.DevicePath
-		isLuks, err := sysluks.IsLuks(ctx, devicePath)
+		isLuks, err := sysenc.IsLuks(ctx, devicePath)
 		if err != nil {
 			return nil, false, nil, fmt.Errorf("failed to check LUKS status: %w", err)
 		}
@@ -80,10 +80,10 @@ func (e *Executor) setupLuks(ctx context.Context, params *pb.LuksParams, actionI
 		output.WriteString(fmt.Sprintf("LUKS: managing volume %s\n", devicePath))
 	} else {
 		// First run — detect volume by PSK
-		vol, err := sysluks.DetectVolumeByKey(ctx, params.PresharedKey)
+		vol, err := sysenc.DetectVolumeByKey(ctx, params.PresharedKey)
 		if err != nil {
 			// Fall back to heuristic detection (PSK may have been removed by a partial prior run)
-			vol, err = sysluks.DetectVolume(ctx)
+			vol, err = sysenc.DetectVolume(ctx)
 			if err != nil {
 				return nil, false, nil, fmt.Errorf("no LUKS-encrypted volumes detected on this device")
 			}
@@ -168,13 +168,13 @@ func (e *Executor) setupLuks(ctx context.Context, params *pb.LuksParams, actionI
 // Server-confirmed: the old key is only removed after the server confirms receipt of the new key.
 // If the server already has a working key (e.g. from a previous run with lost local state),
 // ownership is recovered without re-using the PSK.
-func (e *Executor) takeOwnership(ctx context.Context, params *pb.LuksParams, actionID, devicePath string) error {
+func (e *Executor) takeOwnership(ctx context.Context, params *pb.EncryptionParams, actionID, devicePath string) error {
 	// Recovery: check if server already has a key for this action (state loss recovery).
 	existingKey, getKeyErr := e.luksKeyStore.GetKey(ctx, actionID)
 	if getKeyErr == nil && existingKey != "" {
 		e.logger.Info("LUKS: server has stored key, testing against volume",
 			"action_id", actionID, "key_len", len(existingKey))
-		ok, testErr := sysluks.TestPassphrase(ctx, devicePath, existingKey)
+		ok, testErr := sysenc.TestPassphrase(ctx, devicePath, existingKey)
 		e.logger.Info("LUKS: test-passphrase result", "ok", ok, "error", testErr)
 		if testErr == nil && ok {
 			e.logger.Info("LUKS: recovered ownership from server-stored key", "action_id", actionID)
@@ -195,7 +195,7 @@ func (e *Executor) takeOwnership(ctx context.Context, params *pb.LuksParams, act
 	}
 
 	// Generate managed passphrase
-	passphrase, err := sysluks.GeneratePassphrase(minWords)
+	passphrase, err := sysenc.GeneratePassphrase(minWords)
 	if err != nil {
 		return fmt.Errorf("generate passphrase: %w", err)
 	}
@@ -204,14 +204,14 @@ func (e *Executor) takeOwnership(ctx context.Context, params *pb.LuksParams, act
 	e.logger.Info("LUKS: adding managed key using PSK",
 		"psk_len", len(params.PresharedKey),
 		"new_key_len", len(passphrase))
-	if err := sysluks.AddKey(ctx, devicePath, params.PresharedKey, passphrase); err != nil {
+	if err := sysenc.AddKey(ctx, devicePath, params.PresharedKey, passphrase); err != nil {
 		return fmt.Errorf("add managed key: %w", err)
 	}
 
 	// Store on server — must succeed before removing PSK
 	if err := e.luksKeyStore.StoreKey(ctx, actionID, devicePath, passphrase, "initial"); err != nil {
 		// Rollback: remove the managed key we just added
-		sysluks.RemoveKey(ctx, devicePath, passphrase)
+		sysenc.RemoveKey(ctx, devicePath, passphrase)
 		return fmt.Errorf("store key on server: %w", err)
 	}
 
@@ -223,7 +223,7 @@ func (e *Executor) takeOwnership(ctx context.Context, params *pb.LuksParams, act
 	}
 
 	// Verified — now safe to remove PSK
-	if err := sysluks.RemoveKey(ctx, devicePath, params.PresharedKey); err != nil {
+	if err := sysenc.RemoveKey(ctx, devicePath, params.PresharedKey); err != nil {
 		e.logger.Warn("failed to remove PSK after ownership (both keys work)", "error", err)
 	}
 
@@ -232,7 +232,7 @@ func (e *Executor) takeOwnership(ctx context.Context, params *pb.LuksParams, act
 }
 
 // checkAndRotate checks if a rotation is due and rotates the managed passphrase if needed.
-func (e *Executor) checkAndRotate(ctx context.Context, params *pb.LuksParams, localState *store.LuksState, actionID, devicePath string) (bool, error) {
+func (e *Executor) checkAndRotate(ctx context.Context, params *pb.EncryptionParams, localState *store.LuksState, actionID, devicePath string) (bool, error) {
 	// Check if rotation interval has elapsed
 	if params.RotationIntervalDays > 0 {
 		// No previous rotation recorded — set the timestamp and skip.
@@ -258,20 +258,20 @@ func (e *Executor) checkAndRotate(ctx context.Context, params *pb.LuksParams, lo
 	}
 
 	// Generate new passphrase
-	newPassphrase, err := sysluks.GeneratePassphrase(minWords)
+	newPassphrase, err := sysenc.GeneratePassphrase(minWords)
 	if err != nil {
 		return false, fmt.Errorf("generate passphrase: %w", err)
 	}
 
 	// Add new key using old key (both valid)
-	if err := sysluks.AddKey(ctx, devicePath, currentKey, newPassphrase); err != nil {
+	if err := sysenc.AddKey(ctx, devicePath, currentKey, newPassphrase); err != nil {
 		return false, fmt.Errorf("add new key: %w", err)
 	}
 
 	// Store on server — must succeed before removing old key
 	if err := e.luksKeyStore.StoreKey(ctx, actionID, devicePath, newPassphrase, "scheduled"); err != nil {
 		// Rollback: remove the new key we just added
-		sysluks.RemoveKey(ctx, devicePath, newPassphrase)
+		sysenc.RemoveKey(ctx, devicePath, newPassphrase)
 		return false, fmt.Errorf("store new key on server: %w", err)
 	}
 
@@ -282,7 +282,7 @@ func (e *Executor) checkAndRotate(ctx context.Context, params *pb.LuksParams, lo
 	}
 
 	// Verified — now safe to remove old key
-	if err := sysluks.RemoveKey(ctx, devicePath, currentKey); err != nil {
+	if err := sysenc.RemoveKey(ctx, devicePath, currentKey); err != nil {
 		e.logger.Warn("failed to remove old key after rotation (both keys work)", "error", err)
 	}
 
@@ -295,13 +295,13 @@ func (e *Executor) checkAndRotate(ctx context.Context, params *pb.LuksParams, lo
 }
 
 // reconcileDeviceKey ensures LUKS slot 7 matches the desired device_bound_key_type.
-func (e *Executor) reconcileDeviceKey(ctx context.Context, params *pb.LuksParams, localState *store.LuksState, actionID, devicePath string) (bool, error) {
+func (e *Executor) reconcileDeviceKey(ctx context.Context, params *pb.EncryptionParams, localState *store.LuksState, actionID, devicePath string) (bool, error) {
 	currentType := localState.DeviceKeyType
 	desiredType := "none"
 	switch params.DeviceBoundKeyType {
-	case pb.LuksDeviceBoundKeyType_LUKS_DEVICE_BOUND_KEY_TYPE_TPM:
+	case pb.EncryptionDeviceBoundKeyType_ENCRYPTION_DEVICE_BOUND_KEY_TYPE_TPM:
 		desiredType = "tpm"
-	case pb.LuksDeviceBoundKeyType_LUKS_DEVICE_BOUND_KEY_TYPE_USER_PASSPHRASE:
+	case pb.EncryptionDeviceBoundKeyType_ENCRYPTION_DEVICE_BOUND_KEY_TYPE_USER_PASSPHRASE:
 		desiredType = "user_passphrase"
 	}
 
@@ -329,7 +329,7 @@ func (e *Executor) reconcileDeviceKey(ctx context.Context, params *pb.LuksParams
 
 // enrollTpm enrolls a TPM2 key for the LUKS volume.
 func (e *Executor) enrollTpm(ctx context.Context, actionID, devicePath string) error {
-	hasTPM, err := sysluks.HasTPM2(ctx)
+	hasTPM, err := sysenc.HasTPM2(ctx)
 	if err != nil {
 		return fmt.Errorf("check TPM2: %w", err)
 	}
@@ -342,7 +342,7 @@ func (e *Executor) enrollTpm(ctx context.Context, actionID, devicePath string) e
 		return fmt.Errorf("get managed key: %w", err)
 	}
 
-	if err := sysluks.EnrollTPM(ctx, devicePath, managedKey); err != nil {
+	if err := sysenc.EnrollTPM(ctx, devicePath, managedKey); err != nil {
 		return err
 	}
 
@@ -358,11 +358,11 @@ func (e *Executor) revokeDeviceKeyInternal(ctx context.Context, localState *stor
 
 	switch localState.DeviceKeyType {
 	case "tpm":
-		if err := sysluks.WipeTPM(ctx, localState.DevicePath, managedKey); err != nil {
+		if err := sysenc.WipeTPM(ctx, localState.DevicePath, managedKey); err != nil {
 			return err
 		}
 	case "user_passphrase":
-		if err := sysluks.KillSlot(ctx, localState.DevicePath, 7, managedKey); err != nil {
+		if err := sysenc.KillSlot(ctx, localState.DevicePath, 7, managedKey); err != nil {
 			return err
 		}
 	case "none":
@@ -413,13 +413,13 @@ func (e *Executor) resolveLuksConflict(actionID string) (string, error) {
 
 	var candidates []luksCandidate
 	for _, sa := range stored {
-		if sa.Action.Type != pb.ActionType_ACTION_TYPE_LUKS {
+		if sa.Action.Type != pb.ActionType_ACTION_TYPE_ENCRYPTION {
 			continue
 		}
 		if sa.Action.DesiredState == pb.DesiredState_DESIRED_STATE_ABSENT {
 			continue
 		}
-		params := sa.Action.GetLuks()
+		params := sa.Action.GetEncryption()
 		if params == nil {
 			continue
 		}
@@ -491,7 +491,7 @@ func (e *Executor) verifyKeyRoundTrip(ctx context.Context, actionID, devicePath,
 		}
 
 		// Defense-in-depth: verify the key actually unlocks the volume.
-		ok, testErr := sysluks.TestPassphrase(ctx, devicePath, storedKey)
+		ok, testErr := sysenc.TestPassphrase(ctx, devicePath, storedKey)
 		if testErr != nil || !ok {
 			return fmt.Errorf("server-stored key does not unlock volume (test_ok=%v, err=%v)", ok, testErr)
 		}

--- a/internal/executor/sudo.go
+++ b/internal/executor/sudo.go
@@ -25,7 +25,7 @@ func sudoersFilePath(actionID string) string {
 }
 
 // executeSudo manages sudoers policies via /etc/sudoers.d/ drop-in files.
-func (e *Executor) executeSudo(ctx context.Context, params *pb.SudoParams, state pb.DesiredState, actionID string) (*pb.CommandOutput, bool, error) {
+func (e *Executor) executeSudo(ctx context.Context, params *pb.AdminPolicyParams, state pb.DesiredState, actionID string) (*pb.CommandOutput, bool, error) {
 	if params == nil {
 		return nil, false, fmt.Errorf("sudo params required")
 	}
@@ -45,7 +45,7 @@ func (e *Executor) executeSudo(ctx context.Context, params *pb.SudoParams, state
 }
 
 // setupSudoPolicy creates or updates a sudo policy: group, sudoers file, and user membership.
-func (e *Executor) setupSudoPolicy(ctx context.Context, params *pb.SudoParams, groupName, sudoersPath string) (*pb.CommandOutput, bool, error) {
+func (e *Executor) setupSudoPolicy(ctx context.Context, params *pb.AdminPolicyParams, groupName, sudoersPath string) (*pb.CommandOutput, bool, error) {
 	var output strings.Builder
 	changed := false
 
@@ -59,11 +59,11 @@ func (e *Executor) setupSudoPolicy(ctx context.Context, params *pb.SudoParams, g
 	// Generate sudoers content
 	var content string
 	switch params.AccessLevel {
-	case pb.SudoAccessLevel_SUDO_ACCESS_LEVEL_FULL:
+	case pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_FULL:
 		content = generateFullSudoConfig(groupName)
-	case pb.SudoAccessLevel_SUDO_ACCESS_LEVEL_LIMITED:
+	case pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_LIMITED:
 		content = generateLimitedSudoConfig(groupName)
-	case pb.SudoAccessLevel_SUDO_ACCESS_LEVEL_CUSTOM:
+	case pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_CUSTOM:
 		if params.CustomConfig == "" {
 			return nil, false, fmt.Errorf("custom_config is required when access_level is CUSTOM")
 		}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -436,7 +436,7 @@ func shouldRevertOnUnassign(actionType pb.ActionType) bool {
 	switch actionType {
 	case pb.ActionType_ACTION_TYPE_SSH,
 		pb.ActionType_ACTION_TYPE_SSHD,
-		pb.ActionType_ACTION_TYPE_SUDO,
+		pb.ActionType_ACTION_TYPE_ADMIN_POLICY,
 		pb.ActionType_ACTION_TYPE_LPS,
 		pb.ActionType_ACTION_TYPE_USER,
 		pb.ActionType_ACTION_TYPE_GROUP:

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -73,7 +73,7 @@ func TestShouldRevertOnUnassign(t *testing.T) {
 	revertible := []pb.ActionType{
 		pb.ActionType_ACTION_TYPE_SSH,
 		pb.ActionType_ACTION_TYPE_SSHD,
-		pb.ActionType_ACTION_TYPE_SUDO,
+		pb.ActionType_ACTION_TYPE_ADMIN_POLICY,
 		pb.ActionType_ACTION_TYPE_LPS,
 		pb.ActionType_ACTION_TYPE_USER,
 		pb.ActionType_ACTION_TYPE_GROUP,
@@ -88,7 +88,7 @@ func TestShouldRevertOnUnassign(t *testing.T) {
 		pb.ActionType_ACTION_TYPE_PACKAGE,
 		pb.ActionType_ACTION_TYPE_SHELL,
 		pb.ActionType_ACTION_TYPE_FILE,
-		pb.ActionType_ACTION_TYPE_SYSTEMD,
+		pb.ActionType_ACTION_TYPE_SERVICE,
 		pb.ActionType_ACTION_TYPE_APP_IMAGE,
 		pb.ActionType_ACTION_TYPE_FLATPAK,
 		pb.ActionType_ACTION_TYPE_REPOSITORY,
@@ -194,7 +194,7 @@ func TestRemoveAction_AllPolicyTypes(t *testing.T) {
 	}{
 		{"SSH", pb.ActionType_ACTION_TYPE_SSH},
 		{"SSHD", pb.ActionType_ACTION_TYPE_SSHD},
-		{"Sudo", pb.ActionType_ACTION_TYPE_SUDO},
+		{"Sudo", pb.ActionType_ACTION_TYPE_ADMIN_POLICY},
 		{"LPS", pb.ActionType_ACTION_TYPE_LPS},
 	}
 
@@ -235,7 +235,7 @@ func TestRemoveAction_OriginalNotMutated(t *testing.T) {
 	sched, mock := newTestScheduler(t)
 	ctx := context.Background()
 
-	action := makeTestAction("sudo-001", pb.ActionType_ACTION_TYPE_SUDO, pb.DesiredState_DESIRED_STATE_PRESENT)
+	action := makeTestAction("sudo-001", pb.ActionType_ACTION_TYPE_ADMIN_POLICY, pb.DesiredState_DESIRED_STATE_PRESENT)
 	if err := sched.AddAction(action); err != nil {
 		t.Fatal(err)
 	}
@@ -331,7 +331,7 @@ func TestSyncActions_MultiplePolicyActionsReverted(t *testing.T) {
 	actions := []*pb.Action{
 		makeTestAction("a-ssh", pb.ActionType_ACTION_TYPE_SSH, pb.DesiredState_DESIRED_STATE_PRESENT),
 		makeTestAction("a-sshd", pb.ActionType_ACTION_TYPE_SSHD, pb.DesiredState_DESIRED_STATE_PRESENT),
-		makeTestAction("a-sudo", pb.ActionType_ACTION_TYPE_SUDO, pb.DesiredState_DESIRED_STATE_PRESENT),
+		makeTestAction("a-sudo", pb.ActionType_ACTION_TYPE_ADMIN_POLICY, pb.DesiredState_DESIRED_STATE_PRESENT),
 		makeTestAction("a-lps", pb.ActionType_ACTION_TYPE_LPS, pb.DesiredState_DESIRED_STATE_PRESENT),
 		makeTestAction("a-pkg", pb.ActionType_ACTION_TYPE_PACKAGE, pb.DesiredState_DESIRED_STATE_PRESENT),
 	}
@@ -357,7 +357,7 @@ func TestSyncActions_MultiplePolicyActionsReverted(t *testing.T) {
 	expectedReverts := []pb.ActionType{
 		pb.ActionType_ACTION_TYPE_SSH,
 		pb.ActionType_ACTION_TYPE_SSHD,
-		pb.ActionType_ACTION_TYPE_SUDO,
+		pb.ActionType_ACTION_TYPE_ADMIN_POLICY,
 		pb.ActionType_ACTION_TYPE_LPS,
 	}
 	for _, at := range expectedReverts {
@@ -379,11 +379,11 @@ func TestSyncActions_RevertPreservesActionFields(t *testing.T) {
 	// Assign a sudo action with parameters
 	sudoAction := &pb.Action{
 		Id:           &pb.ActionId{Value: "sudo-params"},
-		Type:         pb.ActionType_ACTION_TYPE_SUDO,
+		Type:         pb.ActionType_ACTION_TYPE_ADMIN_POLICY,
 		DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
-		Params: &pb.Action_Sudo{
-			Sudo: &pb.SudoParams{
-				AccessLevel: pb.SudoAccessLevel_SUDO_ACCESS_LEVEL_FULL,
+		Params: &pb.Action_AdminPolicy{
+			AdminPolicy: &pb.AdminPolicyParams{
+				AccessLevel: pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_FULL,
 				Users:       []string{"alice"},
 			},
 		},
@@ -411,10 +411,10 @@ func TestSyncActions_RevertPreservesActionFields(t *testing.T) {
 	}
 
 	// Verify the reverted action preserves the original type and parameters
-	if revertCall.Type != pb.ActionType_ACTION_TYPE_SUDO {
+	if revertCall.Type != pb.ActionType_ACTION_TYPE_ADMIN_POLICY {
 		t.Errorf("expected SUDO type, got %s", revertCall.Type)
 	}
-	sudo := revertCall.GetSudo()
+	sudo := revertCall.GetAdminPolicy()
 	if sudo == nil {
 		t.Fatal("expected sudo parameters to be preserved in revert call")
 	}


### PR DESCRIPTION
Closes manchtools/power-manage-agent#41.

## Summary

Adopts the escalator-agnostic SDK v0.2.0 surface shipped in SDK #32.

### Renames (mechanical)

| Area | Old | New |
|---|---|---|
| Packages | `sys/systemd`, `sys/luks` | `sys/service`, `sys/encryption` |
| Action types | `ACTION_TYPE_SYSTEMD`, `ACTION_TYPE_SUDO`, `ACTION_TYPE_LUKS` | `ACTION_TYPE_SERVICE`, `ACTION_TYPE_ADMIN_POLICY`, `ACTION_TYPE_ENCRYPTION` |
| Params | `SystemdParams`, `SudoParams`, `LuksParams` | `ServiceParams`, `AdminPolicyParams`, `EncryptionParams` |
| Exec | `sysexec.Sudo[WithStdin]` | `sysexec.Privileged[WithStdin]` |

### Real changes

- `sysservice.IsEnabled/IsMasked/IsActive` now return `(bool, error)`. Agent's internal wrappers keep single-bool signatures and treat any error as `false` — consistent with the old behaviour where an unreachable systemd meant "not enabled/masked/active".
- `applyBackendOverrides()` runs before any privileged call and wires three new env vars:
  - `POWER_MANAGE_PRIVILEGE_BACKEND=sudo|doas`
  - `POWER_MANAGE_SERVICE_BACKEND=systemd|openrc|runit|s6`
  - `POWER_MANAGE_ENCRYPTION_BACKEND=luks|geli|cgd`

  Unknown or empty values leave the SDK defaults in place (sudo / systemd / luks) so every existing deployment continues working unchanged.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all unit tests green
- [ ] Integration tests (docker-based, CI)
- [ ] Manual: boot with `POWER_MANAGE_PRIVILEGE_BACKEND=doas` on a doas-configured box


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backend selection via environment variables for privilege, service and encryption backends, applied at startup for customizable behavior.

* **Refactor**
  * Switched internal execution and encryption/service/policy plumbing to use modular backend abstractions for cleaner, consistent runtime behavior.

* **Tests**
  * Updated integration and unit tests to reflect new action types and backend-driven behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->