### PR TITLE
chore: remove coderabbit linked_repositories

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -21,6 +21,3 @@ reviews:
 knowledge_base:
   learnings:
     scope: auto
-  linked_repositories:
-    - repository: manchtools/power-manage-sdk
-    - repository: manchtools/power-manage-server


### PR DESCRIPTION
CodeRabbit's current plan tier allows 0 linked repositories. The configured cross-repo references to `power-manage-sdk` and `power-manage-server` were being silently dropped on every review with a warning. Removing the block to stop the noise.

Same change going out on `power-manage-sdk` and `power-manage-server`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated knowledge base configuration to use automatic scoping for enhanced context management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->