### PR TITLE
feat: enforce per-group maintenance window in scheduler (#58)

### DIFF
--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -814,6 +814,13 @@ func syncActionsFromServer(ctx context.Context, client *sdk.Client, sched *sched
 		return 0
 	}
 
+	// Apply the resolved maintenance window from the same sync. Done
+	// after SyncActions so the scheduler's next tick already gates by
+	// the new window — and persisted via the scheduler so an agent
+	// restart inside an active freeze keeps deferring instead of
+	// blasting through queued work. See manchtools/power-manage-server#58.
+	sched.SetMaintenanceWindow(result.MaintenanceWindow)
+
 	// Convert sync interval from minutes to duration
 	var syncInterval time.Duration
 	if result.SyncIntervalMinutes > 0 {

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see agent/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260502221138-995a7814adeb
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260503161545-a3dd8bc45112
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260502221138-995a7814adeb h1:NxY+2F95GqfkUZiG8Bux5wR09wWmid+0tceOgEatgIw=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260502221138-995a7814adeb/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260503161545-a3dd8bc45112 h1:PMlIH3nqUmyQ+1aa8odJuBZDgtkB1QUd/ZDB+OMiRhI=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260503161545-a3dd8bc45112/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"log/slog"
 	"sync"
 	"time"
@@ -85,15 +84,20 @@ func New(store *store.Store, executor ActionExecutor, logger *slog.Logger) *Sche
 }
 
 // SetMaintenanceWindow replaces the active window in memory and on
-// disk. A nil or empty window clears the gate; non-nil rewrites both
-// the cached pointer and the persisted JSON. Persistence errors are
-// logged but non-fatal — the in-memory pointer is still updated so
-// the running scheduler reflects the latest sync.
+// disk. A nil or empty window clears the gate; non-empty windows are
+// deep-cloned so the caller cannot mutate the cached pointer after
+// returning. Persistence errors are logged but non-fatal — the
+// in-memory pointer is still updated so the running scheduler
+// reflects the latest sync.
 func (s *Scheduler) SetMaintenanceWindow(w *pb.MaintenanceWindow) {
+	var normalized *pb.MaintenanceWindow
+	if w != nil && len(w.GetSchedule()) > 0 {
+		normalized = proto.Clone(w).(*pb.MaintenanceWindow)
+	}
 	s.windowMu.Lock()
-	s.window = w
+	s.window = normalized
 	s.windowMu.Unlock()
-	if err := storeMaintenanceWindow(s.store, w); err != nil {
+	if err := storeMaintenanceWindow(s.store, normalized); err != nil {
 		s.logger.Warn("failed to persist maintenance window; in-memory only", "error", err)
 	}
 }
@@ -109,30 +113,21 @@ func (s *Scheduler) activeWindow() *pb.MaintenanceWindow {
 // loadMaintenanceWindow restores the persisted window from settings.
 // An empty / missing entry yields (nil, nil) — the agent boots
 // unconstrained, which is the same default a fresh-install device
-// gets before its first sync.
+// gets before its first sync. Encoded with proto wire format so any
+// future field added to MaintenanceWindow round-trips automatically;
+// a JSON shadow schema would silently drop new fields and let the
+// post-restart evaluator diverge from the live one.
 func loadMaintenanceWindow(st *store.Store) (*pb.MaintenanceWindow, error) {
 	raw, err := st.GetSetting(maintenanceWindowSettingKey)
 	if err != nil || raw == "" {
 		return nil, err
 	}
-	var payload struct {
-		Schedule []struct {
-			Days  []string `json:"days"`
-			Allow string   `json:"allow"`
-		} `json:"schedule"`
-	}
-	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+	out := &pb.MaintenanceWindow{}
+	if err := proto.Unmarshal([]byte(raw), out); err != nil {
 		return nil, err
 	}
-	if len(payload.Schedule) == 0 {
+	if len(out.GetSchedule()) == 0 {
 		return nil, nil
-	}
-	out := &pb.MaintenanceWindow{Schedule: make([]*pb.MaintenanceWindowEntry, 0, len(payload.Schedule))}
-	for _, e := range payload.Schedule {
-		out.Schedule = append(out.Schedule, &pb.MaintenanceWindowEntry{
-			Days:  e.Days,
-			Allow: e.Allow,
-		})
 	}
 	return out, nil
 }
@@ -140,19 +135,13 @@ func loadMaintenanceWindow(st *store.Store) (*pb.MaintenanceWindow, error) {
 // storeMaintenanceWindow encodes the window for the settings table.
 // nil / empty windows clear the row so a subsequent restart sees
 // "no constraint" (matches the SetMaintenanceWindow contract: empty
-// in = unconstrained out).
+// in = unconstrained out). Uses proto wire format so persistence
+// stays bound to the message shape the shared evaluator consumes.
 func storeMaintenanceWindow(st *store.Store, w *pb.MaintenanceWindow) error {
 	if w == nil || len(w.GetSchedule()) == 0 {
 		return st.DeleteSetting(maintenanceWindowSettingKey)
 	}
-	entries := make([]map[string]any, 0, len(w.GetSchedule()))
-	for _, e := range w.GetSchedule() {
-		entries = append(entries, map[string]any{
-			"days":  e.GetDays(),
-			"allow": e.GetAllow(),
-		})
-	}
-	raw, err := json.Marshal(map[string]any{"schedule": entries})
+	raw, err := proto.Marshal(w)
 	if err != nil {
 		return err
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"log/slog"
 	"sync"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/manchtools/power-manage/agent/internal/executor"
 	"github.com/manchtools/power-manage/agent/internal/store"
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/maintenance"
 )
 
 const (
@@ -29,6 +31,13 @@ type ActionExecutor interface {
 	Execute(ctx context.Context, action *pb.Action) *pb.ActionResult
 }
 
+// maintenanceWindowSettingKey is the agent-store settings key under
+// which the most-recently-synced resolved MaintenanceWindow lives.
+// Persisting it across restarts means an agent that boots inside a
+// freeze window won't blast through queued actions just because it
+// hasn't completed its first sync yet.
+const maintenanceWindowSettingKey = "maintenance_window"
+
 // Scheduler manages autonomous action execution.
 type Scheduler struct {
 	store    *store.Store
@@ -39,6 +48,12 @@ type Scheduler struct {
 	running   bool
 	stopCh    chan struct{}
 	resultsCh chan *ExecutionResult
+
+	// windowMu guards window. Separate from mu so a long Sync that
+	// also holds mu cannot block runDueActions' window check on a
+	// scheduler that's already started.
+	windowMu sync.RWMutex
+	window   *pb.MaintenanceWindow
 }
 
 // ExecutionResult contains the result of a scheduled execution.
@@ -50,14 +65,98 @@ type ExecutionResult struct {
 	ExecutedAt time.Time
 }
 
-// New creates a new scheduler.
+// New creates a new scheduler. The persisted maintenance window (if
+// any) is restored from the agent store so a restart inside an active
+// freeze keeps gating dispatches until the next sync overwrites it.
 func New(store *store.Store, executor ActionExecutor, logger *slog.Logger) *Scheduler {
-	return &Scheduler{
+	s := &Scheduler{
 		store:     store,
 		executor:  executor,
 		logger:    logger,
 		resultsCh: make(chan *ExecutionResult, 100),
 	}
+	if w, err := loadMaintenanceWindow(store); err != nil {
+		logger.Warn("failed to load persisted maintenance window; defaulting to no constraint",
+			"error", err)
+	} else {
+		s.window = w
+	}
+	return s
+}
+
+// SetMaintenanceWindow replaces the active window in memory and on
+// disk. A nil or empty window clears the gate; non-nil rewrites both
+// the cached pointer and the persisted JSON. Persistence errors are
+// logged but non-fatal — the in-memory pointer is still updated so
+// the running scheduler reflects the latest sync.
+func (s *Scheduler) SetMaintenanceWindow(w *pb.MaintenanceWindow) {
+	s.windowMu.Lock()
+	s.window = w
+	s.windowMu.Unlock()
+	if err := storeMaintenanceWindow(s.store, w); err != nil {
+		s.logger.Warn("failed to persist maintenance window; in-memory only", "error", err)
+	}
+}
+
+// activeWindow returns a snapshot of the current window for read
+// without holding the lock during evaluation.
+func (s *Scheduler) activeWindow() *pb.MaintenanceWindow {
+	s.windowMu.RLock()
+	defer s.windowMu.RUnlock()
+	return s.window
+}
+
+// loadMaintenanceWindow restores the persisted window from settings.
+// An empty / missing entry yields (nil, nil) — the agent boots
+// unconstrained, which is the same default a fresh-install device
+// gets before its first sync.
+func loadMaintenanceWindow(st *store.Store) (*pb.MaintenanceWindow, error) {
+	raw, err := st.GetSetting(maintenanceWindowSettingKey)
+	if err != nil || raw == "" {
+		return nil, err
+	}
+	var payload struct {
+		Schedule []struct {
+			Days  []string `json:"days"`
+			Allow string   `json:"allow"`
+		} `json:"schedule"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return nil, err
+	}
+	if len(payload.Schedule) == 0 {
+		return nil, nil
+	}
+	out := &pb.MaintenanceWindow{Schedule: make([]*pb.MaintenanceWindowEntry, 0, len(payload.Schedule))}
+	for _, e := range payload.Schedule {
+		out.Schedule = append(out.Schedule, &pb.MaintenanceWindowEntry{
+			Days:  e.Days,
+			Allow: e.Allow,
+		})
+	}
+	return out, nil
+}
+
+// storeMaintenanceWindow encodes the window for the settings table.
+// nil / empty windows clear the row so a subsequent restart sees
+// "no constraint" (matches the SetMaintenanceWindow contract: empty
+// in = unconstrained out).
+func storeMaintenanceWindow(st *store.Store, w *pb.MaintenanceWindow) error {
+	if w == nil || len(w.GetSchedule()) == 0 {
+		return st.DeleteSetting(maintenanceWindowSettingKey)
+	}
+	entries := make([]map[string]any, 0, len(w.GetSchedule()))
+	for _, e := range w.GetSchedule() {
+		entries = append(entries, map[string]any{
+			"days":  e.GetDays(),
+			"allow": e.GetAllow(),
+		})
+	}
+	raw, err := json.Marshal(map[string]any{"schedule": entries})
+	if err != nil {
+		return err
+	}
+	return st.SetSetting(maintenanceWindowSettingKey, string(raw))
 }
 
 // HasPriorExecution returns true if the action has been executed before.
@@ -169,6 +268,27 @@ func (s *Scheduler) runDueActions(ctx context.Context) {
 	}
 
 	if len(actions) == 0 && len(groups) == 0 {
+		return
+	}
+
+	// Maintenance-window gate. Evaluated in device-local time so
+	// "02:00 local" means 02:00 wherever the device runs (the server
+	// can't compute this; only the agent knows its time.Local). When
+	// the active window denies the moment, every due item defers to
+	// the next tick — runDueActions does NOT advance next_execute_at,
+	// so a deferred action stays "due" until the window opens.
+	//
+	// The window does not gate the stream-dispatched path: instant
+	// actions (REBOOT, SYNC) and pushed dispatches arrive through
+	// the gateway and bypass this scheduler entirely. That matches
+	// the spec — admins hitting "reboot now" expect immediate
+	// execution.
+	window := s.activeWindow()
+	if !maintenance.IsAllowed(window, time.Now().Local()) {
+		s.logger.Info("maintenance window closed; deferring due dispatches",
+			"standalone", len(actions),
+			"groups", len(groups),
+		)
 		return
 	}
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/manchtools/power-manage/agent/internal/store"
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -528,4 +529,134 @@ func TestRunDueActions_GroupedActionsSkipStandaloneTick(t *testing.T) {
 	if got := len(mock.getCalls()); got != 0 {
 		t.Fatalf("far-future group must not fire AND its member must not run via standalone tick, got %d calls", got)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Maintenance window gate
+// ---------------------------------------------------------------------------
+
+// A window that allows every weekday and every hour acts like "no
+// constraint" — useful as a control for the deny case below.
+//
+// Uses a group rather than a standalone action because SyncActions
+// runs new standalone actions inline (advancing their cursor), which
+// would leave runDueActions with nothing due. Group members never
+// run on the inline-sync path, so a freshly-synced group is still
+// due on the first runDueActions tick.
+func TestRunDueActions_MaintenanceWindow_AllAllowed(t *testing.T) {
+	sched, mock := newTestScheduler(t)
+	ctx := context.Background()
+
+	g := &pb.ActionGroup{
+		SourceLabel: "action_set:permissive",
+		Schedule:    &pb.ActionSchedule{RunOnAssign: true, IntervalHours: 8},
+		Actions: []*pb.Action{
+			makeTestAction("g-a", pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT),
+		},
+	}
+	if err := sched.SyncActions(ctx, nil, []*pb.ActionGroup{g}, false); err != nil {
+		t.Fatal(err)
+	}
+	mock.reset()
+
+	sched.SetMaintenanceWindow(&pb.MaintenanceWindow{Schedule: []*pb.MaintenanceWindowEntry{
+		{Days: []string{"mon", "tue", "wed", "thu", "fri", "sat", "sun"}, Allow: "00:00-23:59"},
+	}})
+
+	sched.runDueActions(ctx)
+	if got := len(mock.getCalls()); got != 1 {
+		t.Fatalf("permissive window should not gate dispatch, got %d calls", got)
+	}
+}
+
+// A window with no entry matching the current weekday must defer
+// every due group dispatch without advancing the group's next-fire
+// cursor — reopening the window in the next tick replays the work.
+//
+// Standalone actions stay out of this case on purpose: SyncActions
+// executes new/changed standalone actions inline as part of the sync
+// (firstSync / new-action codepath), which leaves them with an
+// already-advanced next_execute_at by the time runDueActions runs.
+// The group path is the load-bearing one for the gate — group
+// members never run on the inline-sync path; they only fire through
+// runDueActions, so deferring them is observable.
+func TestRunDueActions_MaintenanceWindow_NoMatchingDayDefersAll(t *testing.T) {
+	sched, mock := newTestScheduler(t)
+	ctx := context.Background()
+
+	g := &pb.ActionGroup{
+		SourceLabel: "action_set:gated",
+		Schedule:    &pb.ActionSchedule{RunOnAssign: true, IntervalHours: 8},
+		Actions: []*pb.Action{
+			makeTestAction("g-a", pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT),
+		},
+	}
+	if err := sched.SyncActions(ctx, nil, []*pb.ActionGroup{g}, false); err != nil {
+		t.Fatal(err)
+	}
+	mock.reset()
+
+	// Pick a weekday three days from today so neither today nor
+	// yesterday matches — the latter check is what catches a window
+	// that crosses midnight from the previous day.
+	now := time.Now().Local()
+	farDay := weekdayToken((int(now.Weekday()) + 3) % 7)
+	sched.SetMaintenanceWindow(&pb.MaintenanceWindow{Schedule: []*pb.MaintenanceWindowEntry{
+		{Days: []string{farDay}, Allow: "00:01-23:58"},
+	}})
+
+	sched.runDueActions(ctx)
+	if got := len(mock.getCalls()); got != 0 {
+		t.Fatalf("closed window must defer due group, got %d calls", got)
+	}
+
+	// Reopening the window and re-ticking must run the deferred
+	// group — proves the defer didn't advance the group's
+	// next_execute_at past now.
+	sched.SetMaintenanceWindow(nil)
+	sched.runDueActions(ctx)
+	if got := len(mock.getCalls()); got != 1 {
+		t.Fatalf("after reopening, deferred group member must fire exactly once, got %d", got)
+	}
+}
+
+// SetMaintenanceWindow round-trips through the agent store so a
+// scheduler restored via New() picks up the previously-set window.
+func TestSetMaintenanceWindow_PersistsAcrossSchedulerRestart(t *testing.T) {
+	dir := t.TempDir()
+	st, err := store.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	first := New(st, &mockExecutor{}, slog.Default())
+	w := &pb.MaintenanceWindow{Schedule: []*pb.MaintenanceWindowEntry{
+		{Days: []string{"mon", "tue", "wed", "thu", "fri"}, Allow: "22:00-06:00"},
+	}}
+	first.SetMaintenanceWindow(w)
+
+	// Fresh scheduler against the same store — simulates a restart.
+	restored := New(st, &mockExecutor{}, slog.Default())
+	got := restored.activeWindow()
+	if got == nil || len(got.Schedule) != 1 {
+		t.Fatalf("expected restored window, got %v", got)
+	}
+	if got.Schedule[0].Allow != "22:00-06:00" {
+		t.Fatalf("restored allow range mismatch: %q", got.Schedule[0].Allow)
+	}
+
+	// Clearing the window deletes the persisted row.
+	first.SetMaintenanceWindow(nil)
+	cleared := New(st, &mockExecutor{}, slog.Default())
+	if w := cleared.activeWindow(); w != nil && len(w.Schedule) != 0 {
+		t.Fatalf("clearing the window should remove persistence, got %v", w)
+	}
+}
+
+// weekdayToken maps a 0..6 weekday index (Sunday=0) to the lowercase
+// three-letter token used in MaintenanceWindowEntry.Days.
+func weekdayToken(idx int) string {
+	tokens := [7]string{"sun", "mon", "tue", "wed", "thu", "fri", "sat"}
+	return tokens[idx]
 }


### PR DESCRIPTION
## Summary

- Read the resolved `MaintenanceWindow` from `SyncActionsResult`, persist it in the agent's settings table, and gate `runDueActions` by it
- Window evaluation runs in **device-local time** (only the agent knows `time.Local`) using the shared `sdk/go/maintenance` evaluator so semantics match the server bit-for-bit
- Deferred dispatches do **not** advance `next_execute_at` — a deferred group stays "due" until the window opens on a later tick
- Stream-dispatched actions (REBOOT, SYNC, ad-hoc) bypass the gate by design (they arrive through the gateway and never touch this scheduler)
- Persistence via the existing `settings` table so a restart inside an active freeze keeps deferring instead of blasting through queued work pre-first-sync

Refs manchtools/power-manage-server#58

## Test plan

- [x] `go test ./internal/scheduler/`
- [x] `TestRunDueActions_MaintenanceWindow_AllAllowed` — permissive window does not gate
- [x] `TestRunDueActions_MaintenanceWindow_NoMatchingDayDefersAll` — closed window defers, reopened window fires the deferred work (proves no cursor advance)
- [x] `TestSetMaintenanceWindow_PersistsAcrossSchedulerRestart` — settings round-trip survives a fresh `New()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Maintenance windows now reliably block action dispatch during configured periods, including immediately after sync.
* **New Features**
  * Maintenance window settings persist across restarts and are restored on startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->