### PR TITLE
fix: agent security/reliability audit pass (install.sh, repo, creds, mTLS bump)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ The agent supports two enrollment methods:
 6. The Control Server validates the token, signs the certificate, and returns credentials
 7. The agent saves credentials, closes the enrollment socket, starts the auth socket, and connects to the gateway
 
+> **Trust boundary.** The enrollment socket is intentionally
+> world-accessible (mode `0666`); the security boundary is the
+> registration token, which is validated by the Control Server.
+> The agent applies a **global** rate limit of 5 enrollment attempts
+> per minute across all local callers, so any local user can briefly
+> prevent a legitimate enrollment by flooding the socket with bad
+> tokens. This is acceptable for a self-hosted MDM — the admin who
+> runs the install script will retry — but it is not suitable for
+> adversarial multi-tenant hosts.
+
 ```
                                   ┌─────────────────────────┐
   User (no sudo)                  │   Agent (systemd svc)   │

--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -663,7 +663,16 @@ func startCertRotation(ctx context.Context, credStore *credentials.Store, hostna
 			continue
 		}
 
-		// Build mTLS client using current (still valid) certificate
+		// Build mTLS client using current (still valid) certificate.
+		//
+		// NOTE: after the agent bumps to sdk >= v0.3.0 (which makes
+		// WithMTLSFromPEM strict — internal CA only — to close the
+		// trust-broadening audit finding), this call must switch to
+		// sdk.WithMTLSFromPEMAndSystemRoots. The control server sits
+		// behind a public CA (Traefik + Let's Encrypt in the
+		// reference deployment), so server verification needs
+		// system roots; application-layer identity is proven by the
+		// current certificate in the RenewCertificate request body.
 		mtlsOpt, err := sdk.WithMTLSFromPEM(creds.Certificate, creds.PrivateKey, creds.CACert)
 		if err != nil {
 			logger.Error("cert rotation: failed to configure mTLS", "error", err)

--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -664,16 +664,15 @@ func startCertRotation(ctx context.Context, credStore *credentials.Store, hostna
 		}
 
 		// Build mTLS client using current (still valid) certificate.
-		//
-		// NOTE: after the agent bumps to sdk >= v0.3.0 (which makes
-		// WithMTLSFromPEM strict — internal CA only — to close the
-		// trust-broadening audit finding), this call must switch to
-		// sdk.WithMTLSFromPEMAndSystemRoots. The control server sits
-		// behind a public CA (Traefik + Let's Encrypt in the
-		// reference deployment), so server verification needs
-		// system roots; application-layer identity is proven by the
-		// current certificate in the RenewCertificate request body.
-		mtlsOpt, err := sdk.WithMTLSFromPEM(creds.Certificate, creds.PrivateKey, creds.CACert)
+		// The control server sits behind a public CA (Traefik +
+		// Let's Encrypt in the reference deployment), so server
+		// verification needs the host's system roots — the strict
+		// sdk.WithMTLSFromPEM (internal CA only, as of SDK audit
+		// pass) is correct for the gateway mTLS path but not for
+		// this one. Application-layer identity of the agent is
+		// already proven by the current certificate in the
+		// RenewCertificate request body.
+		mtlsOpt, err := sdk.WithMTLSFromPEMAndSystemRoots(creds.Certificate, creds.PrivateKey, creds.CACert)
 		if err != nil {
 			logger.Error("cert rotation: failed to configure mTLS", "error", err)
 			select {

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see agent/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.2.2-0.20260421185013-b865ea3f6c2e
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.2.2-0.20260421201745-26b159a9dde7
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see agent/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.2.1
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.2.2-0.20260421185013-b865ea3f6c2e
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see agent/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.2.2-0.20260421201745-26b159a9dde7
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.3.0
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.2.1 h1:vlsJ7GjHgsdRVWeoOELt1G4Mr4SqVxuG1fHYRFY1rvU=
-github.com/manchtools/power-manage-sdk v0.2.1/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.2.2-0.20260421185013-b865ea3f6c2e h1:XUCWKOPuHY1KQIgzqjP8CzDuHohdnt5bhAXXEf+9tTo=
+github.com/manchtools/power-manage-sdk v0.2.2-0.20260421185013-b865ea3f6c2e/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.2.2-0.20260421201745-26b159a9dde7 h1:1iewqSfuRiK4R4m/DL/zF46AKif+7CiXIH7kD7jcwz4=
-github.com/manchtools/power-manage-sdk v0.2.2-0.20260421201745-26b159a9dde7/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.3.0 h1:AD8okUjGjYvlV+pK1OfK34/YbT0iP8HQWq1EldVpRc4=
+github.com/manchtools/power-manage-sdk v0.3.0/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.2.2-0.20260421185013-b865ea3f6c2e h1:XUCWKOPuHY1KQIgzqjP8CzDuHohdnt5bhAXXEf+9tTo=
-github.com/manchtools/power-manage-sdk v0.2.2-0.20260421185013-b865ea3f6c2e/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.2.2-0.20260421201745-26b159a9dde7 h1:1iewqSfuRiK4R4m/DL/zF46AKif+7CiXIH7kD7jcwz4=
+github.com/manchtools/power-manage-sdk v0.2.2-0.20260421201745-26b159a9dde7/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/install.sh
+++ b/install.sh
@@ -250,8 +250,18 @@ download_binary() {
     local tmp_binary tmp_sums
     tmp_binary=$(mktemp "${dest_dir}/.power-manage-agent.XXXXXX")
     tmp_sums=$(mktemp "${dest_dir}/.SHA256SUMS.XXXXXX")
-    # shellcheck disable=SC2064
-    trap "rm -f '${tmp_binary}' '${tmp_sums}'" EXIT INT TERM
+    # Trap via a named function so the tmp paths are expanded
+    # inside the function body (where normal "$var" quoting
+    # handles spaces / quotes cleanly) rather than spliced into
+    # the trap command string at registration time. An earlier
+    # shape used `trap "rm -f '${tmp_binary}' '${tmp_sums}'"`,
+    # which would break if BINARY_PATH's directory ever contained
+    # a single quote — unlikely on a typical deploy host, but a
+    # gratuitous shell-quoting fragility we can just drop.
+    cleanup_download_tmp() {
+        rm -f "$tmp_binary" "$tmp_sums"
+    }
+    trap cleanup_download_tmp EXIT INT TERM
 
     if command -v curl &>/dev/null; then
         if ! curl -gfSL --progress-bar -o "$tmp_binary" "$download_url"; then

--- a/install.sh
+++ b/install.sh
@@ -225,25 +225,50 @@ download_binary() {
     local arch
     arch=$(detect_arch)
     local binary_name="power-manage-agent-linux-${arch}"
-    local download_url
+    local download_url sums_url release_base
 
     if [[ "$VERSION" == "latest" ]]; then
-        download_url="https://github.com/${GITHUB_REPO}/releases/latest/download/${binary_name}"
+        release_base="https://github.com/${GITHUB_REPO}/releases/latest/download"
     else
-        download_url="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/${binary_name}"
+        release_base="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}"
     fi
+    download_url="${release_base}/${binary_name}"
+    sums_url="${release_base}/SHA256SUMS"
 
     log_info "Detected architecture: ${arch}"
     log_info "Downloading agent from ${download_url}..."
 
+    # Download to a sibling tmp file inside the destination directory
+    # so the final `mv` is an atomic rename inside the same filesystem.
+    # Clobbering BINARY_PATH directly with a partial download — the
+    # previous behaviour — could leave the host with a truncated or
+    # malicious binary if the transfer was interrupted or the release
+    # endpoint was compromised.
+    local dest_dir
+    dest_dir=$(dirname "$BINARY_PATH")
+    mkdir -p "$dest_dir"
+    local tmp_binary tmp_sums
+    tmp_binary=$(mktemp "${dest_dir}/.power-manage-agent.XXXXXX")
+    tmp_sums=$(mktemp "${dest_dir}/.SHA256SUMS.XXXXXX")
+    # shellcheck disable=SC2064
+    trap "rm -f '${tmp_binary}' '${tmp_sums}'" EXIT INT TERM
+
     if command -v curl &>/dev/null; then
-        if ! curl -gfSL --progress-bar -o "$BINARY_PATH" "$download_url"; then
+        if ! curl -gfSL --progress-bar -o "$tmp_binary" "$download_url"; then
             log_error "Download failed. Check the version and that the release exists."
             exit 1
         fi
+        if ! curl -gfSL -o "$tmp_sums" "$sums_url"; then
+            log_error "SHA256SUMS download failed. Refusing to install unverified binary."
+            exit 1
+        fi
     elif command -v wget &>/dev/null; then
-        if ! wget -q --show-progress -O "$BINARY_PATH" "$download_url"; then
+        if ! wget -q --show-progress -O "$tmp_binary" "$download_url"; then
             log_error "Download failed. Check the version and that the release exists."
+            exit 1
+        fi
+        if ! wget -q -O "$tmp_sums" "$sums_url"; then
+            log_error "SHA256SUMS download failed. Refusing to install unverified binary."
             exit 1
         fi
     else
@@ -251,7 +276,46 @@ download_binary() {
         exit 1
     fi
 
-    chmod +x "$BINARY_PATH"
+    # Verify the downloaded binary against the publisher's SHA256SUMS.
+    # Fail closed: a missing / mismatched / tampered checksum ends the
+    # install before we touch BINARY_PATH. The SHA256SUMS file is served
+    # by the same GitHub release as the binary, so this does not protect
+    # against a release-channel compromise on its own — the release
+    # workflow should additionally sign the file (cosign / minisign) and
+    # this script should verify that signature once CI publishes it.
+    # Until then, SHA256SUMS still catches the "half-downloaded binary
+    # was silently installed as root" class of failures.
+    local expected_sha actual_sha
+    expected_sha=$(awk -v f="$binary_name" '$2 == f || $2 == "*" f { print $1; exit }' "$tmp_sums")
+    if [[ -z "$expected_sha" ]]; then
+        log_error "SHA256SUMS has no entry for ${binary_name}. Refusing to install."
+        exit 1
+    fi
+    if ! command -v sha256sum &>/dev/null; then
+        log_error "sha256sum not found. Cannot verify binary integrity; refusing to install."
+        exit 1
+    fi
+    actual_sha=$(sha256sum "$tmp_binary" | awk '{print $1}')
+    if [[ "$expected_sha" != "$actual_sha" ]]; then
+        log_error "SHA256 mismatch for ${binary_name}."
+        log_error "  expected: ${expected_sha}"
+        log_error "  actual:   ${actual_sha}"
+        log_error "Refusing to install tampered or corrupt binary."
+        exit 1
+    fi
+    log_info "SHA256 verified."
+
+    chmod 0755 "$tmp_binary"
+    # mv across the same filesystem is atomic, so a crash here never
+    # leaves BINARY_PATH in a partially-written state. The trap above
+    # handles the case where the mv itself fails.
+    if ! mv -f "$tmp_binary" "$BINARY_PATH"; then
+        log_error "Failed to install binary to ${BINARY_PATH}."
+        exit 1
+    fi
+    rm -f "$tmp_sums"
+    trap - EXIT INT TERM
+
     log_info "Binary installed to $BINARY_PATH"
 }
 
@@ -413,10 +477,18 @@ enroll_agent() {
 
     log_info "Enrolling agent with server via socket..."
 
-    local enroll_cmd="$BINARY_PATH enroll -server=$SERVER_URL -token=$REGISTRATION_TOKEN"
+    # Build the enrollment command as an array so arguments are passed
+    # one-per-element and bash does not word-split, glob, or re-tokenise
+    # user-supplied values such as SERVER_URL or REGISTRATION_TOKEN.
+    local -a enroll_cmd=(
+        "$BINARY_PATH"
+        "enroll"
+        "-server=$SERVER_URL"
+        "-token=$REGISTRATION_TOKEN"
+    )
 
     if [[ -n "$SKIP_VERIFY" ]]; then
-        enroll_cmd="$enroll_cmd -skip-verify"
+        enroll_cmd+=("-skip-verify")
     fi
 
     # Wait for the enrollment socket to become available (agent needs to start first)
@@ -433,12 +505,13 @@ enroll_agent() {
     fi
 
     # Enroll via socket — no sudo needed, any user can connect
-    if $enroll_cmd; then
+    if "${enroll_cmd[@]}"; then
         log_info "Agent enrolled successfully"
     else
         log_error "Agent enrollment failed"
         log_info "You can try again later by running:"
-        log_info "  $enroll_cmd"
+        # printf %q quotes each argument safely for copy-paste.
+        log_info "  $(printf '%q ' "${enroll_cmd[@]}")"
         return 1
     fi
 }
@@ -549,9 +622,14 @@ install_luks_sudoers() {
 
     log_info "Installing LUKS sudoers rule..."
 
-    cat > "$sudoers_file" << 'EOF'
+    # Unquoted heredoc so $BINARY_PATH expands — the rule must match
+    # the actual binary location, which differs when the operator passes
+    # --binary. Sudoers treats wildcards on the argument list specially,
+    # so this remains a path match for /PATH/TO/power-manage-agent +
+    # "luks" verb + any args.
+    cat > "$sudoers_file" <<EOF
 # Allow all users to run LUKS passphrase commands without password
-ALL ALL=(root) NOPASSWD: /usr/local/bin/power-manage-agent luks *
+ALL ALL=(root) NOPASSWD: ${BINARY_PATH} luks *
 EOF
 
     chmod 440 "$sudoers_file"

--- a/install.sh
+++ b/install.sh
@@ -632,6 +632,25 @@ install_luks_sudoers() {
 
     log_info "Installing LUKS sudoers rule..."
 
+    # Validate BINARY_PATH before interpolating it into a NOPASSWD
+    # sudoers rule. The rule grants passwordless root for anything
+    # matching "$BINARY_PATH luks *", so a malicious or malformed
+    # path is a privilege-escalation hazard:
+    #   - Must be absolute (anchors the sudoers pattern; relative
+    #     paths in sudoers are a non-starter).
+    #   - Must contain only characters that are safe both in a file
+    #     path and in a sudoers Cmnd_Alias: letters, digits,
+    #     `/._-`. Notably no spaces (sudoers tokenizer), no quotes,
+    #     no commas, no wildcards of our own.
+    if [[ "$BINARY_PATH" != /* ]]; then
+        log_error "BINARY_PATH ($BINARY_PATH) must be absolute to install sudoers rule"
+        exit 1
+    fi
+    if [[ ! "$BINARY_PATH" =~ ^/[A-Za-z0-9/._-]+$ ]]; then
+        log_error "BINARY_PATH ($BINARY_PATH) contains characters unsafe for sudoers; must match /[A-Za-z0-9/._-]+"
+        exit 1
+    fi
+
     # Unquoted heredoc so $BINARY_PATH expands — the rule must match
     # the actual binary location, which differs when the operator passes
     # --binary. Sudoers treats wildcards on the argument list specially,
@@ -644,13 +663,17 @@ EOF
 
     chmod 440 "$sudoers_file"
 
-    # Validate sudoers syntax
-    if visudo -c -f "$sudoers_file" &>/dev/null; then
-        log_info "LUKS sudoers rule installed"
-    else
-        log_error "Invalid sudoers syntax, removing file"
+    # Validate sudoers syntax. Fail-closed: if visudo rejects the
+    # generated file, remove it AND fail the install. Continuing
+    # the install after visudo rejection used to leave the host in
+    # a state where LUKS actions would prompt for a password (no
+    # sudoers rule in effect) — surprising and undebuggable.
+    if ! visudo -c -f "$sudoers_file" &>/dev/null; then
+        log_error "Invalid sudoers syntax in $sudoers_file; removing and aborting install"
         rm -f "$sudoers_file"
+        exit 1
     fi
+    log_info "LUKS sudoers rule installed"
 }
 
 show_status() {

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -94,12 +94,72 @@ func (s *Store) Save(creds *Credentials) error {
 		return fmt.Errorf("encrypt credentials: %w", err)
 	}
 
-	// Write encrypted credentials with secure permissions
+	// Write encrypted credentials atomically. A direct os.WriteFile
+	// leaves a partially written file on crash / full disk / power
+	// loss, which corrupts the agent's enrollment and forces a
+	// re-enroll. Temp-file + fsync + rename is the standard
+	// cure — rename is atomic within a single filesystem, the
+	// fsync before rename ensures the new contents are on disk
+	// before the directory entry is swapped, and the parent-dir
+	// fsync afterwards flushes the directory entry itself.
 	credPath := filepath.Join(s.dataDir, credentialsFile)
-	if err := os.WriteFile(credPath, ciphertext, 0600); err != nil {
+	if err := atomicWriteFile(credPath, ciphertext, 0600); err != nil {
 		return fmt.Errorf("write credentials: %w", err)
 	}
 
+	return nil
+}
+
+// atomicWriteFile writes data to path via a same-directory temp file
+// followed by fsync + rename + directory fsync. Callers MUST use
+// this for any credential / salt / token file where a half-written
+// state would break the agent.
+//
+// Permissions are applied before rename so the final inode has the
+// intended mode from the first moment it is reachable by name.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	// If any step below fails we remove the temp file so we don't
+	// leave ".tmp-*" clutter in the data directory.
+	cleanup := func() {
+		_ = os.Remove(tmpPath)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("chmod temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("fsync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("rename temp: %w", err)
+	}
+	// Flush the directory entry so a crash after the rename still
+	// sees the new inode on recovery. Ignore ENOSYS etc. on exotic
+	// filesystems — the rename itself has already completed.
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
 	return nil
 }
 
@@ -176,8 +236,10 @@ func (s *Store) loadOrCreateSalt() ([]byte, error) {
 		return nil, fmt.Errorf("generate salt: %w", err)
 	}
 
-	// Save salt with secure permissions
-	if err := os.WriteFile(saltPath, salt, 0600); err != nil {
+	// Save salt atomically — the salt is paired with the encrypted
+	// credentials and a corrupt salt is just as fatal as a corrupt
+	// credentials.enc.
+	if err := atomicWriteFile(saltPath, salt, 0600); err != nil {
 		return nil, fmt.Errorf("write salt: %w", err)
 	}
 

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -1,0 +1,83 @@
+package credentials
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAtomicWriteFile_WritesAndReplaces covers the success paths:
+// first write creates the file; a subsequent write replaces it
+// atomically without leaving behind the temp file.
+func TestAtomicWriteFile_WritesAndReplaces(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "creds.enc")
+
+	if err := atomicWriteFile(target, []byte("v1"), 0600); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, []byte("v1")) {
+		t.Fatalf("got %q, want %q", got, "v1")
+	}
+
+	if err := atomicWriteFile(target, []byte("v2"), 0600); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	got, err = os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, []byte("v2")) {
+		t.Fatalf("got %q, want %q", got, "v2")
+	}
+
+	// No leftover temp files.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "creds.enc" {
+			t.Errorf("unexpected leftover: %q", e.Name())
+		}
+	}
+}
+
+// TestAtomicWriteFile_AppliesMode asserts the final file carries the
+// requested permissions — credentials must be 0600 the moment they
+// become visible under the target name, not briefly world-readable.
+func TestAtomicWriteFile_AppliesMode(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "salt")
+
+	if err := atomicWriteFile(target, []byte("secret"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0600 {
+		t.Errorf("mode = %o, want 0600", mode)
+	}
+}
+
+// TestAtomicWriteFile_WriteFailsNoLeftover is the reliability
+// guarantee: a failed write into a nonexistent directory must NOT
+// leave a temp file somewhere for a future operator to stumble over.
+func TestAtomicWriteFile_WriteFailsNoLeftover(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "does-not-exist", "creds.enc")
+	if err := atomicWriteFile(missing, []byte("x"), 0600); err == nil {
+		t.Fatal("expected error writing into nonexistent directory")
+	}
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		t.Errorf("unexpected artifact in %s: %s", dir, e.Name())
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -69,72 +69,84 @@ var (
 // directives into /etc/apt/sources.list.d/*, /etc/yum.repos.d/*,
 // /etc/pacman.conf, or zypper metadata.
 func validateRepositoryParams(params *pb.RepositoryParams) error {
-	reject := func(field, value string) error {
-		return fmt.Errorf("repository %s contains newline or invalid character: %q", field, value)
+	// Field-level errors name the offending field but do NOT echo
+	// the rejected value. Repository URLs / GPG key URLs / descriptions
+	// can carry secrets or per-deployment URLs that should not leak
+	// into task-result payloads, audit projections, or log sinks. A
+	// named field tells the operator enough to go check the action
+	// definition — the full value is one click away in the UI.
+	reject := func(field string) error {
+		return fmt.Errorf("repository field %q contains newline or control character", field)
 	}
-	badShape := func(field, value string) error {
-		return fmt.Errorf("repository %s has invalid shape: %q", field, value)
+	badShape := func(field string) error {
+		return fmt.Errorf("repository field %q has invalid shape", field)
 	}
 
 	if apt := params.Apt; apt != nil {
 		if containsNewline(apt.Url) {
-			return reject("apt.url", apt.Url)
+			return reject("apt.url")
 		}
 		if containsNewline(apt.Distribution) {
-			return reject("apt.distribution", apt.Distribution)
+			return reject("apt.distribution")
 		}
 		if apt.Distribution != "" && !validAptDistribution.MatchString(apt.Distribution) {
-			return badShape("apt.distribution", apt.Distribution)
+			return badShape("apt.distribution")
 		}
 		for _, c := range apt.Components {
 			if containsNewline(c) {
-				return reject("apt.components entry", c)
+				return reject("apt.components entry")
 			}
 			if !validAptComponent.MatchString(c) {
-				return badShape("apt.components entry", c)
+				return badShape("apt.components entry")
 			}
 		}
 		if containsNewline(apt.Arch) {
-			return reject("apt.arch", apt.Arch)
+			return reject("apt.arch")
 		}
 		if apt.Arch != "" && !validAptArch.MatchString(apt.Arch) {
-			return badShape("apt.arch", apt.Arch)
+			return badShape("apt.arch")
 		}
 		if containsNewline(apt.GpgKeyUrl) {
-			return reject("apt.gpg_key_url", apt.GpgKeyUrl)
+			return reject("apt.gpg_key_url")
 		}
 	}
 	if dnf := params.Dnf; dnf != nil {
-		if containsNewline(dnf.Baseurl) || containsNewline(dnf.Description) {
-			return reject("dnf.baseurl or dnf.description", dnf.Baseurl+" / "+dnf.Description)
+		if containsNewline(dnf.Baseurl) {
+			return reject("dnf.baseurl")
+		}
+		if containsNewline(dnf.Description) {
+			return reject("dnf.description")
 		}
 		if containsNewline(dnf.Gpgkey) {
-			return reject("dnf.gpgkey", dnf.Gpgkey)
+			return reject("dnf.gpgkey")
 		}
 	}
 	if pac := params.Pacman; pac != nil {
 		if containsNewline(pac.Server) {
-			return reject("pacman.server", pac.Server)
+			return reject("pacman.server")
 		}
 		if containsNewline(pac.SigLevel) {
-			return reject("pacman.sig_level", pac.SigLevel)
+			return reject("pacman.sig_level")
 		}
 		if pac.SigLevel != "" && !validPacmanSigLevel.MatchString(pac.SigLevel) {
-			return badShape("pacman.sig_level", pac.SigLevel)
+			return badShape("pacman.sig_level")
 		}
 	}
 	if zyp := params.Zypper; zyp != nil {
-		if containsNewline(zyp.Url) || containsNewline(zyp.Description) {
-			return reject("zypper.url or zypper.description", zyp.Url+" / "+zyp.Description)
+		if containsNewline(zyp.Url) {
+			return reject("zypper.url")
+		}
+		if containsNewline(zyp.Description) {
+			return reject("zypper.description")
 		}
 		if containsNewline(zyp.Gpgkey) {
-			return reject("zypper.gpgkey", zyp.Gpgkey)
+			return reject("zypper.gpgkey")
 		}
 		if containsNewline(zyp.Type) {
-			return reject("zypper.type", zyp.Type)
+			return reject("zypper.type")
 		}
 		if zyp.Type != "" && !validZypperType.MatchString(zyp.Type) {
-			return badShape("zypper.type", zyp.Type)
+			return badShape("zypper.type")
 		}
 	}
 	return nil
@@ -2313,13 +2325,15 @@ func (e *Executor) executeRepository(ctx context.Context, params *pb.RepositoryP
 		return nil, false, fmt.Errorf("repository name required")
 	}
 
-	// Repair filesystem if mounted read-only
-	if out, err := e.requireWritableFS(ctx); err != nil {
-		return out, false, err
-	}
-
+	// Validate BEFORE requireWritableFS: requireWritableFS can
+	// invoke sudo-backed remount/repair on a read-only root, so
+	// dispatching it for a malformed action (invalid name, oversized
+	// name, newline injection in a URL/GPG field, etc.) leaks
+	// privileged side-effects that the action should have been
+	// rejected for up front. Keep validation cheap and before any
+	// system mutation.
 	if !validRepoName.MatchString(params.Name) {
-		return nil, false, fmt.Errorf("invalid repository name %q: must match [a-zA-Z0-9][a-zA-Z0-9._-]*", params.Name)
+		return nil, false, fmt.Errorf("invalid repository name: must match [a-zA-Z0-9][a-zA-Z0-9._-]*")
 	}
 	if len(params.Name) > 128 {
 		return nil, false, fmt.Errorf("repository name too long: max 128 characters")
@@ -2330,6 +2344,13 @@ func (e *Executor) executeRepository(ctx context.Context, params *pb.RepositoryP
 	// validateRepositoryParams for the per-field rules.
 	if err := validateRepositoryParams(params); err != nil {
 		return nil, false, err
+	}
+
+	// Repair filesystem if mounted read-only. Only reached once the
+	// action has passed every structural check, so the sudo-backed
+	// remount never fires for a payload we were going to refuse.
+	if out, err := e.requireWritableFS(ctx); err != nil {
+		return out, false, err
 	}
 
 	// Detect package manager and execute the appropriate configuration

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -38,6 +38,108 @@ import (
 // This prevents path traversal, shell injection, and sed/regex injection.
 var validRepoName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
+// Repo-field shape constraints. These run in addition to the
+// newline-rejection pass in validateRepositoryParams — newlines are
+// the classic config-injection vector (they let a signed action
+// smuggle extra lines into apt/dnf/pacman configuration), but the
+// fields below also have a naturally narrow grammar, so an allow-list
+// of permitted characters costs nothing and eliminates shell /
+// argument-confusion attacks on runSudoCmd calls that splice these
+// values into a command line.
+var (
+	// APT distribution codenames: "jammy", "bookworm", "focal-updates".
+	validAptDistribution = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+	// APT components: "main", "contrib", "non-free-firmware".
+	validAptComponent = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+	// APT architecture filter: "amd64", "arm64", comma-separated list.
+	validAptArch = regexp.MustCompile(`^[a-z0-9][a-z0-9,_-]*$`)
+	// Pacman SigLevel: space-separated tokens, e.g. "Optional TrustAll".
+	validPacmanSigLevel = regexp.MustCompile(`^[a-zA-Z ]+$`)
+	// Zypper repository type: "rpm-md", "yast2", "plaindir".
+	validZypperType = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]*$`)
+)
+
+// validateRepositoryParams refuses repository configurations that
+// contain newlines in any string field the agent later splices into
+// a config file or shell argument, plus tight regex grammars on the
+// enum-like fields (distribution, component, architecture, siglevel,
+// zypper type). Since actions are signed and admin-controlled, this
+// is not "untrusted input" in the classic sense — but a compromised
+// or malformed admin action should not be able to inject extra
+// directives into /etc/apt/sources.list.d/*, /etc/yum.repos.d/*,
+// /etc/pacman.conf, or zypper metadata.
+func validateRepositoryParams(params *pb.RepositoryParams) error {
+	reject := func(field, value string) error {
+		return fmt.Errorf("repository %s contains newline or invalid character: %q", field, value)
+	}
+	badShape := func(field, value string) error {
+		return fmt.Errorf("repository %s has invalid shape: %q", field, value)
+	}
+
+	if apt := params.Apt; apt != nil {
+		if containsNewline(apt.Url) {
+			return reject("apt.url", apt.Url)
+		}
+		if containsNewline(apt.Distribution) {
+			return reject("apt.distribution", apt.Distribution)
+		}
+		if apt.Distribution != "" && !validAptDistribution.MatchString(apt.Distribution) {
+			return badShape("apt.distribution", apt.Distribution)
+		}
+		for _, c := range apt.Components {
+			if containsNewline(c) {
+				return reject("apt.components entry", c)
+			}
+			if !validAptComponent.MatchString(c) {
+				return badShape("apt.components entry", c)
+			}
+		}
+		if containsNewline(apt.Arch) {
+			return reject("apt.arch", apt.Arch)
+		}
+		if apt.Arch != "" && !validAptArch.MatchString(apt.Arch) {
+			return badShape("apt.arch", apt.Arch)
+		}
+		if containsNewline(apt.GpgKeyUrl) {
+			return reject("apt.gpg_key_url", apt.GpgKeyUrl)
+		}
+	}
+	if dnf := params.Dnf; dnf != nil {
+		if containsNewline(dnf.Baseurl) || containsNewline(dnf.Description) {
+			return reject("dnf.baseurl or dnf.description", dnf.Baseurl+" / "+dnf.Description)
+		}
+		if containsNewline(dnf.Gpgkey) {
+			return reject("dnf.gpgkey", dnf.Gpgkey)
+		}
+	}
+	if pac := params.Pacman; pac != nil {
+		if containsNewline(pac.Server) {
+			return reject("pacman.server", pac.Server)
+		}
+		if containsNewline(pac.SigLevel) {
+			return reject("pacman.sig_level", pac.SigLevel)
+		}
+		if pac.SigLevel != "" && !validPacmanSigLevel.MatchString(pac.SigLevel) {
+			return badShape("pacman.sig_level", pac.SigLevel)
+		}
+	}
+	if zyp := params.Zypper; zyp != nil {
+		if containsNewline(zyp.Url) || containsNewline(zyp.Description) {
+			return reject("zypper.url or zypper.description", zyp.Url+" / "+zyp.Description)
+		}
+		if containsNewline(zyp.Gpgkey) {
+			return reject("zypper.gpgkey", zyp.Gpgkey)
+		}
+		if containsNewline(zyp.Type) {
+			return reject("zypper.type", zyp.Type)
+		}
+		if zyp.Type != "" && !validZypperType.MatchString(zyp.Type) {
+			return badShape("zypper.type", zyp.Type)
+		}
+	}
+	return nil
+}
+
 // maxScriptSize is the maximum allowed size for shell scripts (1 MiB).
 const maxScriptSize = 1 << 20
 
@@ -2223,18 +2325,11 @@ func (e *Executor) executeRepository(ctx context.Context, params *pb.RepositoryP
 		return nil, false, fmt.Errorf("repository name too long: max 128 characters")
 	}
 
-	// Validate that repo URLs/descriptions don't contain newlines (config injection)
-	if params.Apt != nil && containsNewline(params.Apt.Url) {
-		return nil, false, fmt.Errorf("APT repository URL contains newlines")
-	}
-	if params.Dnf != nil && (containsNewline(params.Dnf.Baseurl) || containsNewline(params.Dnf.Description)) {
-		return nil, false, fmt.Errorf("DNF repository URL or description contains newlines")
-	}
-	if params.Pacman != nil && containsNewline(params.Pacman.Server) {
-		return nil, false, fmt.Errorf("Pacman server URL contains newlines")
-	}
-	if params.Zypper != nil && (containsNewline(params.Zypper.Url) || containsNewline(params.Zypper.Description)) {
-		return nil, false, fmt.Errorf("Zypper repository URL or description contains newlines")
+	// Reject config-injection or shape-violating values in every
+	// repository string field, not just URL/description. See
+	// validateRepositoryParams for the per-field rules.
+	if err := validateRepositoryParams(params); err != nil {
+		return nil, false, err
 	}
 
 	// Detect package manager and execute the appropriate configuration

--- a/internal/executor/repository_validation_test.go
+++ b/internal/executor/repository_validation_test.go
@@ -1,0 +1,111 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// TestValidateRepositoryParams_AcceptsRealistic pins the expected
+// shapes of legitimate repository configurations — regressions in
+// the validator grammar must not reject these.
+func TestValidateRepositoryParams_AcceptsRealistic(t *testing.T) {
+	cases := map[string]*pb.RepositoryParams{
+		"apt": {
+			Apt: &pb.AptRepository{
+				Url:          "https://apt.example.com/debian",
+				Distribution: "bookworm",
+				Components:   []string{"main", "contrib", "non-free-firmware"},
+				Arch:         "amd64,arm64",
+				GpgKeyUrl:    "https://apt.example.com/signing.asc",
+			},
+		},
+		"dnf": {
+			Dnf: &pb.DnfRepository{
+				Baseurl:     "https://dnf.example.com/fedora/$releasever",
+				Description: "Example DNF repo",
+				Gpgkey:      "https://dnf.example.com/key.asc",
+				Gpgcheck:    true,
+			},
+		},
+		"pacman-optional-trustall": {
+			Pacman: &pb.PacmanRepository{
+				Server:   "https://arch.example.com/os/$arch",
+				SigLevel: "Optional TrustAll",
+			},
+		},
+		"zypper": {
+			Zypper: &pb.ZypperRepository{
+				Url:         "https://zypper.example.com/15.5",
+				Description: "Example Zypper repo",
+				Gpgkey:      "https://zypper.example.com/key.asc",
+				Type:        "rpm-md",
+			},
+		},
+	}
+	for name, p := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := validateRepositoryParams(p); err != nil {
+				t.Fatalf("legitimate config rejected: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateRepositoryParams_RejectsInjection is the regression:
+// every repo string field must refuse newline injection and the
+// enum-like fields must reject out-of-grammar values. A malformed
+// signed action must NOT be able to smuggle extra directives into
+// apt/dnf/pacman/zypper config.
+func TestValidateRepositoryParams_RejectsInjection(t *testing.T) {
+	cases := map[string]*pb.RepositoryParams{
+		"apt distribution newline": {
+			Apt: &pb.AptRepository{Distribution: "bookworm\nEvil: yes"},
+		},
+		"apt component newline": {
+			Apt: &pb.AptRepository{Components: []string{"main", "contrib\nEvil: 1"}},
+		},
+		"apt component shape": {
+			Apt: &pb.AptRepository{Components: []string{"main", "non-free evil"}},
+		},
+		"apt arch newline": {
+			Apt: &pb.AptRepository{Arch: "amd64\n"},
+		},
+		"apt arch shape": {
+			Apt: &pb.AptRepository{Arch: "amd64 arm64"}, // space not allowed
+		},
+		"apt gpg_key_url newline": {
+			Apt: &pb.AptRepository{GpgKeyUrl: "https://a\nhttps://b"},
+		},
+		"dnf gpgkey newline": {
+			Dnf: &pb.DnfRepository{Gpgkey: "https://a\nhttps://b"},
+		},
+		"pacman siglevel newline": {
+			Pacman: &pb.PacmanRepository{SigLevel: "Required\nInjected=1"},
+		},
+		"pacman siglevel shape": {
+			Pacman: &pb.PacmanRepository{SigLevel: "Required! TrustAll"},
+		},
+		"zypper type newline": {
+			Zypper: &pb.ZypperRepository{Type: "rpm-md\nEvil: 1"},
+		},
+		"zypper type shape": {
+			Zypper: &pb.ZypperRepository{Type: "rpm md"},
+		},
+		"zypper gpgkey newline": {
+			Zypper: &pb.ZypperRepository{Gpgkey: "https://a\nhttps://b"},
+		},
+	}
+	for name, p := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := validateRepositoryParams(p)
+			if err == nil {
+				t.Fatalf("expected rejection, got nil")
+			}
+			if !strings.Contains(err.Error(), "repository") {
+				t.Errorf("error should name the repository field; got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Addresses the seven actionable items from the agent security audit, plus the coordinated SDK bump for finding #4.

**Depends on**: [manchtools/power-manage-sdk#35](https://github.com/manchtools/power-manage-sdk/pull/35) (bumped via \`replace\` to a pseudo-version of that branch; re-pin to the tagged SDK release before merging).

### Fixes

| # | Area | Change |
|---|------|--------|
| 1 | \`install.sh\` | Download \`SHA256SUMS\` alongside the binary; fail-closed on missing/mismatched hash; install via sibling-tmp-file + atomic \`mv\`. Previously a curl failure could leave \`BINARY_PATH\` half-written or replaced by a tampered binary. |
| 2 | \`executor/repository\` | New \`validateRepositoryParams\` covers every repo string field splice surface: APT distribution/components/arch/gpg_key_url, DNF gpgkey, Pacman SigLevel, Zypper type/gpgkey. Regex grammars on the enum-like fields (distribution, component, arch, siglevel, type). |
| 4 | \`main.go\` | Gateway mTLS call sites unchanged — they automatically benefit from the new strict \`WithMTLSFromPEM\` once the SDK is bumped. \`RenewCertificate\` call site switched to new \`WithMTLSFromPEMAndSystemRoots\` (control server sits behind Let's Encrypt in the reference deployment). |
| 5 | \`install.sh\` | Enrollment command built as a bash array and invoked via \`"\${cmd[@]}"\`; "try again" log line uses \`printf %q\` for safe copy-paste. |
| 6 | \`install.sh\` | LUKS sudoers rule expands \`\$BINARY_PATH\` (unquoted heredoc), so \`--binary\` installs no longer silently break LUKS actions. |
| 7 | \`README.md\` | Trust-boundary note: the 0666 enrollment socket + 5/min global rate limit means a hostile local user can briefly DoS enrollment. Acceptable for self-hosted MDM, documented for operators. |
| 8 | \`credentials\` | \`atomicWriteFile\`: tmp + fsync + rename + dir-fsync for both \`credentials.enc\` and the salt. Crash / full disk during write no longer corrupts enrollment state. |

Finding #3 (package-name option injection) is fixed in the SDK PR itself — the agent inherits the protection the moment \`pkg.New()\` is called, because \`Detect()\` now returns a validation-wrapped Manager. No per-site change needed here.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test ./...\` — full agent sweep passes
- New: \`TestValidateRepositoryParams_AcceptsRealistic\` / \`_RejectsInjection\`
- New: \`TestAtomicWriteFile_WritesAndReplaces\` / \`_AppliesMode\` / \`_WriteFailsNoLeftover\`
- [ ] Install-script dry run on a fresh host (confirm SHA verification triggers on tampered binary)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installation now verifies downloaded binary integrity using SHA256 checksums.

* **Bug Fixes**
  * Improved certificate verification for better security and compatibility.
  * Enhanced credential storage reliability with atomic file operations.
  * Strengthened repository parameter validation to prevent injection attacks.

* **Documentation**
  * Added trust boundary clarifications for enrollment socket configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->