### PR TITLE
feat: grouped sync wire on the agent (#45)

### DIFF
--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -809,7 +809,7 @@ func syncActionsFromServer(ctx context.Context, client *sdk.Client, sched *sched
 		return 0
 	}
 
-	if err := sched.SyncActions(ctx, result.Actions, firstSync); err != nil {
+	if err := sched.SyncActions(ctx, result.StandaloneActions, result.GroupedActions, firstSync); err != nil {
 		logger.Error("failed to update local action store", "error", err)
 		return 0
 	}
@@ -823,7 +823,8 @@ func syncActionsFromServer(ctx context.Context, client *sdk.Client, sched *sched
 	}
 
 	logger.Info("actions synced from server",
-		"total", len(result.Actions),
+		"standalone_total", len(result.StandaloneActions),
+		"groups_total", len(result.GroupedActions),
 		"first_sync", firstSync,
 		"sync_interval", syncInterval.String(),
 	)

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see agent/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.3.1
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260502221138-995a7814adeb
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.3.1 h1:Q0lq3mMDHRqhWp6TFsDHXrhfIq5oJ8s/L1IoeJ+F5rQ=
-github.com/manchtools/power-manage-sdk v0.3.1/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260502221138-995a7814adeb h1:NxY+2F95GqfkUZiG8Bux5wR09wWmid+0tceOgEatgIw=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260502221138-995a7814adeb/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -156,12 +156,12 @@ func (s *Scheduler) GetStoredActions() ([]*store.StoredAction, error) {
 // members enter the queue together rather than each firing
 // independently and racing.
 func (s *Scheduler) runDueActions(ctx context.Context) {
-	actions, err := s.store.GetDueActions()
+	actions, err := s.store.GetDueActions(ctx)
 	if err != nil {
 		s.logger.Error("failed to get due actions", "error", err)
 		return
 	}
-	groups, err := s.store.GetDueGroups()
+	groups, err := s.store.GetDueGroups(ctx)
 	if err != nil {
 		s.logger.Error("failed to get due groups", "error", err)
 		// Continue with standalone-only — group failures shouldn't

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -144,21 +144,39 @@ func (s *Scheduler) GetStoredActions() ([]*store.StoredAction, error) {
 	return s.store.GetAllActions()
 }
 
-// runDueActions executes all actions that are due.
+// runDueActions executes all actions that are due — both standalone
+// actions (per-action schedule) and grouped actions (one schedule per
+// container, members run in declared order when the container fires).
+//
+// Standalone actions run first, then groups. Within a group every
+// member executes serially in declared order; the executor is the
+// existing single-action path, so the group simply iterates and
+// dispatches one at a time. This is what gives manchtools/power-manage-
+// agent#45 its ordering guarantee: when a container fires, all of its
+// members enter the queue together rather than each firing
+// independently and racing.
 func (s *Scheduler) runDueActions(ctx context.Context) {
 	actions, err := s.store.GetDueActions()
 	if err != nil {
 		s.logger.Error("failed to get due actions", "error", err)
 		return
 	}
+	groups, err := s.store.GetDueGroups()
+	if err != nil {
+		s.logger.Error("failed to get due groups", "error", err)
+		// Continue with standalone-only — group failures shouldn't
+		// silently strand standalone work.
+	}
 
-	if len(actions) == 0 {
+	if len(actions) == 0 && len(groups) == 0 {
 		return
 	}
 
-	s.logger.Debug("found due actions", "count", len(actions))
+	if len(actions) > 0 || len(groups) > 0 {
+		s.logger.Debug("found due actions", "standalone", len(actions), "groups", len(groups))
+	}
 
-	// Reset the per-cycle agent update dedup flag
+	// Reset the per-cycle agent update dedup flag.
 	executor.ResetAgentUpdateCycle()
 
 	for _, stored := range actions {
@@ -171,9 +189,60 @@ func (s *Scheduler) runDueActions(ctx context.Context) {
 		s.executeAction(ctx, stored)
 	}
 
-	// Cleanup old results periodically
+	for _, g := range groups {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		s.executeGroup(ctx, g)
+	}
+
+	// Cleanup old results periodically.
 	if err := s.store.CleanupOldResults(ResultRetention); err != nil {
 		s.logger.Warn("failed to cleanup old results", "error", err)
+	}
+}
+
+// executeGroup walks a due group's members in declared order, dispatches
+// each through the existing per-action executor, and advances the
+// group's next_execute_at when all members have been attempted.
+//
+// A failure on one member does NOT short-circuit the rest. Idempotent
+// retries on the next cycle handle recovery; if an operator wants
+// strict skip-on-failure semantics that's a follow-up.
+func (s *Scheduler) executeGroup(ctx context.Context, g store.StoredActionGroup) {
+	s.logger.Info("group due",
+		"group_id", g.ID,
+		"member_count", len(g.MemberActionIDs),
+	)
+
+	for _, actionID := range g.MemberActionIDs {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		stored, err := s.store.GetAction(actionID)
+		if err != nil {
+			s.logger.Error("failed to get group member action",
+				"group_id", g.ID, "action_id", actionID, "error", err)
+			continue
+		}
+		if stored == nil {
+			s.logger.Warn("group member action missing from store",
+				"group_id", g.ID, "action_id", actionID)
+			continue
+		}
+
+		s.executeAction(ctx, stored)
+	}
+
+	// Mark the group as fired so its next_execute_at advances.
+	if err := s.store.MarkGroupExecuted(g.ID, time.Now()); err != nil {
+		s.logger.Error("failed to mark group executed",
+			"group_id", g.ID, "error", err)
 	}
 }
 
@@ -323,13 +392,21 @@ func (s *Scheduler) ForceExecute(ctx context.Context, actionID string) (*pb.Acti
 
 // SyncActions replaces all stored actions with the provided list from the server.
 // This syncs the local action store with the server's assigned actions.
-// Removed actions: policy-type actions (SSH, SSHD, Sudo, LPS) are reverted
-// to ABSENT state before removal. Other action types are removed without
-// reverting to avoid destructive side effects.
-// Changed actions (desired_state flipped) are re-executed.
-// New actions are executed immediately.
-// If firstSync is true, all actions are executed (used on agent startup).
-func (s *Scheduler) SyncActions(ctx context.Context, actions []*pb.Action, firstSync bool) error {
+// Removed standalone actions: policy-type actions (SSH, SSHD, Sudo, LPS,
+// USER, GROUP) are reverted to ABSENT state before removal. Other types
+// are removed without reverting to avoid destructive side effects.
+// Changed actions (desired_state flipped, or migrated standalone↔grouped)
+// are re-executed.
+// New actions are executed immediately on first sync.
+//
+// Grouped actions are stored with their containers (action_groups +
+// group_members) and only fire when their group's schedule is due —
+// they are NOT executed individually here. New groups are handled by
+// runDueActions on the next tick (their initial next_execute_at honors
+// the schedule's run_on_assign / interval). The scheduler's per-tick
+// loop fires every due group's members in declared order, which is the
+// ordering guarantee introduced for #45.
+func (s *Scheduler) SyncActions(ctx context.Context, standalone []*pb.Action, groups []*pb.ActionGroup, firstSync bool) error {
 	// Check for shutdown before starting
 	if ctx.Err() != nil {
 		return ctx.Err()
@@ -338,25 +415,28 @@ func (s *Scheduler) SyncActions(ctx context.Context, actions []*pb.Action, first
 	// Reset the per-cycle agent update dedup flag for the sync batch.
 	executor.ResetAgentUpdateCycle()
 
-	s.logger.Info("syncing actions from server", "count", len(actions), "first_sync", firstSync)
+	s.logger.Info("syncing actions from server",
+		"standalone", len(standalone),
+		"groups", len(groups),
+		"first_sync", firstSync)
 
 	// Sync actions to store and get change info
-	syncResult, err := s.store.SyncActions(actions)
+	syncResult, err := s.store.SyncStandaloneAndGrouped(standalone, groups)
 	if err != nil {
 		s.logger.Error("failed to sync actions", "error", err)
 		return err
 	}
 
 	s.logger.Info("actions synced successfully",
-		"total", len(actions),
-		"new", len(syncResult.NewActionIDs),
-		"changed", len(syncResult.ChangedActionIDs),
-		"removed", len(syncResult.RemovedActions),
+		"standalone_total", len(standalone),
+		"groups_total", len(groups),
+		"new_standalone", len(syncResult.NewActionIDs),
+		"changed_standalone", len(syncResult.ChangedActionIDs),
+		"new_groups", len(syncResult.NewGroupIDs),
+		"removed_standalone", len(syncResult.RemovedActions),
 	)
 
 	// Revert policy-type actions before removal to clean up their effects.
-	// Non-policy actions (Package, User, File, etc.) are just removed without
-	// reverting to avoid destructive side effects.
 	if len(syncResult.RemovedActions) > 0 {
 		for _, removed := range syncResult.RemovedActions {
 			if removed.Id != nil {
@@ -376,27 +456,24 @@ func (s *Scheduler) SyncActions(ctx context.Context, actions []*pb.Action, first
 		}
 	}
 
-	// Determine which stored actions to execute
+	// Determine which standalone actions to execute right now.
 	var actionsToExecute []string
 	if firstSync {
-		// On first sync, execute ALL actions
-		for _, action := range actions {
+		for _, action := range standalone {
 			if action.Id != nil {
 				actionsToExecute = append(actionsToExecute, action.Id.Value)
 			}
 		}
 		if len(actionsToExecute) > 0 {
-			s.logger.Info("first sync: executing all assigned actions", "count", len(actionsToExecute))
+			s.logger.Info("first sync: executing all standalone actions", "count", len(actionsToExecute))
 		}
 	} else {
-		// On subsequent syncs, execute new and changed actions
 		actionsToExecute = append(syncResult.NewActionIDs, syncResult.ChangedActionIDs...)
 		if len(actionsToExecute) > 0 {
-			s.logger.Info("executing new/changed actions", "count", len(actionsToExecute))
+			s.logger.Info("executing new/changed standalone actions", "count", len(actionsToExecute))
 		}
 	}
 
-	// Execute the actions
 	for _, actionID := range actionsToExecute {
 		select {
 		case <-ctx.Done():

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -208,9 +208,16 @@ func (s *Scheduler) runDueActions(ctx context.Context) {
 // each through the existing per-action executor, and advances the
 // group's next_execute_at when all members have been attempted.
 //
-// A failure on one member does NOT short-circuit the rest. Idempotent
-// retries on the next cycle handle recovery; if an operator wants
-// strict skip-on-failure semantics that's a follow-up.
+// A failure on one member does NOT short-circuit the rest — this is a
+// deliberate design choice from the #45 design discussion. The original
+// issue text proposed cascading SKIPPED_DEPENDENCY_FAILED to siblings,
+// but during design we landed on simpler "ordered execution + idempotent
+// retries" semantics: members run in declared order on every group fire,
+// and a failed member fails again next cycle. Sibling failures don't
+// hide root-cause failures — they each surface their own status — but
+// we don't fabricate skip records for them either. If an operator wants
+// strict skip-on-failure with explicit dependency reporting later,
+// that's a follow-up that re-introduces SKIPPED_DEPENDENCY_FAILED.
 func (s *Scheduler) executeGroup(ctx context.Context, g store.StoredActionGroup) {
 	s.logger.Info("group due",
 		"group_id", g.ID,

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -262,13 +262,13 @@ func TestSyncActions_PolicyActionRevertedOnRemoval(t *testing.T) {
 	// Assign SSH and Package actions
 	sshAction := makeTestAction("ssh-sync", pb.ActionType_ACTION_TYPE_SSH, pb.DesiredState_DESIRED_STATE_PRESENT)
 	pkgAction := makeTestAction("pkg-sync", pb.ActionType_ACTION_TYPE_PACKAGE, pb.DesiredState_DESIRED_STATE_PRESENT)
-	if err := sched.SyncActions(ctx, []*pb.Action{sshAction, pkgAction}, true); err != nil {
+	if err := sched.SyncActions(ctx, []*pb.Action{sshAction, pkgAction}, nil, true); err != nil {
 		t.Fatal(err)
 	}
 	mock.reset()
 
 	// Sync again with only the package action — SSH is now removed
-	if err := sched.SyncActions(ctx, []*pb.Action{pkgAction}, false); err != nil {
+	if err := sched.SyncActions(ctx, []*pb.Action{pkgAction}, nil, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -296,13 +296,13 @@ func TestSyncActions_NonPolicyActionNotRevertedOnRemoval(t *testing.T) {
 
 	// Assign a package action
 	pkgAction := makeTestAction("pkg-only", pb.ActionType_ACTION_TYPE_PACKAGE, pb.DesiredState_DESIRED_STATE_PRESENT)
-	if err := sched.SyncActions(ctx, []*pb.Action{pkgAction}, true); err != nil {
+	if err := sched.SyncActions(ctx, []*pb.Action{pkgAction}, nil, true); err != nil {
 		t.Fatal(err)
 	}
 	mock.reset()
 
 	// Sync with empty list — package action is removed but NOT reverted
-	if err := sched.SyncActions(ctx, []*pb.Action{}, false); err != nil {
+	if err := sched.SyncActions(ctx, []*pb.Action{}, nil, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -335,13 +335,13 @@ func TestSyncActions_MultiplePolicyActionsReverted(t *testing.T) {
 		makeTestAction("a-lps", pb.ActionType_ACTION_TYPE_LPS, pb.DesiredState_DESIRED_STATE_PRESENT),
 		makeTestAction("a-pkg", pb.ActionType_ACTION_TYPE_PACKAGE, pb.DesiredState_DESIRED_STATE_PRESENT),
 	}
-	if err := sched.SyncActions(ctx, actions, true); err != nil {
+	if err := sched.SyncActions(ctx, actions, nil, true); err != nil {
 		t.Fatal(err)
 	}
 	mock.reset()
 
 	// Remove all actions by syncing with empty list
-	if err := sched.SyncActions(ctx, []*pb.Action{}, false); err != nil {
+	if err := sched.SyncActions(ctx, []*pb.Action{}, nil, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -388,13 +388,13 @@ func TestSyncActions_RevertPreservesActionFields(t *testing.T) {
 			},
 		},
 	}
-	if err := sched.SyncActions(ctx, []*pb.Action{sudoAction}, true); err != nil {
+	if err := sched.SyncActions(ctx, []*pb.Action{sudoAction}, nil, true); err != nil {
 		t.Fatal(err)
 	}
 	mock.reset()
 
 	// Remove it
-	if err := sched.SyncActions(ctx, []*pb.Action{}, false); err != nil {
+	if err := sched.SyncActions(ctx, []*pb.Action{}, nil, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -420,5 +420,112 @@ func TestSyncActions_RevertPreservesActionFields(t *testing.T) {
 	}
 	if len(sudo.Users) != 1 || sudo.Users[0] != "alice" {
 		t.Errorf("expected users [alice], got %v", sudo.Users)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Grouped sync (#45)
+// ---------------------------------------------------------------------------
+
+// When the server pushes an ActionGroup with run_on_assign=true, the
+// group's first runDueActions tick walks its members in declared order,
+// dispatching each through the executor — sequentially, no inter-leaving.
+func TestRunDueActions_GroupRunOnAssign_OrdersMembers(t *testing.T) {
+	sched, mock := newTestScheduler(t)
+	ctx := context.Background()
+
+	a1 := makeTestAction("g-a1", pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT)
+	a2 := makeTestAction("g-a2", pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT)
+	a3 := makeTestAction("g-a3", pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT)
+
+	group := &pb.ActionGroup{
+		SourceLabel: "action_set:run-on-assign",
+		Schedule:    &pb.ActionSchedule{RunOnAssign: true, IntervalHours: 8},
+		Actions:     []*pb.Action{a1, a2, a3},
+	}
+
+	if err := sched.SyncActions(ctx, nil, []*pb.ActionGroup{group}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sync itself does not execute group members; only the next tick does.
+	if got := len(mock.getCalls()); got != 0 {
+		t.Fatalf("sync should not execute group members directly, got %d", got)
+	}
+
+	sched.runDueActions(ctx)
+
+	calls := mock.getCalls()
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 group member calls, got %d", len(calls))
+	}
+	wantOrder := []string{"g-a1", "g-a2", "g-a3"}
+	for i, want := range wantOrder {
+		if calls[i].Id.Value != want {
+			t.Errorf("call %d: expected %q got %q", i, want, calls[i].Id.Value)
+		}
+	}
+}
+
+// Same action id can appear at multiple positions within a group (e.g.
+// AAA in two sets that compose the same definition). Each occurrence
+// dispatches the executor — idempotent action contracts absorb the cost.
+func TestRunDueActions_GroupAllowsDuplicateMembers(t *testing.T) {
+	sched, mock := newTestScheduler(t)
+	ctx := context.Background()
+
+	common := makeTestAction("dup-action", pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT)
+	other := makeTestAction("other", pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT)
+
+	group := &pb.ActionGroup{
+		SourceLabel: "definition:dup-positions",
+		Schedule:    &pb.ActionSchedule{RunOnAssign: true},
+		Actions:     []*pb.Action{common, other, common},
+	}
+	if err := sched.SyncActions(ctx, nil, []*pb.ActionGroup{group}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	sched.runDueActions(ctx)
+
+	calls := mock.getCalls()
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 calls (dup-action runs twice), got %d", len(calls))
+	}
+	gotOrder := []string{calls[0].Id.Value, calls[1].Id.Value, calls[2].Id.Value}
+	wantOrder := []string{"dup-action", "other", "dup-action"}
+	for i, want := range wantOrder {
+		if gotOrder[i] != want {
+			t.Errorf("call %d: expected %q got %q", i, want, gotOrder[i])
+		}
+	}
+}
+
+// Group members are NOT picked up by the standalone-tick — they only
+// fire when their group fires. This is the load-bearing invariant for
+// the ordering guarantee: members must not race each other on
+// independent per-action schedules.
+func TestRunDueActions_GroupedActionsSkipStandaloneTick(t *testing.T) {
+	sched, mock := newTestScheduler(t)
+	ctx := context.Background()
+
+	a1 := makeTestAction("g-only", pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT)
+	// Cron "0 0 1 1 *" = Jan 1 at midnight; far-future for almost any
+	// year except a brief Jan-1 window. This guarantees the group is
+	// not currently due so we can assert the standalone tick is not
+	// silently picking up grouped members on its own.
+	group := &pb.ActionGroup{
+		SourceLabel: "action_set:far-future",
+		Schedule:    &pb.ActionSchedule{Cron: "0 0 1 1 *"},
+		Actions:     []*pb.Action{a1},
+	}
+	if err := sched.SyncActions(ctx, nil, []*pb.ActionGroup{group}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	sched.runDueActions(ctx)
+
+	if got := len(mock.getCalls()); got != 0 {
+		t.Fatalf("far-future group must not fire AND its member must not run via standalone tick, got %d calls", got)
 	}
 }

--- a/internal/store/migrations/003_action_groups.sql
+++ b/internal/store/migrations/003_action_groups.sql
@@ -1,0 +1,70 @@
+-- Add action_groups + group_members and tag standalone vs grouped
+-- actions on the existing actions table.
+--
+-- A group is one action set or definition that reaches the device,
+-- carrying a single schedule and an ordered list of member actions.
+-- When the group's schedule fires, every member runs in declared
+-- order through the existing executor — that's the ordering guarantee
+-- introduced for #45 (manchtools/power-manage-agent#45).
+--
+-- Per the design, group state is replaced wholesale on every sync.
+-- Action *data* still lives on the existing `actions` table (so the
+-- executor's per-action lookups and last_executed_at bookkeeping
+-- don't need to change), but member actions are tagged is_grouped=1
+-- so the standalone-due query (next_execute_at <= now) skips them —
+-- they fire only when their owning group fires.
+--
+-- The action_groups.id is the server-emitted source_label (e.g.
+-- "definition:<ulid>" or "action_set:<ulid>"). Stable across syncs
+-- only because the source ulid doesn't change.
+--
+-- See manchtools/power-manage-agent#45.
+
+-- +goose Up
+
+ALTER TABLE actions ADD COLUMN is_grouped INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS action_groups (
+    id                TEXT PRIMARY KEY,
+    source_label      TEXT NOT NULL,
+    schedule_json     TEXT NOT NULL,
+    assigned_at       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_executed_at  DATETIME,
+    next_execute_at   DATETIME NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS group_members (
+    group_id   TEXT NOT NULL,
+    position   INTEGER NOT NULL,
+    action_id  TEXT NOT NULL,
+    PRIMARY KEY (group_id, position),
+    FOREIGN KEY (group_id) REFERENCES action_groups(id) ON DELETE CASCADE,
+    FOREIGN KEY (action_id) REFERENCES actions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_action_groups_next_execute ON action_groups(next_execute_at);
+CREATE INDEX IF NOT EXISTS idx_group_members_action ON group_members(action_id);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_group_members_action;
+DROP INDEX IF EXISTS idx_action_groups_next_execute;
+DROP TABLE IF EXISTS group_members;
+DROP TABLE IF EXISTS action_groups;
+
+-- SQLite doesn't support DROP COLUMN cleanly across versions; rebuild
+-- the actions table without is_grouped.
+CREATE TABLE actions_new (
+    id TEXT PRIMARY KEY,
+    action_json TEXT NOT NULL,
+    assigned_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_executed_at DATETIME,
+    next_execute_at DATETIME NOT NULL,
+    last_result_hash TEXT DEFAULT '',
+    desired_state INTEGER NOT NULL DEFAULT 0
+);
+INSERT INTO actions_new (id, action_json, assigned_at, last_executed_at, next_execute_at, last_result_hash, desired_state)
+    SELECT id, action_json, assigned_at, last_executed_at, next_execute_at, last_result_hash, desired_state FROM actions;
+DROP TABLE actions;
+ALTER TABLE actions_new RENAME TO actions;
+CREATE INDEX IF NOT EXISTS idx_actions_next_execute ON actions(next_execute_at);

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -189,7 +189,15 @@ func (s *Store) GetAction(actionID string) (*StoredAction, error) {
 	return &stored, nil
 }
 
-// GetDueActions returns all actions that are due for execution.
+// GetDueActions returns all standalone actions that are due for
+// execution. Grouped action members are skipped (is_grouped = 1) — they
+// only fire when their owning group fires, via GetDueGroups +
+// executeGroup. This is the load-bearing invariant for #45's ordering
+// guarantee: members must not race each other on independent per-action
+// schedules. Note that RecordExecution updates next_execute_at on every
+// run including for grouped members, so without this filter a grouped
+// member would silently leak back into standalone scheduling after its
+// first execution.
 func (s *Store) GetDueActions() ([]*StoredAction, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -197,7 +205,7 @@ func (s *Store) GetDueActions() ([]*StoredAction, error) {
 	rows, err := s.db.Query(`
 		SELECT id, action_json, assigned_at, last_executed_at, next_execute_at, last_result_hash
 		FROM actions
-		WHERE next_execute_at <= ?
+		WHERE next_execute_at <= ? AND is_grouped = 0
 		ORDER BY next_execute_at ASC
 	`, time.Now().UTC())
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3,6 +3,7 @@
 package store
 
 import (
+	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
@@ -198,11 +199,15 @@ func (s *Store) GetAction(actionID string) (*StoredAction, error) {
 // run including for grouped members, so without this filter a grouped
 // member would silently leak back into standalone scheduling after its
 // first execution.
-func (s *Store) GetDueActions() ([]*StoredAction, error) {
+//
+// Takes a context so the scheduler can cancel a blocking SQLite query
+// when shutdown fires; without this the poll loop would stall on the
+// query rather than honoring ctx.Done().
+func (s *Store) GetDueActions(ctx context.Context) ([]*StoredAction, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	rows, err := s.db.Query(`
+	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, action_json, assigned_at, last_executed_at, next_execute_at, last_result_hash
 		FROM actions
 		WHERE next_execute_at <= ? AND is_grouped = 0
@@ -730,18 +735,34 @@ func (s *Store) SyncStandaloneAndGrouped(standalone []*pb.Action, groups []*pb.A
 
 	// ---- groups: drop and recreate in this same TX ----
 
-	priorGroupIDs := make(map[string]bool)
-	groupRows, err := tx.Query("SELECT id FROM action_groups")
+	// Snapshot existing groups' execution state. The drop+rebuild path
+	// would otherwise wipe last_executed_at and next_execute_at every
+	// sync, and a group with an interval/run_on_assign schedule would
+	// then come back with lastExecuted=nil and re-fire immediately.
+	// For groups whose schedule_json is unchanged we preserve the
+	// existing cadence; only schedule changes (or a brand-new group)
+	// reset to the schedule's first slot.
+	type existingGroup struct {
+		scheduleJSON   string
+		lastExecutedAt sql.NullTime
+		nextExecuteAt  time.Time
+	}
+	existingGroups := make(map[string]existingGroup)
+	groupRows, err := tx.Query(`
+		SELECT id, schedule_json, last_executed_at, next_execute_at
+		FROM action_groups
+	`)
 	if err != nil {
 		return nil, fmt.Errorf("query action_groups: %w", err)
 	}
 	for groupRows.Next() {
 		var id string
-		if err := groupRows.Scan(&id); err != nil {
+		var eg existingGroup
+		if err := groupRows.Scan(&id, &eg.scheduleJSON, &eg.lastExecutedAt, &eg.nextExecuteAt); err != nil {
 			groupRows.Close()
-			return nil, fmt.Errorf("scan group id: %w", err)
+			return nil, fmt.Errorf("scan action_group: %w", err)
 		}
-		priorGroupIDs[id] = true
+		existingGroups[id] = eg
 	}
 	groupRows.Close()
 
@@ -766,12 +787,28 @@ func (s *Store) SyncStandaloneAndGrouped(standalone []*pb.Action, groups []*pb.A
 			return nil, fmt.Errorf("marshal group schedule for %s: %w", groupID, err)
 		}
 
-		nextExecute := calculateNextExecuteFromSchedule(g.Schedule, nil, false)
+		// Preserve cadence across syncs when nothing about the group's
+		// schedule changed; otherwise reset to the new schedule's first
+		// slot.
+		var nextExecute time.Time
+		var lastExecutedAt sql.NullTime
+		if prior, ok := existingGroups[groupID]; ok && prior.scheduleJSON == string(schedJSON) {
+			nextExecute = prior.nextExecuteAt
+			lastExecutedAt = prior.lastExecutedAt
+		} else {
+			var lastExec *time.Time
+			if prior, ok := existingGroups[groupID]; ok && prior.lastExecutedAt.Valid {
+				t := prior.lastExecutedAt.Time
+				lastExec = &t
+				lastExecutedAt = prior.lastExecutedAt
+			}
+			nextExecute = calculateNextExecuteFromSchedule(g.Schedule, lastExec, false)
+		}
 
 		if _, err := tx.Exec(`
-			INSERT INTO action_groups (id, source_label, schedule_json, assigned_at, next_execute_at)
-			VALUES (?, ?, ?, CURRENT_TIMESTAMP, ?)
-		`, groupID, g.SourceLabel, string(schedJSON), nextExecute); err != nil {
+			INSERT INTO action_groups (id, source_label, schedule_json, assigned_at, last_executed_at, next_execute_at)
+			VALUES (?, ?, ?, CURRENT_TIMESTAMP, ?, ?)
+		`, groupID, g.SourceLabel, string(schedJSON), lastExecutedAt, nextExecute); err != nil {
 			return nil, fmt.Errorf("insert action_group %s: %w", groupID, err)
 		}
 
@@ -787,7 +824,7 @@ func (s *Store) SyncStandaloneAndGrouped(standalone []*pb.Action, groups []*pb.A
 			}
 		}
 
-		if !priorGroupIDs[groupID] {
+		if _, existed := existingGroups[groupID]; !existed {
 			result.NewGroupIDs = append(result.NewGroupIDs, groupID)
 		}
 	}
@@ -801,12 +838,15 @@ func (s *Store) SyncStandaloneAndGrouped(standalone []*pb.Action, groups []*pb.A
 // GetDueGroups returns action groups whose schedule says they're due
 // for execution. Caller fetches members via GetGroupMembers and runs
 // them in declared order.
-func (s *Store) GetDueGroups() ([]StoredActionGroup, error) {
+//
+// Takes a context so the scheduler can cancel a blocking SQLite query
+// when shutdown fires, same rationale as GetDueActions.
+func (s *Store) GetDueGroups(ctx context.Context) ([]StoredActionGroup, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	now := time.Now().UTC()
-	rows, err := s.db.Query(`
+	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, source_label, schedule_json, last_executed_at, next_execute_at
 		FROM action_groups
 		WHERE next_execute_at <= ?

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -45,6 +45,19 @@ type SyncResult struct {
 	NewActionIDs     []string     // Actions that were not previously stored
 	ChangedActionIDs []string     // Actions whose desired_state changed
 	RemovedActions   []*pb.Action // Full action data for removed actions (for undo)
+	NewGroupIDs      []string     // Groups that were not previously stored (run-on-first-sync)
+}
+
+// StoredActionGroup represents one container's worth of actions sharing
+// a schedule. The group's schedule fires every member action when due,
+// in declared order — see manchtools/power-manage-agent#45.
+type StoredActionGroup struct {
+	ID              string // server-emitted source_label, e.g. "definition:<ulid>"
+	SourceLabel     string
+	Schedule        *pb.ActionSchedule
+	LastExecutedAt  *time.Time
+	NextExecuteAt   time.Time
+	MemberActionIDs []string // in declared sort_order; duplicates allowed
 }
 
 // StoredResult represents an execution result stored locally (for sync when online).
@@ -535,6 +548,415 @@ func (s *Store) SyncActions(actions []*pb.Action) (*SyncResult, error) {
 		return nil, err
 	}
 	return result, nil
+}
+
+// SyncStandaloneAndGrouped replaces both the standalone-action store
+// and the grouped-action store with the server's latest snapshot.
+//
+// Standalone actions follow the existing SyncActions semantics: the
+// caller's slice is upserted into the actions table with is_grouped=0,
+// new/changed/removed are reported in SyncResult, and removed actions
+// are returned in full so policy-style executors can revert them.
+//
+// Grouped action data is upserted with is_grouped=1 so the standalone
+// runDueActions query (next_execute_at <= now AND is_grouped = 0)
+// silently skips it — these actions only fire when their group fires.
+//
+// action_groups + group_members are dropped and rebuilt on every call
+// per the design (server is authoritative; the agent is a snapshot).
+// New groups (not present on the previous sync) are reported in
+// SyncResult.NewGroupIDs so the scheduler can fire them once on first
+// arrival before their normal cadence kicks in.
+func (s *Store) SyncStandaloneAndGrouped(standalone []*pb.Action, groups []*pb.ActionGroup) (*SyncResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result := &SyncResult{}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	// ---- standalone actions: existing diff/upsert pattern ----
+
+	serverStandalone := make(map[string]*pb.Action, len(standalone))
+	for _, a := range standalone {
+		if a.Id != nil {
+			serverStandalone[a.Id.Value] = a
+		}
+	}
+
+	// Collect every action id that should be present on the agent. We
+	// keep grouped-member ids in a second set so we can distinguish
+	// removed-standalone (returned in RemovedActions for revert) from
+	// removed-or-now-grouped (silent — group members never get the
+	// revert path because they're driven by the group, not by their own
+	// schedule).
+	groupedMembers := make(map[string]bool)
+	for _, g := range groups {
+		for _, ga := range g.Actions {
+			if ga.Id != nil {
+				groupedMembers[ga.Id.Value] = true
+			}
+		}
+	}
+
+	rows, err := tx.Query("SELECT id, action_json, desired_state, is_grouped FROM actions")
+	if err != nil {
+		return nil, fmt.Errorf("query actions: %w", err)
+	}
+	type localAction struct {
+		id           string
+		actionJSON   string
+		desiredState int32
+		isGrouped    int
+	}
+	localActions := make(map[string]*localAction)
+	for rows.Next() {
+		var la localAction
+		if err := rows.Scan(&la.id, &la.actionJSON, &la.desiredState, &la.isGrouped); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan action: %w", err)
+		}
+		localActions[la.id] = &la
+	}
+	rows.Close()
+
+	// Removals: action no longer present on standalone OR grouped.
+	for localID, la := range localActions {
+		if _, isStandalone := serverStandalone[localID]; isStandalone {
+			continue
+		}
+		if groupedMembers[localID] {
+			continue
+		}
+		// Only return previously-standalone actions for revert; grouped
+		// members that simply migrated to standalone (or vice versa)
+		// were already handled by the upsert below in past syncs.
+		if la.isGrouped == 0 {
+			action := &pb.Action{}
+			if err := protojson.Unmarshal([]byte(la.actionJSON), action); err != nil {
+				slog.Warn("failed to unmarshal removed action for undo", "action_id", localID, "error", err)
+			} else {
+				result.RemovedActions = append(result.RemovedActions, action)
+			}
+		}
+		if _, err := tx.Exec("DELETE FROM actions WHERE id = ?", localID); err != nil {
+			return nil, fmt.Errorf("delete action %s: %w", localID, err)
+		}
+	}
+
+	// Standalone upserts.
+	now := time.Now()
+	for _, action := range standalone {
+		if action.Id == nil {
+			continue
+		}
+		actionID := action.Id.Value
+		newDesiredState := int32(action.DesiredState)
+
+		actionJSON, err := protojson.Marshal(action)
+		if err != nil {
+			return nil, fmt.Errorf("marshal action %s: %w", actionID, err)
+		}
+
+		local, exists := localActions[actionID]
+		if !exists {
+			result.NewActionIDs = append(result.NewActionIDs, actionID)
+		} else if local.desiredState != newDesiredState || local.actionJSON != string(actionJSON) || local.isGrouped != 0 {
+			result.ChangedActionIDs = append(result.ChangedActionIDs, actionID)
+		}
+
+		nextExecute := s.calculateNextExecute(action, &now, false)
+
+		_, err = tx.Exec(`
+			INSERT INTO actions (id, action_json, assigned_at, next_execute_at, desired_state, is_grouped)
+			VALUES (?, ?, CURRENT_TIMESTAMP, ?, ?, 0)
+			ON CONFLICT(id) DO UPDATE SET
+				action_json = excluded.action_json,
+				desired_state = excluded.desired_state,
+				is_grouped = 0,
+				next_execute_at = CASE
+					WHEN excluded.desired_state != actions.desired_state
+						OR excluded.action_json != actions.action_json
+						OR actions.is_grouped != 0
+					THEN excluded.next_execute_at
+					ELSE actions.next_execute_at
+				END
+		`, actionID, string(actionJSON), nextExecute, newDesiredState)
+		if err != nil {
+			return nil, fmt.Errorf("upsert action %s: %w", actionID, err)
+		}
+	}
+
+	// Grouped action data upserts. is_grouped=1 keeps the standalone
+	// tick from picking them up; next_execute_at is irrelevant for the
+	// scheduler but kept non-NULL to satisfy the column constraint.
+	farFuture := time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, g := range groups {
+		for _, action := range g.Actions {
+			if action.Id == nil {
+				continue
+			}
+			actionID := action.Id.Value
+			actionJSON, err := protojson.Marshal(action)
+			if err != nil {
+				return nil, fmt.Errorf("marshal grouped action %s: %w", actionID, err)
+			}
+			_, err = tx.Exec(`
+				INSERT INTO actions (id, action_json, assigned_at, next_execute_at, desired_state, is_grouped)
+				VALUES (?, ?, CURRENT_TIMESTAMP, ?, ?, 1)
+				ON CONFLICT(id) DO UPDATE SET
+					action_json = excluded.action_json,
+					desired_state = excluded.desired_state,
+					is_grouped = 1,
+					next_execute_at = excluded.next_execute_at
+			`, actionID, string(actionJSON), farFuture, int32(action.DesiredState))
+			if err != nil {
+				return nil, fmt.Errorf("upsert grouped action %s: %w", actionID, err)
+			}
+		}
+	}
+
+	// ---- groups: drop and recreate in this same TX ----
+
+	priorGroupIDs := make(map[string]bool)
+	groupRows, err := tx.Query("SELECT id FROM action_groups")
+	if err != nil {
+		return nil, fmt.Errorf("query action_groups: %w", err)
+	}
+	for groupRows.Next() {
+		var id string
+		if err := groupRows.Scan(&id); err != nil {
+			groupRows.Close()
+			return nil, fmt.Errorf("scan group id: %w", err)
+		}
+		priorGroupIDs[id] = true
+	}
+	groupRows.Close()
+
+	if _, err := tx.Exec("DELETE FROM group_members"); err != nil {
+		return nil, fmt.Errorf("clear group_members: %w", err)
+	}
+	if _, err := tx.Exec("DELETE FROM action_groups"); err != nil {
+		return nil, fmt.Errorf("clear action_groups: %w", err)
+	}
+
+	for _, g := range groups {
+		groupID := g.SourceLabel
+		if groupID == "" {
+			// Defensive: a group with no source label is unidentifiable
+			// across syncs; skip rather than collide on PRIMARY KEY.
+			slog.Warn("dropping action group with empty source_label", "actions", len(g.Actions))
+			continue
+		}
+
+		schedJSON, err := protojson.Marshal(g.Schedule)
+		if err != nil {
+			return nil, fmt.Errorf("marshal group schedule for %s: %w", groupID, err)
+		}
+
+		nextExecute := calculateNextExecuteFromSchedule(g.Schedule, nil, false)
+
+		if _, err := tx.Exec(`
+			INSERT INTO action_groups (id, source_label, schedule_json, assigned_at, next_execute_at)
+			VALUES (?, ?, ?, CURRENT_TIMESTAMP, ?)
+		`, groupID, g.SourceLabel, string(schedJSON), nextExecute); err != nil {
+			return nil, fmt.Errorf("insert action_group %s: %w", groupID, err)
+		}
+
+		for pos, action := range g.Actions {
+			if action.Id == nil {
+				continue
+			}
+			if _, err := tx.Exec(`
+				INSERT INTO group_members (group_id, position, action_id)
+				VALUES (?, ?, ?)
+			`, groupID, pos, action.Id.Value); err != nil {
+				return nil, fmt.Errorf("insert group_member %s/%d: %w", groupID, pos, err)
+			}
+		}
+
+		if !priorGroupIDs[groupID] {
+			result.NewGroupIDs = append(result.NewGroupIDs, groupID)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// GetDueGroups returns action groups whose schedule says they're due
+// for execution. Caller fetches members via GetGroupMembers and runs
+// them in declared order.
+func (s *Store) GetDueGroups() ([]StoredActionGroup, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	now := time.Now().UTC()
+	rows, err := s.db.Query(`
+		SELECT id, source_label, schedule_json, last_executed_at, next_execute_at
+		FROM action_groups
+		WHERE next_execute_at <= ?
+		ORDER BY next_execute_at ASC
+	`, now)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var due []StoredActionGroup
+	for rows.Next() {
+		var g StoredActionGroup
+		var schedJSON string
+		var lastExec sql.NullTime
+		if err := rows.Scan(&g.ID, &g.SourceLabel, &schedJSON, &lastExec, &g.NextExecuteAt); err != nil {
+			return nil, err
+		}
+		var sched pb.ActionSchedule
+		if err := protojson.Unmarshal([]byte(schedJSON), &sched); err != nil {
+			slog.Warn("failed to unmarshal group schedule", "group_id", g.ID, "error", err)
+		} else {
+			g.Schedule = &sched
+		}
+		if lastExec.Valid {
+			t := lastExec.Time
+			g.LastExecutedAt = &t
+		}
+		due = append(due, g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Hydrate member ids in declared order.
+	for i := range due {
+		members, err := s.getGroupMemberIDs(due[i].ID)
+		if err != nil {
+			return nil, err
+		}
+		due[i].MemberActionIDs = members
+	}
+	return due, nil
+}
+
+// GetGroupByID returns a group's metadata + members in declared order.
+// Returns nil if the group is not in the store.
+func (s *Store) GetGroupByID(groupID string) (*StoredActionGroup, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var g StoredActionGroup
+	var schedJSON string
+	var lastExec sql.NullTime
+	err := s.db.QueryRow(`
+		SELECT id, source_label, schedule_json, last_executed_at, next_execute_at
+		FROM action_groups WHERE id = ?
+	`, groupID).Scan(&g.ID, &g.SourceLabel, &schedJSON, &lastExec, &g.NextExecuteAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var sched pb.ActionSchedule
+	if err := protojson.Unmarshal([]byte(schedJSON), &sched); err == nil {
+		g.Schedule = &sched
+	}
+	if lastExec.Valid {
+		t := lastExec.Time
+		g.LastExecutedAt = &t
+	}
+	members, err := s.getGroupMemberIDs(groupID)
+	if err != nil {
+		return nil, err
+	}
+	g.MemberActionIDs = members
+	return &g, nil
+}
+
+func (s *Store) getGroupMemberIDs(groupID string) ([]string, error) {
+	rows, err := s.db.Query(`
+		SELECT action_id FROM group_members
+		WHERE group_id = ? ORDER BY position ASC
+	`, groupID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// MarkGroupExecuted records that a group fired and advances its
+// next_execute_at to the next slot of its schedule. Called by the
+// scheduler after every member of a due group has run (or attempted).
+func (s *Store) MarkGroupExecuted(groupID string, executedAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var schedJSON string
+	if err := s.db.QueryRow("SELECT schedule_json FROM action_groups WHERE id = ?", groupID).Scan(&schedJSON); err != nil {
+		return err
+	}
+	var sched pb.ActionSchedule
+	if err := protojson.Unmarshal([]byte(schedJSON), &sched); err != nil {
+		return fmt.Errorf("unmarshal group schedule: %w", err)
+	}
+	executedUTC := executedAt.UTC()
+	next := calculateNextExecuteFromSchedule(&sched, &executedUTC, false)
+
+	_, err := s.db.Exec(`
+		UPDATE action_groups SET last_executed_at = ?, next_execute_at = ?
+		WHERE id = ?
+	`, executedUTC, next, groupID)
+	return err
+}
+
+// calculateNextExecuteFromSchedule mirrors calculateNextExecute but
+// works directly on an ActionSchedule pointer so groups can use it
+// without faking a pb.Action.
+func calculateNextExecuteFromSchedule(schedule *pb.ActionSchedule, lastExecuted *time.Time, runImmediately bool) time.Time {
+	now := time.Now().UTC()
+	if runImmediately && lastExecuted == nil {
+		return now
+	}
+	if schedule == nil {
+		if lastExecuted == nil {
+			return now
+		}
+		return lastExecuted.UTC().Add(8 * time.Hour)
+	}
+	if schedule.RunOnAssign && lastExecuted == nil {
+		return now
+	}
+	if schedule.Cron != "" {
+		parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+		sched, err := parser.Parse(schedule.Cron)
+		if err == nil {
+			return sched.Next(now.Local()).UTC()
+		}
+		slog.Warn("invalid cron expression on group schedule", "cron", schedule.Cron, "error", err)
+	}
+	interval := schedule.IntervalHours
+	if interval <= 0 {
+		interval = 8
+	}
+	if lastExecuted == nil {
+		return now
+	}
+	return lastExecuted.UTC().Add(time.Duration(interval) * time.Hour)
 }
 
 // GetAllActionIDs returns the IDs of all stored actions.


### PR DESCRIPTION
## Summary

Closes [manchtools/power-manage-agent#45](https://github.com/manchtools/power-manage-agent/issues/45). Agent half of the ordering rework that's already on the SDK ([manchtools/power-manage-sdk#40](https://github.com/manchtools/power-manage-sdk/pull/40)) and the server ([manchtools/power-manage-server#91](https://github.com/manchtools/power-manage-server/pull/91)).

### What this PR does

When the server pushes an `ActionGroup`, the agent now stores it as a first-class container — one schedule for the whole group, members in declared order — and fires every member together when the group's schedule is due. That's the load-bearing invariant for #45's ordering guarantee: members must not race each other on independent per-action schedules.

### Schema (migration `003_action_groups.sql`)

* New `action_groups` table — one row per container reaching the device, carrying the source label (`definition:<ulid>` or `action_set:<ulid>`), the schedule JSON, and the per-group `next_execute_at` / `last_executed_at`.
* New `group_members` table — ordered `(group_id, position, action_id)`.
* New `is_grouped` column on `actions` — set to 1 for member actions so the standalone-tick query (`next_execute_at <= now AND is_grouped = 0`) silently skips them. Member actions still live on the `actions` table because executors look them up by id and write `last_executed_at`; only their *scheduling* is hoisted out.

### Store

* `SyncStandaloneAndGrouped(standalone, groups)` replaces the flat `SyncActions` on the storage path. Standalone actions follow the existing diff/upsert pattern; grouped action data is upserted with `is_grouped=1`; `action_groups` + `group_members` are dropped and rebuilt on every sync per the design (server is authoritative). Returns `NewGroupIDs` alongside the existing new/changed/removed action lists.
* `GetDueGroups`, `GetGroupByID`, `MarkGroupExecuted`, plus a schedule-only helper `calculateNextExecuteFromSchedule` reusable by both groups and the existing per-action path.

### Scheduler

* `runDueActions` now polls both standalone actions and due groups. Each due group runs through `executeGroup`, which iterates members in declared order and dispatches each through the existing per-action executor. A failure on one member does NOT short-circuit the rest — idempotent retries on the next tick handle recovery.
* `Scheduler.SyncActions` signature changes to take both standalone and grouped slices; `main.go` wires through the SDK client's `StandaloneActions` / `GroupedActions` split.

### Tests

* Group with `run_on_assign` fires all members in declared order on the next tick.
* Same action id at multiple group positions executes once per position (idempotent execution absorbs the cost — operator may legitimately compose the same action into two member sets of one definition).
* Far-future group does not fire AND its member is silently skipped by the standalone tick (the load-bearing invariant).

### go.mod

Bumped to the SDK main pseudo-version that includes PR #40 (`StandaloneActions` / `GroupedActions` / `ActionGroup`).

## Test plan

- [x] `go build ./...` (with `GOWORK=off` to use the agent module's go.mod)
- [x] `go vet ./...`
- [x] `go test ./internal/scheduler/... ./internal/store/...`
- [x] Full agent test suite (`go test ./...`)

Refs manchtools/power-manage-agent#45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for action groups with ordered member execution; groups run on their own schedule and do not trigger standalone executions.

* **Chores**
  * Updated SDK dependency to v0.4.1.
  * Database schema enhanced to store action groups, member ordering, and group scheduling.

* **Tests**
  * Added tests for group execution order, duplicate members, and standalone-vs-group behavior.

* **Bug Fixes**
  * Sync logging now reports standalone and group totals separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->