### PR TITLE
fix: rc10 — refuse h2c gateway URL, docs match binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,13 +168,20 @@ URI Parameters:
 
 ### Environment Variables
 
+When both a flag and an env var are set, the env var wins (flag defaults are
+applied first, then env vars override).
+
 | Variable | Description |
 |----------|-------------|
-| `PM_SERVER` | Control server URL (used for registration) |
-| `PM_TOKEN` | Registration token |
-| `PM_DATA_DIR` | Data directory |
-| `PM_SKIP_VERIFY` | Skip TLS verification |
-| `PM_LOG_LEVEL` | Log level |
+| `POWER_MANAGE_SERVER` | Control server URL (used for registration) |
+| `POWER_MANAGE_TOKEN` | Registration token (first run only) |
+| `POWER_MANAGE_DATA_DIR` | Data directory for state |
+| `POWER_MANAGE_SKIP_VERIFY` | Skip TLS certificate verification (`true` to enable) |
+| `POWER_MANAGE_PRIVILEGE_BACKEND` | Privilege backend override: `sudo` (default) or `doas` |
+| `POWER_MANAGE_SERVICE_BACKEND` | Service backend override: `systemd` (default) |
+| `POWER_MANAGE_ENCRYPTION_BACKEND` | Encryption backend override: `luks` (default) |
+
+Log level has no env var; set it via the `-log-level` flag.
 
 ## Action Types
 

--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -495,28 +495,26 @@ func runAgent(ctx context.Context, creds *credentials.Credentials, hostname stri
 		// Reset handler connection state for new connection
 		h.ResetConnection()
 
-		var client *sdk.Client
-
-		// Check if using http:// (h2c mode for development) or https:// (mTLS for production)
+		// rc10: refuse http:// (h2c) for the network gateway path.
+		// The only h2c use in this binary is the local unix-socket
+		// enrollment client, never a remote gateway. A stored
+		// `http://` GatewayAddr means either a dev-leftover creds
+		// file or a tampered redirect — both are reasons to fail
+		// fast rather than silently skip mTLS on the live fleet.
 		if strings.HasPrefix(creds.GatewayAddr, "http://") {
-			// Development mode: use h2c (HTTP/2 cleartext)
-			logger.Debug("using h2c mode (development)")
-			client = sdk.NewClient(creds.GatewayAddr,
-				sdk.WithH2C(),
-				sdk.WithAuth(creds.DeviceID, ""),
-			)
-		} else {
-			// Production mode: use mTLS
-			mtlsOpt, err := sdk.WithMTLSFromPEM(creds.Certificate, creds.PrivateKey, creds.CACert)
-			if err != nil {
-				logger.Error("failed to configure mTLS", "error", err)
-				os.Exit(1)
-			}
-			client = sdk.NewClient(creds.GatewayAddr,
-				mtlsOpt,
-				sdk.WithAuth(creds.DeviceID, ""),
-			)
+			logger.Error("refusing h2c gateway URL — agent requires https:// for gateway connections; re-enrol against an https:// gateway or delete the cached credentials",
+				"gateway", creds.GatewayAddr)
+			os.Exit(1)
 		}
+		mtlsOpt, err := sdk.WithMTLSFromPEM(creds.Certificate, creds.PrivateKey, creds.CACert)
+		if err != nil {
+			logger.Error("failed to configure mTLS", "error", err)
+			os.Exit(1)
+		}
+		client := sdk.NewClient(creds.GatewayAddr,
+			mtlsOpt,
+			sdk.WithAuth(creds.DeviceID, ""),
+		)
 
 		// Create a child context for this connection session
 		sessionCtx, cancelSession := context.WithCancel(ctx)
@@ -567,7 +565,7 @@ func runAgent(ctx context.Context, creds *credentials.Credentials, hostname stri
 
 		// Wait for the stream to end
 		connStart := time.Now()
-		err := <-streamDone
+		err = <-streamDone
 
 		// Stop the goroutines and clear connection-dependent state
 		cancelSession()
@@ -1348,19 +1346,23 @@ func runLuksSetPassphrase(token, dataDir string) {
 		os.Exit(1)
 	}
 
-	// Connect to gateway via mTLS
-	var clientOpts []sdk.ClientOption
+	// Connect to gateway via mTLS. rc10 refuses http:// here too —
+	// the luks-setup command path is production-only (ships via the
+	// packaged binary on managed devices), so an http:// gateway
+	// would mean the stored credentials are stale or tampered.
 	if strings.HasPrefix(creds.GatewayAddr, "http://") {
-		clientOpts = append(clientOpts, sdk.WithH2C(), sdk.WithAuth(creds.DeviceID, ""))
-	} else {
-		mtlsOpt, err := sdk.WithMTLSFromPEM(creds.Certificate, creds.PrivateKey, creds.CACert)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: failed to configure mTLS: %v\n", err)
-			os.Exit(1)
-		}
-		clientOpts = append(clientOpts, mtlsOpt, sdk.WithAuth(creds.DeviceID, ""))
+		fmt.Fprintf(os.Stderr, "error: refusing h2c gateway URL (%s) — agent requires https:// for gateway connections\n", creds.GatewayAddr)
+		os.Exit(1)
 	}
-	client := sdk.NewClient(creds.GatewayAddr, clientOpts...)
+	mtlsOpt, err := sdk.WithMTLSFromPEM(creds.Certificate, creds.PrivateKey, creds.CACert)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: failed to configure mTLS: %v\n", err)
+		os.Exit(1)
+	}
+	client := sdk.NewClient(creds.GatewayAddr,
+		mtlsOpt,
+		sdk.WithAuth(creds.DeviceID, ""),
+	)
 
 	// Validate token — server returns action details and complexity requirements
 	result, err := client.ValidateLuksToken(ctx, token)
@@ -1562,24 +1564,24 @@ func runSelfTest(args []string) int {
 	}
 	logger.Info("self-test: credentials loaded", "device_id", creds.DeviceID)
 
-	// Step 2: Create mTLS client
-	var client *sdk.Client
+	// Step 2: Create mTLS client. rc10 refuses http:// here: the
+	// self-test is invoked by the packaged install flow on managed
+	// devices and must exercise the same security posture as normal
+	// agent operation.
 	if strings.HasPrefix(creds.GatewayAddr, "http://") {
-		client = sdk.NewClient(creds.GatewayAddr,
-			sdk.WithH2C(),
-			sdk.WithAuth(creds.DeviceID, ""),
-		)
-	} else {
-		mtlsOpt, err := sdk.WithMTLSFromPEM(creds.Certificate, creds.PrivateKey, creds.CACert)
-		if err != nil {
-			logger.Error("self-test: failed to configure mTLS", "error", err)
-			return 1
-		}
-		client = sdk.NewClient(creds.GatewayAddr,
-			mtlsOpt,
-			sdk.WithAuth(creds.DeviceID, ""),
-		)
+		logger.Error("self-test: refusing h2c gateway URL — agent requires https:// for gateway connections",
+			"gateway", creds.GatewayAddr)
+		return 1
 	}
+	mtlsOpt, err := sdk.WithMTLSFromPEM(creds.Certificate, creds.PrivateKey, creds.CACert)
+	if err != nil {
+		logger.Error("self-test: failed to configure mTLS", "error", err)
+		return 1
+	}
+	client := sdk.NewClient(creds.GatewayAddr,
+		mtlsOpt,
+		sdk.WithAuth(creds.DeviceID, ""),
+	)
 
 	// Step 3: Connect and send Hello, wait for Welcome
 	if err := client.Connect(ctx); err != nil {


### PR DESCRIPTION
## Summary

- **Breaking**: Agent's three network-gateway client paths (main streaming loop, `luks-setup` command, `self-test`) now refuse a stored gateway URL that starts with `http://`. The only legitimate h2c consumer in this binary is the local unix-socket enrollment client, which is unaffected. An `http://` gateway URL on a production-installed agent means either a stale-credentials file or a tampered redirect — in both cases fail-fast is the correct behavior.
- README env-var section rewritten to match the binary: `POWER_MANAGE_*` names only, drops the never-read `PM_LOG_LEVEL`, documents the three backend-override vars (privilege/service/encryption) that were previously undocumented.

## Deferred to a follow-up

The rc10 plan also called for CA-cert-missing fail-open post-enrollment, cert-rotation UNHEALTHY flag on the ops socket, Welcome-sent heartbeat cadence honor, and an install.sh enrollment-socket wait bump to 30s with explicit failure exit. Those are incremental improvements and land in a separate follow-up PR to keep this one focused on the security-critical h2c removal.

Part of manchtools/power-manage-server#74.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` clean
- [ ] After tag: enroll a test device against an https:// gateway, confirm streaming works
- [ ] Confirm that pointing the agent at an http:// URL exits with the new \`refusing h2c gateway URL\` error