### PR TITLE
chore: agent security + quality cleanup pass

### DIFF
--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -187,9 +187,8 @@ func normalizedServiceBackend(s string) string {
 // Config holds the agent configuration.
 type Config struct {
 	// Registration
-	Token      string
-	ServerURL  string
-	SkipVerify bool
+	Token     string
+	ServerURL string
 
 	// Storage
 	DataDir string
@@ -404,11 +403,26 @@ func main() {
 	// Create handler with scheduler integration
 	h := handler.NewHandler(logger, exec, sched, actionStore, syncTrigger)
 
-	// Enable action-based agent self-update.
+	// Enable action-based agent self-update. The binary path is
+	// resolved at runtime via os.Executable() so the self-update
+	// targets the actually-running binary, not a hardcoded
+	// install location. Operators who install with `install.sh
+	// --binary /opt/bin/...` get correct in-place updates instead
+	// of a silently-wrong overwrite of /usr/local/bin/.
+	binaryPath, err := os.Executable()
+	if err != nil {
+		// os.Executable can fail on platforms that don't expose
+		// /proc/self/exe symlink semantics; fall back to the
+		// canonical install path so self-update at least targets
+		// the documented default rather than refusing to enable.
+		logger.Warn("os.Executable failed; falling back to /usr/local/bin/power-manage-agent for self-update target",
+			"error", err)
+		binaryPath = "/usr/local/bin/power-manage-agent"
+	}
 	exec.SetUpdateConfig(&executor.AgentUpdateConfig{
 		Version:    version,
 		DataDir:    cfg.DataDir,
-		BinaryPath: "/usr/local/bin/power-manage-agent",
+		BinaryPath: binaryPath,
 		Shutdown:   cancel,
 	})
 
@@ -445,15 +459,12 @@ func register(ctx context.Context, cfg *Config, hostname string, logger *slog.Lo
 		return nil, fmt.Errorf("generate CSR: %w", err)
 	}
 
-	// Create client options for registration
-	var clientOpts []sdk.ClientOption
-	if cfg.SkipVerify {
-		logger.Warn("TLS verification disabled - only use for development!")
-		clientOpts = append(clientOpts, sdk.WithInsecureSkipVerify())
-	}
-
-	// Register via control server RPC
-	result, err := sdk.RegisterAgent(ctx, cfg.ServerURL, cfg.Token, hostname, version, csrPEM, clientOpts...)
+	// Register via control server RPC. TLS verification is always
+	// enforced — there is intentionally no opt-out, as bypassing it
+	// during initial registration enables MITM attacks that can
+	// substitute the gateway URL and a malicious certificate before
+	// the agent has any trust anchor of its own.
+	result, err := sdk.RegisterAgent(ctx, cfg.ServerURL, cfg.Token, hostname, version, csrPEM)
 	if err != nil {
 		return nil, fmt.Errorf("register: %w", err)
 	}
@@ -607,8 +618,34 @@ func runAgent(ctx context.Context, creds *credentials.Credentials, hostname stri
 // startCertRotation runs a background loop that renews the agent's mTLS
 // certificate before it expires. Renewal is attempted at 80% of the cert's
 // lifetime. On failure it retries every hour.
+//
+// Consecutive failures are tracked so prolonged outages become visible
+// in operator logs without an additional alerting pipeline. The first
+// few failures stay at "the call failed once, retrying" volume; once
+// the count crosses a threshold the messages escalate to mention how
+// long the agent has been unable to rotate, which is what an operator
+// needs to triage "is the control server reachable?".
 func startCertRotation(ctx context.Context, credStore *credentials.Store, hostname string, logger *slog.Logger) {
-	const retryInterval = 1 * time.Hour
+	const (
+		retryInterval     = 1 * time.Hour
+		escalateThreshold = 3 // hours of consecutive failure before the log volume rises
+	)
+	consecutiveFailures := 0
+	logRetryFailure := func(stage string, err error) {
+		consecutiveFailures++
+		attrs := []any{"stage", stage, "error", err, "consecutive_failures", consecutiveFailures}
+		if consecutiveFailures >= escalateThreshold {
+			// Escalated wording so a `journalctl -u power-manage-agent
+			// | grep "rotation stalled"` query surfaces the issue
+			// fast. The hours-stalled value is the operator-facing
+			// triage handle.
+			logger.Error("cert rotation: rotation stalled, control server may be unreachable",
+				append(attrs, "hours_stalled", consecutiveFailures)...,
+			)
+		} else {
+			logger.Error("cert rotation: renewal attempt failed, will retry", attrs...)
+		}
+	}
 
 	for {
 		creds, err := credStore.Load()
@@ -652,7 +689,7 @@ func startCertRotation(ctx context.Context, credStore *credentials.Store, hostna
 		// Generate CSR from existing private key
 		csrPEM, err := pmcrypto.GenerateCSRFromKey(hostname, creds.PrivateKey)
 		if err != nil {
-			logger.Error("cert rotation: failed to generate CSR", "error", err)
+			logRetryFailure("generate_csr", err)
 			select {
 			case <-ctx.Done():
 				return
@@ -672,7 +709,7 @@ func startCertRotation(ctx context.Context, credStore *credentials.Store, hostna
 		// RenewCertificate request body.
 		mtlsOpt, err := sdk.WithMTLSFromPEMAndSystemRoots(creds.Certificate, creds.PrivateKey, creds.CACert)
 		if err != nil {
-			logger.Error("cert rotation: failed to configure mTLS", "error", err)
+			logRetryFailure("configure_mtls", err)
 			select {
 			case <-ctx.Done():
 				return
@@ -684,7 +721,7 @@ func startCertRotation(ctx context.Context, credStore *credentials.Store, hostna
 		// Call RenewCertificate on the control server
 		result, err := sdk.RenewCertificate(ctx, creds.ControlAddr, csrPEM, creds.Certificate, mtlsOpt)
 		if err != nil {
-			logger.Error("cert rotation: renewal failed, will retry", "error", err)
+			logRetryFailure("renew_certificate", err)
 			select {
 			case <-ctx.Done():
 				return
@@ -699,7 +736,7 @@ func startCertRotation(ctx context.Context, credStore *credentials.Store, hostna
 			creds.CACert = result.CACert
 		}
 		if err := credStore.Save(creds); err != nil {
-			logger.Error("cert rotation: failed to save new certificate", "error", err)
+			logRetryFailure("save_credentials", err)
 			select {
 			case <-ctx.Done():
 				return
@@ -708,6 +745,10 @@ func startCertRotation(ctx context.Context, credStore *credentials.Store, hostna
 			continue
 		}
 
+		// Successful rotation — reset the consecutive-failure counter
+		// so the next failure starts at 1, not stuck above the
+		// escalation threshold from a prior outage.
+		consecutiveFailures = 0
 		logger.Info("cert rotation: certificate renewed successfully",
 			"not_after", result.NotAfter,
 		)
@@ -950,7 +991,6 @@ func parseFlags() *Config {
 	flag.StringVar(&cfg.Token, "t", "", "Registration token (shorthand)")
 	flag.StringVar(&cfg.ServerURL, "server", "", "Control server URL for registration")
 	flag.StringVar(&cfg.ServerURL, "s", "", "Control server URL (shorthand)")
-	flag.BoolVar(&cfg.SkipVerify, "skip-verify", false, "Skip TLS verification (development only)")
 	flag.StringVar(&cfg.DataDir, "data-dir", credentials.DefaultDataDir, "Data directory for credentials")
 	flag.StringVar(&cfg.LogLevel, "log-level", "info", "Log level (debug, info, warn, error)")
 	flag.StringVar(&cfg.LogFormat, "log-format", "text", "Log format (text, json)")
@@ -970,7 +1010,7 @@ func parseFlags() *Config {
 	}
 
 	// Parse power-manage:// URI if provided (registration URIs)
-	// Format: power-manage://server:port?token=xxx[&skip-verify=true]
+	// Format: power-manage://server:port?token=xxx
 	if uri != "" {
 		if parsed, err := parseRegistrationURI(uri); err == nil {
 			// Try socket enrollment first (no sudo needed)
@@ -980,7 +1020,6 @@ func parseFlags() *Config {
 			// Fallback to direct registration (sudo/service mode)
 			cfg.ServerURL = parsed.ServerURL
 			cfg.Token = parsed.Token
-			cfg.SkipVerify = parsed.SkipVerify
 		}
 	}
 
@@ -994,9 +1033,6 @@ func parseFlags() *Config {
 	if v := os.Getenv("POWER_MANAGE_DATA_DIR"); v != "" {
 		cfg.DataDir = v
 	}
-	if os.Getenv("POWER_MANAGE_SKIP_VERIFY") == "true" {
-		cfg.SkipVerify = true
-	}
 
 	cfg.PrivilegeBackend = strings.ToLower(os.Getenv("POWER_MANAGE_PRIVILEGE_BACKEND"))
 	cfg.ServiceBackend = strings.ToLower(os.Getenv("POWER_MANAGE_SERVICE_BACKEND"))
@@ -1007,20 +1043,22 @@ func parseFlags() *Config {
 
 // registrationURI holds parsed registration URI data.
 type registrationURI struct {
-	ServerURL  string
-	Token      string
-	SkipVerify bool
+	ServerURL string
+	Token     string
 }
 
 // parseRegistrationURI parses a power-manage:// URI.
-// Format: power-manage://server:port?token=xxx[&skip-verify=true][&tls=false]
+// Format: power-manage://server:port?token=xxx
 // Examples:
 //   - power-manage://gateway.example.com:8080?token=abc123
-//   - power-manage://192.168.1.100:8080?token=abc123&skip-verify=true
-//   - power-manage://gateway.example.com:8080?token=abc123&tls=false
+//
+// TLS verification is always enforced. The previous `skip-verify=true`
+// and `tls=false` query parameters were removed because bypassing
+// TLS during initial registration enables MITM attacks that can
+// substitute the gateway URL and a malicious certificate before the
+// agent has any trust anchor of its own.
 func parseRegistrationURI(rawURI string) (*registrationURI, error) {
-	// Replace power-manage:// with https:// for parsing
-	// We'll determine the actual scheme from query params
+	// Replace power-manage:// with https:// for parsing.
 	normalizedURI := strings.Replace(rawURI, "power-manage://", "https://", 1)
 
 	parsed, err := url.Parse(normalizedURI)
@@ -1028,33 +1066,16 @@ func parseRegistrationURI(rawURI string) (*registrationURI, error) {
 		return nil, fmt.Errorf("invalid URI: %w", err)
 	}
 
-	result := &registrationURI{}
-
-	// Get query parameters
-	query := parsed.Query()
-
-	// Token is required
-	result.Token = query.Get("token")
-	if result.Token == "" {
+	// Token is required.
+	token := parsed.Query().Get("token")
+	if token == "" {
 		return nil, fmt.Errorf("token parameter is required in URI")
 	}
 
-	// Check for skip-verify
-	if query.Get("skip-verify") == "true" {
-		result.SkipVerify = true
-	}
-
-	// Determine scheme (default to https)
-	scheme := "https"
-	if query.Get("tls") == "false" {
-		scheme = "http"
-		result.SkipVerify = true // No TLS means no verification needed
-	}
-
-	// Build server URL
-	result.ServerURL = fmt.Sprintf("%s://%s", scheme, parsed.Host)
-
-	return result, nil
+	return &registrationURI{
+		ServerURL: fmt.Sprintf("https://%s", parsed.Host),
+		Token:     token,
+	}, nil
 }
 
 // runSetup installs the agent's privilege-escalation configuration.
@@ -1739,7 +1760,6 @@ func runEnroll(args []string) {
 	fs := flag.NewFlagSet("enroll", flag.ExitOnError)
 	token := fs.String("token", "", "Registration token")
 	server := fs.String("server", "", "Control server URL")
-	skipVerify := fs.Bool("skip-verify", false, "Skip TLS verification")
 	socketPath := fs.String("socket", deviceauth.EnrollSocketPath, "Agent enrollment socket")
 	fs.Parse(args)
 
@@ -1750,7 +1770,6 @@ func runEnroll(args []string) {
 			if parsed, err := parseRegistrationURI(arg); err == nil {
 				*server = parsed.ServerURL
 				*token = parsed.Token
-				*skipVerify = parsed.SkipVerify
 			} else {
 				fmt.Fprintf(os.Stderr, "error: %v\n", err)
 				os.Exit(1)
@@ -1785,11 +1804,12 @@ func runEnroll(args []string) {
 		return
 	}
 
-	// Enroll via socket
+	// Enroll via socket. SkipVerify is intentionally NOT set —
+	// the agent CLI no longer exposes any way to disable TLS
+	// verification during registration (MITM hardening).
 	resp, err := client.Enroll(ctx, connect.NewRequest(&pm.EnrollRequest{
-		ServerUrl:  *server,
-		Token:      *token,
-		SkipVerify: *skipVerify,
+		ServerUrl: *server,
+		Token:     *token,
 	}))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: enrollment failed: %v\n", err)
@@ -1821,9 +1841,8 @@ func trySocketEnroll(parsed *registrationURI) bool {
 	}
 
 	resp, err := client.Enroll(ctx, connect.NewRequest(&pm.EnrollRequest{
-		ServerUrl:  parsed.ServerURL,
-		Token:      parsed.Token,
-		SkipVerify: parsed.SkipVerify,
+		ServerUrl: parsed.ServerURL,
+		Token:     parsed.Token,
 	}))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: socket enrollment failed: %v\n", err)

--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -409,6 +409,15 @@ func main() {
 	// install location. Operators who install with `install.sh
 	// --binary /opt/bin/...` get correct in-place updates instead
 	// of a silently-wrong overwrite of /usr/local/bin/.
+	//
+	// Symlink note: os.Executable resolves symlinks on Linux, so
+	// if the agent was launched via a symlink chain (e.g.
+	// /usr/bin/power-manage-agent -> /opt/pm/current/bin/power-manage-agent)
+	// the self-update replaces the symlink TARGET, leaving the
+	// symlink itself intact. That matches the typical "rotate
+	// /opt/pm/current/" deployment pattern; if an operator
+	// instead intends "update by repointing the symlink" they
+	// should rely on package management rather than self-update.
 	binaryPath, err := os.Executable()
 	if err != nil {
 		// os.Executable can fail on platforms that don't expose

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,6 @@
 #   -d, --data-dir DIR      Data directory (default: /var/lib/power-manage)
 #   -b, --binary PATH       Path to the agent binary (default: /usr/local/bin/power-manage-agent)
 #   -u, --user USER         Service user name (default: power-manage)
-#   --skip-verify           Skip TLS certificate verification (development only)
 #   --skip-download         Skip downloading the binary (use existing binary at --binary path)
 #   --uninstall             Remove the agent and all configuration
 #   -h, --help              Show this help message
@@ -39,7 +38,6 @@ SERVICE_USER="power-manage"
 SERVICE_NAME="power-manage-agent"
 REGISTRATION_TOKEN=""
 SERVER_URL=""
-SKIP_VERIFY=""
 SKIP_DOWNLOAD=""
 PRE_RELEASE=""
 VERSION="latest"
@@ -80,7 +78,6 @@ Options:
   -d, --data-dir DIR      Data directory (default: /var/lib/power-manage)
   -b, --binary PATH       Path to the agent binary (default: /usr/local/bin/power-manage-agent)
   -u, --user USER         Service user name (default: power-manage)
-  --skip-verify           Skip TLS certificate verification (development only)
   --skip-download         Skip downloading the binary (use existing binary at --binary path)
   --uninstall             Remove the agent and all configuration
   -h, --help              Show this help message
@@ -135,7 +132,15 @@ parse_args() {
                 shift
                 ;;
             --skip-verify)
-                SKIP_VERIFY="true"
+                # Deprecation shim: the agent CLI no longer accepts
+                # -skip-verify and TLS verification cannot be
+                # disabled. Print a clear, actionable message rather
+                # than silently passing the flag to enroll (which
+                # would now fail with an "unknown flag" error and
+                # surprise operators running install scripts written
+                # against the old contract).
+                log_warn "--skip-verify is no longer supported; TLS verification is always enforced."
+                log_warn "Ignoring --skip-verify flag and continuing with TLS verification."
                 shift
                 ;;
             --skip-download)
@@ -509,10 +514,6 @@ enroll_agent() {
         "-server=$SERVER_URL"
         "-token=$REGISTRATION_TOKEN"
     )
-
-    if [[ -n "$SKIP_VERIFY" ]]; then
-        enroll_cmd+=("-skip-verify")
-    fi
 
     # Wait for the enrollment socket to become available (agent needs to start first)
     local max_wait=10

--- a/install.sh
+++ b/install.sh
@@ -665,13 +665,21 @@ install_luks_sudoers() {
     fi
 
     # Unquoted heredoc so $BINARY_PATH expands — the rule must match
-    # the actual binary location, which differs when the operator passes
-    # --binary. Sudoers treats wildcards on the argument list specially,
-    # so this remains a path match for /PATH/TO/power-manage-agent +
-    # "luks" verb + any args.
+    # the actual binary location, which differs when the operator
+    # passes --binary.
+    #
+    # The previous rule used "luks *" which auto-elevated ANY
+    # future luks subcommand the agent might add. Replaced with an
+    # explicit "luks set-passphrase *" entry so only the currently-
+    # documented subcommand is privileged. New subcommands need a
+    # conscious sudoers update (and review) before they can run
+    # without a password — forward-compatible defense in depth.
     cat > "$sudoers_file" <<EOF
-# Allow all users to run LUKS passphrase commands without password
-ALL ALL=(root) NOPASSWD: ${BINARY_PATH} luks *
+# Allow all users to run the LUKS set-passphrase command without
+# password. The wildcard at the end matches the variable arguments
+# (--token, --data-dir, the token value itself) without granting
+# any other luks subcommand the same privilege.
+ALL ALL=(root) NOPASSWD: ${BINARY_PATH} luks set-passphrase *
 EOF
 
     chmod 440 "$sudoers_file"

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -4,6 +4,7 @@
 package credentials
 
 import (
+	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -32,6 +33,16 @@ const (
 
 	// Default data directory
 	DefaultDataDir = "/var/lib/power-manage"
+
+	// credentialsMagicV1 is the magic prefix for the v1 on-disk
+	// credential format (Argon2id-derived AES-256-GCM, nonce
+	// prepended to the GCM ciphertext). The prefix lets future
+	// format migrations (e.g. TPM-sealed key, different KDF
+	// parameters, alternate cipher) be detected at Load() time
+	// instead of requiring a flag-day migration. Pre-versioning
+	// installs have no magic prefix; Load() detects the absence
+	// and falls back to the legacy parser.
+	credentialsMagicV1 = "pmcred:v1:"
 )
 
 // Credentials holds the agent's identity and certificates.
@@ -88,11 +99,17 @@ func (s *Store) Save(creds *Credentials) error {
 		return fmt.Errorf("marshal credentials: %w", err)
 	}
 
-	// Encrypt
+	// Encrypt and prepend the format-version magic. New writes
+	// always use v1; Load() recognises both v1 (magic-prefixed) and
+	// the original unprefixed layout for backward compatibility with
+	// agents enrolled before the format was versioned. Future
+	// migrations (e.g. TPM-sealed key, different KDF parameters)
+	// bump the magic and Load() picks the matching path.
 	ciphertext, err := encrypt(key, plaintext)
 	if err != nil {
 		return fmt.Errorf("encrypt credentials: %w", err)
 	}
+	ciphertext = append([]byte(credentialsMagicV1), ciphertext...)
 
 	// Write encrypted credentials atomically. A direct os.WriteFile
 	// leaves a partially written file on crash / full disk / power
@@ -183,6 +200,16 @@ func (s *Store) Load() (*Credentials, error) {
 	ciphertext, err := os.ReadFile(credPath)
 	if err != nil {
 		return nil, fmt.Errorf("read credentials: %w", err)
+	}
+
+	// Strip the format-version magic if present. New writes always
+	// include the v1 prefix; pre-versioning installs have raw
+	// nonce+ciphertext with no prefix. The decrypt path is identical
+	// either way once the prefix is removed — the version difference
+	// is purely about future-proofing format migrations, not about
+	// the cipher in use today.
+	if bytes.HasPrefix(ciphertext, []byte(credentialsMagicV1)) {
+		ciphertext = ciphertext[len(credentialsMagicV1):]
 	}
 
 	// Decrypt

--- a/internal/deviceauth/enroll.go
+++ b/internal/deviceauth/enroll.go
@@ -103,14 +103,21 @@ func (h *EnrollHandler) Enroll(ctx context.Context, req *connect.Request[pm.Enro
 		}), nil
 	}
 
-	// Build client options
-	var clientOpts []sdk.ClientOption
+	// Reject any caller that still tries to disable TLS verification
+	// — the CLI surface no longer exposes a path to set this, and
+	// the proto field is being phased out of the SDK. A SkipVerify
+	// request now indicates either an outdated client or a tampered
+	// IPC payload trying to bypass MITM protection.
 	if req.Msg.SkipVerify {
-		clientOpts = append(clientOpts, sdk.WithInsecureSkipVerify())
+		h.logger.Warn("rejecting enrollment request with SkipVerify=true (TLS bypass is not supported)")
+		return connect.NewResponse(&pm.EnrollResponse{
+			Success: false,
+			Error:   "TLS verification cannot be disabled; remove SkipVerify from the enrollment request",
+		}), nil
 	}
 
-	// Register via control server RPC
-	result, err := sdk.RegisterAgent(ctx, req.Msg.ServerUrl, req.Msg.Token, h.hostname, h.version, csrPEM, clientOpts...)
+	// Register via control server RPC.
+	result, err := sdk.RegisterAgent(ctx, req.Msg.ServerUrl, req.Msg.Token, h.hostname, h.version, csrPEM)
 	if err != nil {
 		h.logger.Error("registration failed", "error", err)
 		return connect.NewResponse(&pm.EnrollResponse{

--- a/internal/deviceauth/enroll.go
+++ b/internal/deviceauth/enroll.go
@@ -80,6 +80,25 @@ func (h *EnrollHandler) Enroll(ctx context.Context, req *connect.Request[pm.Enro
 		}), nil
 	}
 
+	// Reject any caller that tries to disable TLS verification —
+	// the CLI surface no longer exposes a path to set this, and
+	// the proto field is being phased out of the SDK. A SkipVerify
+	// request now indicates either an outdated client or a tampered
+	// IPC payload trying to bypass MITM protection.
+	//
+	// This MUST run before the already-enrolled fast path: otherwise
+	// an attacker who finds a SkipVerify-enabled client can hit the
+	// socket on an enrolled agent and get Success=true back, which
+	// could be misread as "the SkipVerify request was honoured".
+	// CR caught this on PR #61.
+	if req.Msg.SkipVerify {
+		h.logger.Warn("rejecting enrollment request with SkipVerify=true (TLS bypass is not supported)")
+		return connect.NewResponse(&pm.EnrollResponse{
+			Success: false,
+			Error:   "TLS verification cannot be disabled; remove SkipVerify from the enrollment request",
+		}), nil
+	}
+
 	// Check if already enrolled
 	if h.credStore.Exists() {
 		creds, err := h.credStore.Load()
@@ -100,19 +119,6 @@ func (h *EnrollHandler) Enroll(ctx context.Context, req *connect.Request[pm.Enro
 		return connect.NewResponse(&pm.EnrollResponse{
 			Success: false,
 			Error:   fmt.Sprintf("failed to generate CSR: %v", err),
-		}), nil
-	}
-
-	// Reject any caller that still tries to disable TLS verification
-	// — the CLI surface no longer exposes a path to set this, and
-	// the proto field is being phased out of the SDK. A SkipVerify
-	// request now indicates either an outdated client or a tampered
-	// IPC payload trying to bypass MITM protection.
-	if req.Msg.SkipVerify {
-		h.logger.Warn("rejecting enrollment request with SkipVerify=true (TLS bypass is not supported)")
-		return connect.NewResponse(&pm.EnrollResponse{
-			Success: false,
-			Error:   "TLS verification cannot be disabled; remove SkipVerify from the enrollment request",
 		}), nil
 	}
 

--- a/internal/executor/agent_update.go
+++ b/internal/executor/agent_update.go
@@ -420,11 +420,13 @@ func clearUpdateState(dataDir string) {
 
 // CheckStartupUpdateState cleans up stale update state from a previous cycle.
 // With the self-test approach, updates are validated before swapping the binary,
-// so there is no rollback logic needed at startup. This function only cleans up
-// state files left behind by interrupted updates.
+// so there is no rollback logic needed at startup. This function cleans up
+// state files left behind by interrupted updates AND any leftover
+// agent-update-*.tmp staging files older than 24h that os.CreateTemp left
+// behind when the agent crashed mid-download.
 //
 // Parameters:
-//   - dataDir: agent data directory containing update/state.json
+//   - dataDir: agent data directory containing update/state.json + update/
 //   - logger: structured logger
 func CheckStartupUpdateState(dataDir string, logger interface {
 	Info(string, ...any)
@@ -438,5 +440,35 @@ func CheckStartupUpdateState(dataDir string, logger interface {
 	if phase != "" {
 		logger.Info("cleaning up stale update state", "phase", phase)
 		clearUpdateState(dataDir)
+	}
+
+	// Sweep stale staging files. The defer os.Remove(tmpPath) inside
+	// executeAgentUpdate handles the happy path AND any return-with-
+	// error path inside that function, but a hard crash (OOM, kernel
+	// panic, power loss) can leave agent-update-*.tmp files behind.
+	// 24h is a generous threshold — a single update completes in
+	// seconds, so anything older is definitively orphaned.
+	updateDir := filepath.Join(dataDir, "update")
+	entries, err := os.ReadDir(updateDir)
+	if err != nil {
+		// update/ doesn't exist on a never-updated agent — not an error.
+		return
+	}
+	cutoff := time.Now().Add(-24 * time.Hour)
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, "agent-update-") || !strings.HasSuffix(name, ".tmp") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		path := filepath.Join(updateDir, name)
+		if err := os.Remove(path); err != nil {
+			logger.Warn("failed to remove stale update tmp file", "path", path, "error", err)
+			continue
+		}
+		logger.Info("removed stale update tmp file", "path", path, "age", time.Since(info.ModTime()).Round(time.Second))
 	}
 }

--- a/internal/executor/agent_update.go
+++ b/internal/executor/agent_update.go
@@ -451,7 +451,15 @@ func CheckStartupUpdateState(dataDir string, logger interface {
 	updateDir := filepath.Join(dataDir, "update")
 	entries, err := os.ReadDir(updateDir)
 	if err != nil {
-		// update/ doesn't exist on a never-updated agent — not an error.
+		// update/ doesn't exist on a never-updated agent — not an
+		// error and not worth a log line. Anything else (EACCES,
+		// IO failure on the device) IS worth surfacing because it
+		// means future self-updates will silently fail to clean up
+		// after themselves.
+		if !os.IsNotExist(err) {
+			logger.Warn("failed to read update dir for stale tmp sweep",
+				"dir", updateDir, "error", err)
+		}
 		return
 	}
 	cutoff := time.Now().Add(-24 * time.Hour)

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3729,20 +3729,35 @@ func (e *Executor) executeSshd(ctx context.Context, params *pb.SshdParams, state
 }
 
 // generateSshdGlobalConfig generates sshd_config content from directives.
-func generateSshdGlobalConfig(params *pb.SshdParams) string {
+// Returns an error if any directive's key or value contains a newline,
+// carriage return, or NUL — these characters would split one directive
+// into multiple lines (or terminate the file early via NUL) and let a
+// crafted action smuggle arbitrary additional sshd directives past the
+// caller's intent. sshd_config has no escape syntax; fail loudly at
+// generation time.
+func generateSshdGlobalConfig(params *pb.SshdParams) (string, error) {
 	var lines []string
 	lines = append(lines, "# Managed by Power Manage - do not edit manually")
 	for _, d := range params.Directives {
+		if strings.ContainsAny(d.Key, "\n\r\x00") {
+			return "", fmt.Errorf("sshd directive key contains forbidden control character (CR, LF, or NUL)")
+		}
+		if strings.ContainsAny(d.Value, "\n\r\x00") {
+			return "", fmt.Errorf("sshd directive %q value contains forbidden control character (CR, LF, or NUL)", d.Key)
+		}
 		lines = append(lines, fmt.Sprintf("%s %s", d.Key, d.Value))
 	}
-	return strings.Join(lines, "\n") + "\n"
+	return strings.Join(lines, "\n") + "\n", nil
 }
 
 // setupSshdConfig creates or updates an sshd_config.d drop-in file and reloads sshd if changed.
 func (e *Executor) setupSshdConfig(ctx context.Context, params *pb.SshdParams, configPath string) (*pb.CommandOutput, bool, error) {
 	var output strings.Builder
 
-	content := generateSshdGlobalConfig(params)
+	content, err := generateSshdGlobalConfig(params)
+	if err != nil {
+		return nil, false, err
+	}
 
 	// Check idempotency
 	if e.configMatchesDesired(ctx, configPath, content) {

--- a/internal/executor/lps.go
+++ b/internal/executor/lps.go
@@ -245,12 +245,24 @@ func shouldRotateLps(state *store.LpsUserState, params *pb.LpsParams, username s
 
 // killUserSessions terminates all sessions and processes for a user.
 // This ensures the old password cannot be used after rotation.
-// Errors are logged but not returned — the user may not have active sessions.
+// Errors are logged at Warn but not returned — the user may have no
+// active sessions (the most common case), in which case both
+// loginctl and pkill exit non-zero. Operators triaging "the old
+// password still works after rotation" need the underlying error in
+// the journal to distinguish "no sessions present" from "loginctl /
+// pkill failed", so the discarded errors get logged with stage tags
+// instead of being silently swallowed.
 func killUserSessions(ctx context.Context, username string) {
 	// Graceful: terminate systemd-logind sessions
-	runSudoCmd(ctx, "loginctl", "terminate-user", username)
+	if _, err := runSudoCmd(ctx, "loginctl", "terminate-user", username); err != nil {
+		slog.Warn("killUserSessions: loginctl terminate-user failed (may be benign — no active sessions)",
+			"username", username, "error", err)
+	}
 	// Forceful: kill all remaining processes owned by the user
-	runSudoCmd(ctx, "pkill", "-KILL", "-u", username)
+	if _, err := runSudoCmd(ctx, "pkill", "-KILL", "-u", username); err != nil {
+		slog.Warn("killUserSessions: pkill failed (may be benign — no remaining processes)",
+			"username", username, "error", err)
+	}
 	// Brief wait for processes to fully exit
 	time.Sleep(500 * time.Millisecond)
 }


### PR DESCRIPTION
## Summary

Six hardening + maintainability improvements from a recent agent code review. All independent of each other but bundled because each is small and they share review surface (security posture).

## 1. Remove `--skip-verify` entirely from the agent CLI

**Removed:** `--skip-verify` flag, `POWER_MANAGE_SKIP_VERIFY` env var, `skip-verify=true` URL query parameter, `tls=false` URL query downgrade, the `if cfg.SkipVerify` branch in `registerAgent`, the `--skip-verify` flag in the `enroll` subcommand, the `SkipVerify` field on `EnrollRequest` calls in `runEnroll` + `trySocketEnroll`.

**Hardened:** the enrollment-socket handler in `internal/deviceauth/enroll.go` now explicitly REJECTS any inbound `EnrollRequest` with `SkipVerify=true` so a tampered local IPC payload can't bypass MITM protection.

**Out of scope (follow-up):** the proto field `EnrollRequest.skip_verify` and `sdk.WithInsecureSkipVerify()` remain in the SDK for now. A coordinated SDK + agent PR will remove them — this PR shrinks the agent's user-facing surface first.

## 2. Self-update binary path uses `os.Executable()`

The hardcoded `/usr/local/bin/power-manage-agent` `BinaryPath` ignored `install.sh --binary <path>`. Now resolved at startup via `os.Executable()` so self-update targets the actually-running binary. Falls back to the canonical path with a Warn log if `os.Executable` fails.

## 3. LUKS sudoers rule narrowed from `luks *` to `luks set-passphrase *`

The previous wildcard auto-elevated any future luks subcommand the agent might add. New subcommands now need a conscious sudoers update before they can run without a password.

## 4. Versioned credentials format

`pmcred:v1:` magic prefix on new credential writes. `Load()` detects the prefix and falls back to the legacy parser when absent so existing installations keep working. Future format migrations (TPM-sealed key, alternate KDF, different cipher) bump the magic and dispatch on it without a flag-day migration.

## 5. Stale `agent-update-*.tmp` cleanup at startup

`CheckStartupUpdateState` now sweeps tmp files in `<dataDir>/update/` older than 24h. The existing `defer os.Remove(tmpPath)` inside `executeAgentUpdate` handles all normal exit paths, but a hard crash mid-download (OOM, kernel panic, power loss) can leave them behind.

## 6. Cert rotation log escalation

Consecutive failures are tracked; after 3 hours the log wording escalates to `cert rotation: rotation stalled, control server may be unreachable` with an `hours_stalled` attribute as the operator-facing triage handle. Successful rotation resets the counter.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/credentials/... ./internal/executor/...` pass
- [x] Manually traced each `SkipVerify` removal path; no remaining call sites in the agent

## Out of scope (filed for later)

- Coordinated SDK + agent PR to remove the proto `skip_verify` field and `sdk.WithInsecureSkipVerify()` entirely.
- `main.go` 1851-line and `executor.go` 3806-line splits (pure refactor; deserves its own PR with focused review surface).
- Move `atomicWriteFile` from `internal/credentials/` to `sdk/go/sys/fs/` (per CLAUDE.md "SDK-First for Shared Code").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Removed insecure TLS verification bypass options during agent enrollment; enrollment now rejects TLS-bypass requests.
  * Narrowed LUKS privilege escalation to password-change operations only.

* **Improvements**
  * Enhanced certificate rotation failure tracking and escalating logging.
  * Improved agent self-update binary path detection at runtime.
  * Added cleanup of stale temporary update files (>24 hours old).
  * Added SSHD configuration validation to reject invalid directives.
  * Credential storage now embeds a versionable on-disk prefix for format detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->