### PR TITLE
feat: keep .bak of previous binary on self-update for operator rollback

### DIFF
--- a/internal/executor/agent_update.go
+++ b/internal/executor/agent_update.go
@@ -193,6 +193,22 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 	// still running in memory, so this is safe. Use atomic
 	// cp → chmod → mv so the live path is only updated after the
 	// new file is fully written and executable.
+	//
+	// Before the swap, save the currently-installed binary to a
+	// `.bak` sibling so an operator can roll back manually with
+	// `mv <BinaryPath>.bak <BinaryPath> && systemctl restart
+	// pm-agent` if the new binary fails to start (the systemd
+	// restart-loop case the self-test cannot catch — bad config
+	// load, missing kernel feature, broken libc dependency, etc.).
+	// We keep only the most recent previous version; older `.bak`s
+	// are rarely useful and accumulate disk cost with frequent
+	// updates. If the backup fails we abort the upgrade rather
+	// than swap without a fallback.
+	bakPath := cfg.BinaryPath + ".bak"
+	if _, err := runSudoCmd(ctx, "cp", cfg.BinaryPath, bakPath); err != nil {
+		return nil, false, fmt.Errorf("backup current binary to %s: %w", bakPath, err)
+	}
+
 	stagePath := cfg.BinaryPath + ".new"
 	if _, err := runSudoCmd(ctx, "cp", tmpPath, stagePath); err != nil {
 		return nil, false, fmt.Errorf("stage binary: %w", err)

--- a/internal/executor/agent_update.go
+++ b/internal/executor/agent_update.go
@@ -204,21 +204,29 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 	// are rarely useful and accumulate disk cost with frequent
 	// updates. If the backup fails we abort the upgrade rather
 	// than swap without a fallback.
+	// All cp/mv/chmod/rm calls below pass `--` before the path
+	// operands as defence in depth against option-injection: any
+	// future code path that lets cfg.BinaryPath, tmpPath, or
+	// stagePath start with a `-` would otherwise be interpreted as
+	// a flag by the sudo'd tool. Today these paths are derived from
+	// fixed config + os.MkdirTemp output (neither produces a
+	// leading-dash filename), but the cost of the separator is
+	// zero and the protection survives future refactors.
 	bakPath := cfg.BinaryPath + ".bak"
-	if _, err := runSudoCmd(ctx, "cp", cfg.BinaryPath, bakPath); err != nil {
+	if _, err := runSudoCmd(ctx, "cp", "--", cfg.BinaryPath, bakPath); err != nil {
 		return nil, false, fmt.Errorf("backup current binary to %s: %w", bakPath, err)
 	}
 
 	stagePath := cfg.BinaryPath + ".new"
-	if _, err := runSudoCmd(ctx, "cp", tmpPath, stagePath); err != nil {
+	if _, err := runSudoCmd(ctx, "cp", "--", tmpPath, stagePath); err != nil {
 		return nil, false, fmt.Errorf("stage binary: %w", err)
 	}
-	if _, err := runSudoCmd(ctx, "chmod", "+x", stagePath); err != nil {
-		runSudoCmd(ctx, "rm", "-f", stagePath)
+	if _, err := runSudoCmd(ctx, "chmod", "+x", "--", stagePath); err != nil {
+		runSudoCmd(ctx, "rm", "-f", "--", stagePath)
 		return nil, false, fmt.Errorf("chmod staged binary: %w", err)
 	}
-	if _, err := runSudoCmd(ctx, "mv", stagePath, cfg.BinaryPath); err != nil {
-		runSudoCmd(ctx, "rm", "-f", stagePath)
+	if _, err := runSudoCmd(ctx, "mv", "--", stagePath, cfg.BinaryPath); err != nil {
+		runSudoCmd(ctx, "rm", "-f", "--", stagePath)
 		return nil, false, fmt.Errorf("swap binary: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

Before this change, a successful self-test → swap path replaced the installed agent binary atomically (\`cp → chmod → mv\`) with no fallback. The self-test catches connectivity and basic startup faults but cannot reproduce every systemd restart-loop scenario (bad config load triggered by host state, missing kernel feature, broken libc dependency, etc.) — so a binary that self-tests clean can still wedge the agent in a crash loop after the systemd restart.

Save the currently-installed binary as \`<BinaryPath>.bak\` immediately before the cp/chmod/mv swap. An operator who finds the agent in a crash loop after an upgrade can roll back manually:

\`\`\`
mv /usr/local/bin/power-manage-agent.bak /usr/local/bin/power-manage-agent
systemctl restart pm-agent
\`\`\`

Only one previous version is kept — older \`.bak\`s are rarely useful and accumulate disk cost with frequent updates. If the backup itself fails (disk full, permissions) we abort the upgrade rather than swap without a fallback.

Automated startup-crash detection + rollback (write upgrade marker, schedule restore on first-heartbeat-after-restart) is intentionally a follow-up PR — that requires plumbing state across restarts and a new boot-time check, scope-creep for this targeted reliability win.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./internal/executor/...\` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent updates now create a sudo-backed backup of the currently installed binary before installing the new version, allowing manual rollback if needed.
* **Bug Fixes / Reliability**
  * If creating the backup fails, the update now aborts to prevent partial or unsafe replacements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->