### PR TITLE
refactor: runShellScript via sysexec.PrivilegedStreaming

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see agent/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260507082154-8a164ce50030
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260507091909-dea8b3864f6d
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260507082154-8a164ce50030 h1:91DI92VpzVFd6JW0GE3uZE7ckssD2waAugGl7rGSkwg=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260507082154-8a164ce50030/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260507091909-dea8b3864f6d h1:x0JpouAKvWAwS8hCRLigYdasvNz9aVyAkR1J/Z+7HzM=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260507091909-dea8b3864f6d/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -940,20 +940,16 @@ func (e *Executor) executeShell(ctx context.Context, params *pb.ShellParams) (*p
 
 // runShellScript executes a single shell script string using the shared interpreter,
 // environment, sudo, and working directory settings from ShellParams.
+//
+// RunAsRoot dispatches through sysexec.PrivilegedStreaming, which
+// goes through the SDK's privilege-backend resolution
+// (sudo/doas + -n flag + absolute-path + backend-installed check)
+// so the agent stays consistent with the rest of the SDK's
+// privilege contract instead of hard-coding "sudo -n".
 func (e *Executor) runShellScript(ctx context.Context, params *pb.ShellParams, script string, callback OutputCallback) (*pb.CommandOutput, error) {
 	interpreter := params.Interpreter
 	if interpreter == "" {
 		interpreter = "/bin/sh"
-	}
-
-	var name string
-	var args []string
-	if params.RunAsRoot {
-		name = "sudo"
-		args = []string{"-n", interpreter, "-c", script}
-	} else {
-		name = interpreter
-		args = []string{"-c", script}
 	}
 
 	// Build environment — reject dangerous variable names that could
@@ -969,7 +965,12 @@ func (e *Executor) runShellScript(ctx context.Context, params *pb.ShellParams, s
 		}
 	}
 
-	return runCmdStreaming(ctx, name, args, envVars, params.WorkingDirectory, callback)
+	args := []string{"-c", script}
+	if params.RunAsRoot {
+		r, err := sysexec.PrivilegedStreaming(ctx, interpreter, args, envVars, params.WorkingDirectory, callback)
+		return toOutput(r), err
+	}
+	return runCmdStreaming(ctx, interpreter, args, envVars, params.WorkingDirectory, callback)
 }
 
 // executeShellStreaming executes a shell action with optional detection/execution/verification flow.


### PR DESCRIPTION
## Summary

Followup to SDK PR manchtools/power-manage-sdk#52 (merged \`dea8b38\`), which added \`sysexec.PrivilegedStreaming\` as the streaming counterpart of \`sysexec.Privileged\`.

The hand-rolled \`sudo -n interpreter -c script\` build that \`runShellScript\` used when \`params.RunAsRoot=true\` skipped three pieces of the SDK's privilege contract that the non-streaming \`Privileged\` / \`PrivilegedWithStdin\` already provide:

- **Privilege-backend resolution** (sudo/doas via \`SetPrivilegeBackend\` on agent boot).
- **Absolute-path resolution** of the interpreter so the sudoers rule's exact-path requirement matches.
- **\"privilege backend not installed\"** error when the backend tool itself is missing — silently degraded to a \"command not found\" for \`sudo\` before.

\`runShellScript\` now collapses to a clean pick between the privileged and unprivileged streaming variants.

\`go.mod\` replace directive bumped to the SDK #52 merge commit (\`dea8b3864f6d\`).

## Test plan

- [x] \`GOWORK=off go build ./...\` clean.
- [x] \`GOWORK=off go test ./internal/executor/...\` clean.
- [x] \`GOWORK=off go mod tidy\` clean.

## Coordination

Last piece of the cross-repo PrivilegedStreaming pair: SDK side (#52) merged; agent side this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK dependency to a newer version for enhanced capabilities

* **Refactor**
  * Improved system-level privileged execution handling for better reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->