### PR TITLE
fix: post-#70 security follow-ups (env-var leak + selftest URL parse)

### DIFF
--- a/cmd/power-manage-agent/cmd_selftest.go
+++ b/cmd/power-manage-agent/cmd_selftest.go
@@ -81,7 +81,7 @@ func runSelfTest(args []string) int {
 		logger.Error("self-test: failed to configure mTLS", "error", err)
 		return 1
 	}
-	client := sdk.NewClient(creds.GatewayAddr,
+	client := sdk.NewClient(gatewayAddr,
 		mtlsOpt,
 		sdk.WithAuth(creds.DeviceID, ""),
 	)

--- a/cmd/power-manage-agent/cmd_selftest.go
+++ b/cmd/power-manage-agent/cmd_selftest.go
@@ -71,8 +71,16 @@ func runSelfTest(args []string) int {
 	// URL — both block sdk.WithMTLSFromPEM from running.
 	gatewayAddr := strings.TrimSpace(creds.GatewayAddr)
 	parsed, parseErr := url.Parse(gatewayAddr)
-	if parseErr != nil || strings.ToLower(parsed.Scheme) != "https" {
-		logger.Error("self-test: refusing non-https gateway URL — agent requires https:// for gateway connections",
+	// Require a proper https://host URL. The Opaque + Host checks
+	// catch the corner cases url.Parse leaves accepted: a bare
+	// "https:" parses with Scheme="https" but no Host, and an
+	// opaque "https:foo" parses with Opaque="foo" rather than as
+	// a network URL — both would slip past a Scheme-only check.
+	if parseErr != nil ||
+		strings.ToLower(parsed.Scheme) != "https" ||
+		parsed.Opaque != "" ||
+		parsed.Host == "" {
+		logger.Error("self-test: refusing non-https or hostless gateway URL — agent requires https://host for gateway connections",
 			"gateway", creds.GatewayAddr, "parse_error", parseErr)
 		return 1
 	}

--- a/cmd/power-manage-agent/cmd_selftest.go
+++ b/cmd/power-manage-agent/cmd_selftest.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"flag"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -58,13 +59,21 @@ func runSelfTest(args []string) int {
 	}
 	logger.Info("self-test: credentials loaded", "device_id", creds.DeviceID)
 
-	// Step 2: Create mTLS client. rc10 refuses http:// here: the
-	// self-test is invoked by the packaged install flow on managed
-	// devices and must exercise the same security posture as normal
-	// agent operation.
-	if strings.HasPrefix(creds.GatewayAddr, "http://") {
-		logger.Error("self-test: refusing h2c gateway URL — agent requires https:// for gateway connections",
-			"gateway", creds.GatewayAddr)
+	// Step 2: Create mTLS client. rc10 refuses anything but https://
+	// here: the self-test is invoked by the packaged install flow on
+	// managed devices and must exercise the same security posture as
+	// normal agent operation.
+	//
+	// Parse the URL rather than checking a literal prefix so case
+	// variants (HTTP://, Https://), leading whitespace, and any
+	// non-https scheme (ftp://, h2c://, the empty scheme) all fail
+	// closed. A malformed URL is treated the same as a wrong-scheme
+	// URL — both block sdk.WithMTLSFromPEM from running.
+	gatewayAddr := strings.TrimSpace(creds.GatewayAddr)
+	parsed, parseErr := url.Parse(gatewayAddr)
+	if parseErr != nil || strings.ToLower(parsed.Scheme) != "https" {
+		logger.Error("self-test: refusing non-https gateway URL — agent requires https:// for gateway connections",
+			"gateway", creds.GatewayAddr, "parse_error", parseErr)
 		return 1
 	}
 	mtlsOpt, err := sdk.WithMTLSFromPEM(creds.Certificate, creds.PrivateKey, creds.CACert)

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -952,17 +952,32 @@ func (e *Executor) runShellScript(ctx context.Context, params *pb.ShellParams, s
 		interpreter = "/bin/sh"
 	}
 
-	// Build environment — reject dangerous variable names that could
-	// hijack the child process (e.g. LD_PRELOAD, PATH, LD_LIBRARY_PATH).
-	var envVars []string
-	if len(params.Environment) > 0 {
-		envVars = os.Environ()
-		for k, v := range params.Environment {
-			if !sysexec.IsAllowedEnvVar(k) {
-				return nil, fmt.Errorf("environment variable %q is not allowed", k)
-			}
-			envVars = append(envVars, fmt.Sprintf("%s=%s", k, v))
+	// Build environment from a curated baseline plus only the
+	// caller-supplied entries that pass IsAllowedEnvVar. The
+	// previous shape (`os.Environ()` baseline + per-entry validation)
+	// defeated the guard: any dangerous variable already set in the
+	// agent's own environment (LD_PRELOAD, LD_LIBRARY_PATH, PATH
+	// hijacks, etc.) would leak through unchecked, because validation
+	// only ran for *new* additions. Empty `params.Environment` was
+	// even worse — `envVars` stayed nil, so the child silently
+	// inherited the *full* ambient environment.
+	//
+	// The baseline below is the minimum needed for a useful shell:
+	// PATH (to find common binaries) and LANG/HOME/USER (to keep
+	// locale-aware tools and `~` expansion sane). Anything else the
+	// action needs goes through `params.Environment` and the
+	// IsAllowedEnvVar gate.
+	envVars := []string{
+		"PATH=" + os.Getenv("PATH"),
+		"LANG=" + os.Getenv("LANG"),
+		"HOME=" + os.Getenv("HOME"),
+		"USER=" + os.Getenv("USER"),
+	}
+	for k, v := range params.Environment {
+		if !sysexec.IsAllowedEnvVar(k) {
+			return nil, fmt.Errorf("environment variable %q is not allowed", k)
 		}
+		envVars = append(envVars, fmt.Sprintf("%s=%s", k, v))
 	}
 
 	args := []string{"-c", script}


### PR DESCRIPTION
## Summary

Closes #71 and #72.

CR caught two pre-existing bugs while reviewing PR #70 (the main.go file split). Filed both as their own issues to keep #70 scope-pure; this PR fixes them as a focused security pair.

### #71 — runShellScript env-var leak

\`runShellScript\` validated *new* env-var keys via \`sysexec.IsAllowedEnvVar\` but built the child env from \`os.Environ()\`, defeating the guard:

- Any dangerous variable already set in the agent's own environment (\`LD_PRELOAD\`, \`LD_LIBRARY_PATH\`, \`PATH\` hijacks, etc.) leaked through unchecked.
- An empty \`params.Environment\` made \`envVars\` nil — the child silently inherited the **full** ambient environment with zero filtering.

Build the child env from a curated baseline (\`PATH\`, \`LANG\`, \`HOME\`, \`USER\`) plus only validated caller additions.

### #72 — cmd_selftest URL guard

\`cmd_selftest.go\` rejected plain-HTTP gateway URLs with \`strings.HasPrefix(creds.GatewayAddr, \"http://\")\`. The check missed:

- Uppercase / mixed case (\`HTTP://\`, \`Http://\`)
- Leading whitespace (\` http://\`)
- Non-HTTPS schemes (\`ftp://\`, \`h2c://\`, the empty scheme)

Parse via \`net/url\` and require lowercase \`https\`, treating malformed URLs the same as wrong-scheme URLs (both fail closed).

## Test plan

- [x] \`GOWORK=off go build ./...\` clean.
- [x] \`GOWORK=off go test ./...\` clean across all packages.

## Note

Both bugs predate PR #70. The file split made them easier to spot during CR's review. Filed and fixed separately to keep the split's pure-mechanical-move promise intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gateway validation now strictly requires a well-formed HTTPS URL and rejects malformed or non-HTTPS addresses early, preventing insecure or ambiguous targets.
  * Shell script execution now uses a minimal, controlled environment and only appends approved environment variables, avoiding inheritance of unintended ambient variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->