### PR TITLE
fix: grant CAP_AUDIT_WRITE for sudo audit-log writes (#55)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -456,8 +456,17 @@ RestrictSUIDSGID=false
 #
 # The agent's only listener is a UNIX socket at
 # /run/pm-agent/enroll.sock — it does NOT bind TCP ports itself.
-AmbientCapabilities=CAP_SETUID CAP_SETGID
-CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_NET_BIND_SERVICE CAP_NET_ADMIN CAP_SYS_ADMIN
+#
+# CAP_AUDIT_WRITE: required for sudo to write USER_CMD records to the
+# kernel audit subsystem. Without it sudo invocations succeed but
+# emit "audit message cannot be sent: operation not permitted" to
+# stderr (issue #55) and the dedicated kernel-audit channel stays
+# dark for the agent's privileged operations — a compliance gap on
+# SOC2/PCI/CIS-regulated deployments. Granting only the write cap
+# matches what sshd / login / cron / systemd-logind already have;
+# it does not allow reading audit records or controlling auditd.
+AmbientCapabilities=CAP_SETUID CAP_SETGID CAP_AUDIT_WRITE
+CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_AUDIT_WRITE CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_NET_BIND_SERVICE CAP_NET_ADMIN CAP_SYS_ADMIN
 
 # Allow network access
 PrivateNetwork=false

--- a/install.sh
+++ b/install.sh
@@ -457,15 +457,19 @@ RestrictSUIDSGID=false
 # The agent's only listener is a UNIX socket at
 # /run/pm-agent/enroll.sock — it does NOT bind TCP ports itself.
 #
-# CAP_AUDIT_WRITE: required for sudo to write USER_CMD records to the
-# kernel audit subsystem. Without it sudo invocations succeed but
-# emit "audit message cannot be sent: operation not permitted" to
-# stderr (issue #55) and the dedicated kernel-audit channel stays
-# dark for the agent's privileged operations — a compliance gap on
-# SOC2/PCI/CIS-regulated deployments. Granting only the write cap
-# matches what sshd / login / cron / systemd-logind already have;
-# it does not allow reading audit records or controlling auditd.
-AmbientCapabilities=CAP_SETUID CAP_SETGID CAP_AUDIT_WRITE
+# CAP_AUDIT_WRITE: in the bounding set ONLY (not ambient). Required
+# so sudo (setuid-root, invoked for run_as_root shell actions) can
+# call audit_log_user_message() to write USER_CMD records to the
+# kernel audit subsystem. On execve, setuid-root binaries pick up
+# caps from `bounding ∩ file_caps` — the bounding-set entry is what
+# allows sudo to keep CAP_AUDIT_WRITE; the ambient entry would be
+# extra privilege for the agent process itself, which never calls
+# audit(2) directly. Without the bounding-set grant, sudo
+# invocations succeed but emit "audit message cannot be sent:
+# operation not permitted" (issue #55) and the kernel-audit channel
+# is dark for privileged operations — a compliance gap on
+# SOC2/PCI/CIS-regulated deployments.
+AmbientCapabilities=CAP_SETUID CAP_SETGID
 CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_AUDIT_WRITE CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_NET_BIND_SERVICE CAP_NET_ADMIN CAP_SYS_ADMIN
 
 # Allow network access


### PR DESCRIPTION
## Summary

Adds `CAP_AUDIT_WRITE` to the agent's systemd unit so sudo can write `USER_CMD` records to the kernel audit subsystem when the agent shells out for `run_as_root: true` actions.

Closes manchtools/power-manage-agent#55.

## Why

Sudo's `audit_log_user_message()` returned EPERM because the cap wasn't in the bounding set, producing the localised stderr warning ("Audit-Nachricht kann nicht gesendet werden") on every privileged shell action. The privileged command still ran (exit 0), but the warning surfaced as "execution error" on compliance policy results and the dedicated kernel-audit channel was dark for all the agent's privileged operations — a real compliance gap on SOC2/PCI/CIS-regulated deployments.

`CAP_AUDIT_WRITE` is the minimum-privilege cap for "I'm a thing that uses sudo or PAM": only allows writing to the audit log, not reading records or controlling auditd. Standard for sshd, login, cron, systemd-logind.

## Diff

Both `AmbientCapabilities` and `CapabilityBoundingSet` get the cap:

```diff
-AmbientCapabilities=CAP_SETUID CAP_SETGID
-CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_CHOWN ...
+AmbientCapabilities=CAP_SETUID CAP_SETGID CAP_AUDIT_WRITE
+CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_AUDIT_WRITE CAP_CHOWN ...
```

## Test plan

- [ ] Reinstall agent on a host that previously emitted the warning (`sudo bash install.sh ...`)
- [ ] `systemctl restart power-manage-agent && systemctl daemon-reload`
- [ ] Dispatch a `run_as_root: true` compliance action; assert no audit warning in stderr
- [ ] `ausearch -m USER_CMD -ts recent` shows the sudo invocation (was empty before)
- [ ] `journalctl -u power-manage-agent | grep sudo` still shows the entry (existing channel unaffected)

## Milestone

2026.05 — install.sh template change ships with the next agent release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced agent audit logging capabilities to provide improved visibility and tracking of privileged operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->