### PR TITLE
fix: drop interactive-TTY gate + honour create_home=false (cleanup)

### DIFF
--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -1648,21 +1648,25 @@ func runTTY(args []string) int {
 		return 1
 	}
 
-	// Device-authoritative guard for mutating subcommands. `enable`/`disable`
-	// must be invoked by a human with root privileges attached to a real
-	// terminal. Without this gate the server could flip the flag remotely
-	// by dispatching `ACTION_TYPE_SHELL { script: "power-manage-agent tty enable" }` —
-	// that shell runs as the power-manage user which owns the SQLite DB,
-	// so it would otherwise succeed. Status stays readable without a
-	// terminal so operators can `if power-manage-agent tty status` in
-	// shell scripts.
+	// Require root for mutating subcommands. The tty.enabled row in the
+	// agent's SQLite DB is owned by the agent service user; another
+	// unprivileged local user must not be able to flip the flag for a
+	// user they aren't. Root-only enforces that — sudo or an equivalent
+	// privilege backend is the only path to the mutator.
+	//
+	// An earlier revision also required the call to originate from an
+	// interactive TTY so a server-dispatched `ACTION_TYPE_SHELL` couldn't
+	// flip the flag remotely. That gate was dropped in this revision:
+	// the `script(1)` utility routes around it in one line (pty
+	// allocation makes the stdin check pass), so the gate only added
+	// operational friction without providing real defence-in-depth. The
+	// server-side answer to "who can grant terminal access on which
+	// device" belongs in the permission model (RBAC + the fleet-wide
+	// distribution of shell actions), not in a terminal-shape check on
+	// the agent CLI.
 	if sub == "enable" || sub == "disable" {
 		if os.Geteuid() != 0 {
 			fmt.Fprintf(os.Stderr, "Error: tty %s must be run as root (try: sudo power-manage-agent tty %s)\n", sub, sub)
-			return 1
-		}
-		if !term.IsTerminal(int(os.Stdin.Fd())) {
-			fmt.Fprintf(os.Stderr, "Error: tty %s must be run interactively from a local terminal\n", sub)
 			return 1
 		}
 	}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -2974,12 +2974,16 @@ func (e *Executor) createUser(ctx context.Context, params *pb.UserParams, output
 		args = append(args, "-r") // Create system account
 	}
 
-	// Create home directory (default true for normal users)
+	// Respect the explicit create_home value from the proto. A prior
+	// revision inverted false → true for non-system users on the
+	// assumption that proto3 scalar false meant "unset, use default."
+	// That broke the UserParams contract — the server could not
+	// express "no home directory" for a non-system user even when it
+	// explicitly set create_home: false, because the agent would
+	// silently override. The control server's system-managed pm-tty
+	// action and the web UI's "Create home" checkbox both rely on
+	// explicit-false being honoured.
 	createHome := params.CreateHome
-	if !params.SystemUser && !params.CreateHome {
-		// For normal users, default to creating home
-		createHome = true
-	}
 
 	// Determine home directory path to check if it exists
 	homeDir := params.HomeDir
@@ -3153,11 +3157,11 @@ func (e *Executor) updateUser(ctx context.Context, params *pb.UserParams, output
 		changed = true
 	}
 
-	// Ensure home directory exists (may be missing if a prior run failed)
+	// Ensure home directory exists (may be missing if a prior run
+	// failed). Same change as in createUser — honour the explicit
+	// create_home value from the proto rather than inverting false
+	// to true for non-system users.
 	createHome := params.CreateHome
-	if !params.SystemUser && !params.CreateHome {
-		createHome = true
-	}
 	if createHome {
 		homeDir := params.HomeDir
 		if homeDir == "" {

--- a/internal/executor/integration_test.go
+++ b/internal/executor/integration_test.go
@@ -791,7 +791,7 @@ func TestIntegration_User_CreateHomeRespected(t *testing.T) {
 			Username:   username,
 			Shell:      "/usr/sbin/nologin",
 			CreateHome: false,
-			Comment:    "create_home:false regression test",
+			Comment:    "regression test for create_home false",
 		}}
 		result := e.Execute(ctx, action)
 		assertSuccess(t, result)
@@ -816,7 +816,7 @@ func TestIntegration_User_CreateHomeRespected(t *testing.T) {
 		action.Params = &pb.Action_User{User: &pb.UserParams{
 			Username:   username,
 			CreateHome: true,
-			Comment:    "create_home:true regression test",
+			Comment:    "regression test for create_home true",
 		}}
 		result := e.Execute(ctx, action)
 		assertSuccess(t, result)

--- a/internal/executor/integration_test.go
+++ b/internal/executor/integration_test.go
@@ -762,6 +762,76 @@ func TestIntegration_User(t *testing.T) {
 	})
 }
 
+// TestIntegration_User_CreateHomeRespected locks down the fix for the
+// agent inverting `create_home: false` to `true` for non-system users.
+// Before the fix, the control server's pm-tty-* sync explicitly set
+// create_home: false on the UserParams but the agent overrode it and
+// produced a home directory at /home/pm-tty-<username> anyway, which
+// contradicted the wire contract.
+//
+// Two sub-tests — the explicit-false path and the explicit-true path.
+// Both exercise non-system users (the branch that used to invert).
+func TestIntegration_User_CreateHomeRespected(t *testing.T) {
+	e := newTestExecutor()
+	ctx := context.Background()
+
+	t.Run("ExplicitFalse_NoHomeCreated", func(t *testing.T) {
+		username := "pmtestnohome"
+		homeDir := "/home/" + username
+		t.Cleanup(func() {
+			cleanupTestUser(t, username)
+			// Defensive: some failure paths can leave a home behind
+			// even after userdel; clean it up so a re-run isn't
+			// polluted.
+			sudoRun("rm", "-rf", homeDir).Run()
+		})
+
+		action := makeAction(t, pb.ActionType_ACTION_TYPE_USER, pb.DesiredState_DESIRED_STATE_PRESENT)
+		action.Params = &pb.Action_User{User: &pb.UserParams{
+			Username:   username,
+			Shell:      "/usr/sbin/nologin",
+			CreateHome: false,
+			Comment:    "create_home:false regression test",
+		}}
+		result := e.Execute(ctx, action)
+		assertSuccess(t, result)
+		if !userExists(username) {
+			t.Fatal("user not created")
+		}
+
+		if _, err := os.Stat(homeDir); !os.IsNotExist(err) {
+			t.Errorf("home directory %s exists but create_home was false: stat err = %v", homeDir, err)
+		}
+	})
+
+	t.Run("ExplicitTrue_HomeCreated", func(t *testing.T) {
+		username := "pmtestwithhome"
+		homeDir := "/home/" + username
+		t.Cleanup(func() {
+			cleanupTestUser(t, username)
+			sudoRun("rm", "-rf", homeDir).Run()
+		})
+
+		action := makeAction(t, pb.ActionType_ACTION_TYPE_USER, pb.DesiredState_DESIRED_STATE_PRESENT)
+		action.Params = &pb.Action_User{User: &pb.UserParams{
+			Username:   username,
+			CreateHome: true,
+			Comment:    "create_home:true regression test",
+		}}
+		result := e.Execute(ctx, action)
+		assertSuccess(t, result)
+		if !userExists(username) {
+			t.Fatal("user not created")
+		}
+
+		if info, err := os.Stat(homeDir); err != nil {
+			t.Errorf("home directory %s missing but create_home was true: stat err = %v", homeDir, err)
+		} else if !info.IsDir() {
+			t.Errorf("%s exists but is not a directory", homeDir)
+		}
+	})
+}
+
 // =============================================================================
 // Group Tests
 // =============================================================================


### PR DESCRIPTION
Two independent cleanups bundled under one PR since both are small, both are strictly contract-correcting, and both unblock in-flight server work without adding new behaviour.

## 1. Drop the interactive-TTY gate on \`tty enable / disable\`

\`power-manage-agent tty enable|disable\` used to require both euid=0 and an interactive stdin. Only the interactive half is removed; the root check stays.

The stated purpose of the interactive check was to prevent a compromised control plane from flipping \`tty.enabled\` via a shell action. Any server-dispatched shell can route around it with one line:

\`\`\`bash
script -qc 'power-manage-agent tty enable' /dev/null
\`\`\`

which allocates a pty and passes the stdin check. The gate therefore only added operational friction without providing real defence-in-depth — operators had to wrap every remote enable in \`script\` or SSH in manually. Terminal-access authorisation genuinely belongs in the control-plane permission model (manchtools/power-manage-server#70), not in a terminal-shape check on the agent CLI.

Net effect: \`ACTION_TYPE_SHELL { script: "sudo power-manage-agent tty enable" }\` targeted at a device group just works. No pty wrapper, no per-device SSH. The decision of "who can run that action" is an RBAC question in the control plane, which is where it always should have been.

Root check stays — \`tty.enabled\` lives in the agent's SQLite DB owned by the service user, and root-only still prevents an unprivileged local user from flipping the flag for someone else on the device.

## 2. Honour explicit \`create_home: false\` for non-system users

The user executor inverted \`create_home: false\` → \`true\` for non-system users on the assumption that proto3 scalar false meant "unset, use default." That violated the UserParams contract: both the control server's system-managed pm-tty action and the web form's "Create home" checkbox set \`create_home: false\` deliberately and expected no home directory on disk. The inversion silently produced one anyway.

Concrete symptom we observed in prod: empty \`/home/pm-tty-<username>/\` directories (mode 0700, owned by pm-tty-<username>) accumulating on every device a Power Manage user was assigned to.

Both \`createUser\` and \`updateUser\` now use \`createHome := params.CreateHome\` directly — the proto's explicit value is the source of truth. No more inversion.

### Cleanup of existing stray home directories

Not done automatically by this change. Operators can one-liner the cleanup on each device:

\`\`\`bash
sudo rm -rf /home/pm-tty-*
\`\`\`

The directories are empty, 0700, owned by the pm-tty-\* account. A future agent extension could detect \`create_home: false\` + existing home in \`updateUser\` and remove it; deliberately out of scope here to keep the change surgical.

## Test plan

- [x] \`go build ./...\` / \`go vet ./...\` clean
- [x] \`go vet -tags integration ./...\` clean
- [x] New regression test \`TestIntegration_User_CreateHomeRespected\` covers both the explicit-false and explicit-true paths for non-system users (the branch that used to invert)
- [ ] Manual: on a device with power-manage-agent installed, \`sudo power-manage-agent tty enable < /dev/null\` now succeeds without the "must be run interactively" error
- [ ] Operator verification: dispatch \`ACTION_TYPE_SHELL { script: "sudo power-manage-agent tty enable" }\` to a device group — every device accepts the action and subsequently accepts browser terminal sessions
- [ ] Operator verification: create a User action via the web UI with "Create home" unchecked, assign to a device, confirm no \`/home/<username>\` is created

## Related

- manchtools/power-manage-server#69 — server-side typed-params refactor that depends on create_home:false actually being honoured
- manchtools/power-manage-server#70 — role-based TerminalAdmin permissions, the proper place for "who can grant terminal access"