### PR TITLE
refactor: drop now-dead SkipVerify rejection check; bump SDK

### DIFF
--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -1813,9 +1813,9 @@ func runEnroll(args []string) {
 		return
 	}
 
-	// Enroll via socket. SkipVerify is intentionally NOT set —
-	// the agent CLI no longer exposes any way to disable TLS
-	// verification during registration (MITM hardening).
+	// Enroll via the local socket. The SDK proto no longer carries
+	// a TLS-bypass field; agents always validate the server cert
+	// during enrollment.
 	resp, err := client.Enroll(ctx, connect.NewRequest(&pm.EnrollRequest{
 		ServerUrl: *server,
 		Token:     *token,

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see agent/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260503161545-14177a1fae5a
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260507030409-26fe2c926f63
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260503161545-14177a1fae5a h1:exPydycoctMkMlJFs0oPIw9y/XWadKW7a9Wz1RYgfQ4=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260503161545-14177a1fae5a/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260507030409-26fe2c926f63 h1:cuqQopWQY6+CBuKDgaEVEOQR0+EIuLOhMm2Rc7/AMps=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260507030409-26fe2c926f63/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/deviceauth/enroll.go
+++ b/internal/deviceauth/enroll.go
@@ -80,24 +80,11 @@ func (h *EnrollHandler) Enroll(ctx context.Context, req *connect.Request[pm.Enro
 		}), nil
 	}
 
-	// Reject any caller that tries to disable TLS verification —
-	// the CLI surface no longer exposes a path to set this, and
-	// the proto field is being phased out of the SDK. A SkipVerify
-	// request now indicates either an outdated client or a tampered
-	// IPC payload trying to bypass MITM protection.
-	//
-	// This MUST run before the already-enrolled fast path: otherwise
-	// an attacker who finds a SkipVerify-enabled client can hit the
-	// socket on an enrolled agent and get Success=true back, which
-	// could be misread as "the SkipVerify request was honoured".
-	// CR caught this on PR #61.
-	if req.Msg.SkipVerify {
-		h.logger.Warn("rejecting enrollment request with SkipVerify=true (TLS bypass is not supported)")
-		return connect.NewResponse(&pm.EnrollResponse{
-			Success: false,
-			Error:   "TLS verification cannot be disabled; remove SkipVerify from the enrollment request",
-		}), nil
-	}
+	// (The SkipVerify rejection check that lived here was removed
+	// once the SDK dropped the proto field — see SDK PR. The wire
+	// format now has no path to request a TLS bypass; outdated
+	// clients sending the legacy field number are silently
+	// dropped by the proto3 unknown-field handler.)
 
 	// Check if already enrolled
 	if h.credStore.Exists() {


### PR DESCRIPTION
## Summary

Follow-up to SDK PR manchtools/power-manage-sdk#48 (merged 26fe2c9), which removed the \`EnrollRequest.skip_verify\` proto field and the \`WithInsecureSkipVerify\` option. After that landed:

- The rejection branch in \`internal/deviceauth/enroll.go\` that fired on \`req.Msg.SkipVerify\` is no longer reachable from any wire payload — outdated clients sending the legacy field number 3 are silently dropped by proto3's unknown-field handler before the handler ever sees the request.
- The CLI prologue comment in \`cmd/power-manage-agent/main.go\` referenced the field by name; updated to point at the SDK removal.

\`go.mod\` replace directive bumped to the SDK merge commit (\`26fe2c926f63\`).

## Test plan

- [x] \`GOWORK=off go build ./...\` clean.
- [x] \`GOWORK=off go test ./...\` clean (all internal/* packages green).
- [x] \`GOWORK=off go mod tidy\` clean.

## Coordination

This is the agent half of the cross-repo skip_verify removal coordinated change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed TLS verification bypass option during agent enrollment. Agents now always validate server certificates during enrollment.
* **Chores**
  * Updated SDK dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->