### PR TITLE
fix: critical-severity executor.go bugs from #75 review (path traversal, lock unlink, SSH key injection, ABSENT bypass)

### DIFF
--- a/internal/executor/action_directory.go
+++ b/internal/executor/action_directory.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	sysfs "github.com/manchtools/power-manage/sdk/go/sys/fs"
@@ -59,8 +60,12 @@ func (e *Executor) executeDirectory(ctx context.Context, params *pb.DirectoryPar
 			}, false, nil
 		}
 
-		// Safety check: refuse to delete protected system directories
-		if isProtectedPath(cleanPath) {
+		// Safety check: refuse to delete protected system directories.
+		// Check both the resolved path (after sysfs.ResolveAndValidatePath
+		// followed any symlinks) AND the cleaned input path, so that
+		// a symlinked protected directory can't be removed by aiming
+		// at the symlink and slipping past via resolution.
+		if isProtectedPath(cleanPath) || isProtectedPath(filepath.Clean(params.Path)) {
 			return nil, false, fmt.Errorf("refusing to delete protected system path: %s", cleanPath)
 		}
 

--- a/internal/executor/action_directory.go
+++ b/internal/executor/action_directory.go
@@ -66,7 +66,7 @@ func (e *Executor) executeDirectory(ctx context.Context, params *pb.DirectoryPar
 		// a symlinked protected directory can't be removed by aiming
 		// at the symlink and slipping past via resolution.
 		if isProtectedPath(cleanPath) || isProtectedPath(filepath.Clean(params.Path)) {
-			return nil, false, fmt.Errorf("refusing to delete protected system path: %s", cleanPath)
+			return nil, false, fmt.Errorf("refusing to delete protected system path: %s (resolved from %s)", cleanPath, params.Path)
 		}
 
 		// Repair filesystem if mounted read-only

--- a/internal/executor/action_file.go
+++ b/internal/executor/action_file.go
@@ -45,7 +45,11 @@ func (e *Executor) executeFile(ctx context.Context, params *pb.FileParams, state
 		// are off-limits. Check both the cleaned input and the
 		// resolved-symlink path so /etc/resolv.conf -> /run/... can't
 		// slip past via symlink resolution.
-		if isCriticalFile(resolvedPath) || isCriticalFile(params.Path) {
+		// isCriticalFile already runs filepath.Clean internally, but
+		// pass the cleaned path explicitly here for symmetry with the
+		// ABSENT branch's `isProtectedPath(filepath.Clean(...))` call
+		// — both call sites read the same way.
+		if isCriticalFile(resolvedPath) || isCriticalFile(filepath.Clean(params.Path)) {
 			return nil, false, fmt.Errorf("refusing to overwrite critical system file: %s (resolved from %s)", resolvedPath, params.Path)
 		}
 

--- a/internal/executor/action_file.go
+++ b/internal/executor/action_file.go
@@ -46,7 +46,7 @@ func (e *Executor) executeFile(ctx context.Context, params *pb.FileParams, state
 		// resolved-symlink path so /etc/resolv.conf -> /run/... can't
 		// slip past via symlink resolution.
 		if isCriticalFile(resolvedPath) || isCriticalFile(params.Path) {
-			return nil, false, fmt.Errorf("refusing to overwrite critical system file: %s", resolvedPath)
+			return nil, false, fmt.Errorf("refusing to overwrite critical system file: %s (resolved from %s)", resolvedPath, params.Path)
 		}
 
 		// Repair filesystem if mounted read-only
@@ -117,7 +117,7 @@ func (e *Executor) executeFile(ctx context.Context, params *pb.FileParams, state
 		// same rule: editing protected files via block-removal is just
 		// as dangerous as full deletion.
 		if isProtectedPath(resolvedPath) || isProtectedPath(filepath.Clean(params.Path)) {
-			return nil, false, fmt.Errorf("refusing to remove protected system path: %s", resolvedPath)
+			return nil, false, fmt.Errorf("refusing to remove protected system path: %s (resolved from %s)", resolvedPath, params.Path)
 		}
 
 		// Repair filesystem if mounted read-only

--- a/internal/executor/action_file.go
+++ b/internal/executor/action_file.go
@@ -222,8 +222,7 @@ func (e *Executor) fileMatchesDesired(path string, params *pb.FileParams) bool {
 	return true
 }
 
-// protectedPaths contains paths that should never be deleted.
-// These are checked as prefixes after path cleaning.
+// protectedPaths contains directories that should never be deleted as a whole.
 var protectedPaths = []string{
 	"/",
 	"/bin",
@@ -249,24 +248,48 @@ var protectedPaths = []string{
 	"/var",
 }
 
-// isProtectedPath checks if a path is a protected system directory.
-// Returns true if the path should not be deleted.
+// criticalFiles lists individual files whose removal would render the
+// system unbootable, lock the operator out, or destroy account/auth
+// state. Their parent directories (e.g. /etc) are not blanket-protected
+// because legitimate managed-file removal under /etc must keep working;
+// these specific files are denylisted instead.
+var criticalFiles = []string{
+	"/etc/passwd",
+	"/etc/shadow",
+	"/etc/group",
+	"/etc/gshadow",
+	"/etc/sudoers",
+	"/etc/fstab",
+	"/etc/hosts",
+	"/etc/hostname",
+	"/etc/resolv.conf",
+	"/etc/nsswitch.conf",
+	"/etc/ssh/sshd_config",
+	"/etc/pam.conf",
+	"/etc/machine-id",
+}
+
+// isProtectedPath checks if a path is a protected system directory or a
+// critical file. Returns true if the path should not be deleted.
 func isProtectedPath(path string) bool {
-	// Clean and get absolute path
 	cleanPath := filepath.Clean(path)
 
-	// Check exact matches against protected paths
 	for _, protected := range protectedPaths {
 		if cleanPath == protected {
 			return true
 		}
 	}
 
+	for _, critical := range criticalFiles {
+		if cleanPath == critical {
+			return true
+		}
+	}
+
 	// Also protect immediate children of / that aren't in our list
-	// (e.g., /lost+found, or any other top-level directory)
+	// (e.g., /lost+found, or any other top-level directory).
 	parts := strings.Split(strings.TrimPrefix(cleanPath, "/"), "/")
 	if len(parts) == 1 && parts[0] != "" {
-		// This is a top-level directory like /something
 		return true
 	}
 

--- a/internal/executor/action_file.go
+++ b/internal/executor/action_file.go
@@ -37,6 +37,18 @@ func (e *Executor) executeFile(ctx context.Context, params *pb.FileParams, state
 			}, false, nil
 		}
 
+		// Refuse content overwrite of critical files (/etc/passwd,
+		// /etc/shadow, /etc/sudoers, …). Unlike ABSENT, the PRESENT
+		// branch is NOT blocked from writing under protected
+		// directories — managed config under /etc/foo.d/ is the whole
+		// point of the file action; only the named individual files
+		// are off-limits. Check both the cleaned input and the
+		// resolved-symlink path so /etc/resolv.conf -> /run/... can't
+		// slip past via symlink resolution.
+		if isCriticalFile(resolvedPath) || isCriticalFile(params.Path) {
+			return nil, false, fmt.Errorf("refusing to overwrite critical system file: %s", resolvedPath)
+		}
+
 		// Repair filesystem if mounted read-only
 		if out, err := e.requireWritableFS(ctx); err != nil {
 			return out, false, err
@@ -94,15 +106,17 @@ func (e *Executor) executeFile(ctx context.Context, params *pb.FileParams, state
 			}, false, nil
 		}
 
-		// Refuse ABSENT delete on protected system paths. The PRESENT
-		// branches above already guard via isProtectedPath, but
-		// ABSENT used to bypass entirely — a signed action could
-		// request deletion of /etc/shadow, /etc/sudoers, /etc/passwd,
-		// etc. and the agent would oblige. Apply the same allowlist.
-		// Managed-block mode is fine to leave gated by the same
-		// rule: editing protected files via block-removal is just as
-		// dangerous as full deletion.
-		if isProtectedPath(resolvedPath) {
+		// Refuse ABSENT delete on protected system paths. A signed
+		// action could otherwise request deletion of /etc/shadow,
+		// /etc/sudoers, /etc/passwd, etc. and the agent would oblige.
+		// Check BOTH the resolved path and the cleaned original path:
+		// e.g. /etc/resolv.conf is a symlink to /run/systemd/resolve/...
+		// on systemd-resolved hosts; the resolved path has 3 components
+		// and slips past isProtectedPath, but the original is in the
+		// criticalFiles denylist. Managed-block mode is gated by the
+		// same rule: editing protected files via block-removal is just
+		// as dangerous as full deletion.
+		if isProtectedPath(resolvedPath) || isProtectedPath(filepath.Clean(params.Path)) {
 			return nil, false, fmt.Errorf("refusing to remove protected system path: %s", resolvedPath)
 		}
 
@@ -280,10 +294,8 @@ func isProtectedPath(path string) bool {
 		}
 	}
 
-	for _, critical := range criticalFiles {
-		if cleanPath == critical {
-			return true
-		}
+	if isCriticalFile(cleanPath) {
+		return true
 	}
 
 	// Also protect immediate children of / that aren't in our list
@@ -293,5 +305,22 @@ func isProtectedPath(path string) bool {
 		return true
 	}
 
+	return false
+}
+
+// isCriticalFile checks if a path matches a critical-file denylist entry.
+// Used by both ABSENT and PRESENT branches: deletion AND content overwrite
+// of /etc/passwd, /etc/shadow, /etc/sudoers, etc. is catastrophic. The
+// PRESENT branch only blocks criticalFiles (not the protectedPaths
+// directories) because writing managed config under /etc/foo.d/ is the
+// whole point of the file action; only the named individual files are
+// off-limits.
+func isCriticalFile(path string) bool {
+	cleanPath := filepath.Clean(path)
+	for _, critical := range criticalFiles {
+		if cleanPath == critical {
+			return true
+		}
+	}
 	return false
 }

--- a/internal/executor/action_file.go
+++ b/internal/executor/action_file.go
@@ -94,6 +94,18 @@ func (e *Executor) executeFile(ctx context.Context, params *pb.FileParams, state
 			}, false, nil
 		}
 
+		// Refuse ABSENT delete on protected system paths. The PRESENT
+		// branches above already guard via isProtectedPath, but
+		// ABSENT used to bypass entirely — a signed action could
+		// request deletion of /etc/shadow, /etc/sudoers, /etc/passwd,
+		// etc. and the agent would oblige. Apply the same allowlist.
+		// Managed-block mode is fine to leave gated by the same
+		// rule: editing protected files via block-removal is just as
+		// dangerous as full deletion.
+		if isProtectedPath(resolvedPath) {
+			return nil, false, fmt.Errorf("refusing to remove protected system path: %s", resolvedPath)
+		}
+
 		// Repair filesystem if mounted read-only
 		if out, err := e.requireWritableFS(ctx); err != nil {
 			return out, false, err

--- a/internal/executor/action_ssh.go
+++ b/internal/executor/action_ssh.go
@@ -3,6 +3,8 @@ package executor
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -10,20 +12,65 @@ import (
 	sysuser "github.com/manchtools/power-manage/sdk/go/sys/user"
 )
 
-// validateActionIDForFilesystem rejects an actionID that contains
-// any character outside the alphanumeric-safe set. Action IDs flow
-// into filesystem paths (/etc/sudoers.d/<id>,
-// /etc/ssh/sshd_config.d/<id>.conf, …) and into Linux group names
-// (pm-ssh-<id>, pm-sudo-<id>). The entry-point getActionID enforces
-// the same rule, but defense-in-depth at the splice point matters
-// because each action_*.go file accepts actionID as a parameter:
-// any future caller that bypasses getActionID would otherwise smuggle
-// path-meaningful characters straight into a system path.
+// shortGroupName builds a Linux-group-safe name from a prefix and an
+// actionID, enforcing the 32-character group-name limit. If
+// prefix+actionID fits, the actionID is used verbatim (preserving
+// human-readable naming for typical ULID-length inputs). If it would
+// overflow, the actionID is replaced with a short stable hash so two
+// IDs sharing a long common prefix can't collide on the same group.
+// The hash carries 32 bits of collision space — adequate per host
+// because the namespace is per-action and the group is unlinked when
+// the action is removed.
+func shortGroupName(prefix, actionID string) string {
+	const linuxGroupMax = 32
+	lower := strings.ToLower(actionID)
+	full := prefix + lower
+	if len(full) <= linuxGroupMax {
+		return full
+	}
+	sum := sha256.Sum256([]byte(lower))
+	hashHex := hex.EncodeToString(sum[:])
+	// Reserve 1 char for separator, 8 chars for hash; the rest is
+	// readable prefix from the actionID itself.
+	const hashLen = 8
+	const sepLen = 1
+	keep := linuxGroupMax - len(prefix) - sepLen - hashLen
+	if keep < 1 {
+		// Pathological: prefix alone leaves no room for any hash.
+		// Caller should keep prefixes short; truncate the prefix in
+		// that case so the hash fits — name is no longer
+		// human-readable but stays collision-resistant.
+		return prefix[:linuxGroupMax-sepLen-hashLen] + "-" + hashHex[:hashLen]
+	}
+	return prefix + lower[:keep] + "-" + hashHex[:hashLen]
+}
+
+// maxActionIDForFilesystem caps the length of an actionID before it is
+// spliced into a filesystem path or Linux group name. getActionID
+// already enforces the same ceiling at the entry point, but the
+// per-action functions accept actionID as a parameter, so we re-check
+// here as defense in depth. Set the same as getActionID's limit to
+// avoid divergence: any ID accepted upstream is accepted here.
+const maxActionIDForFilesystem = 64
+
+// validateActionIDForFilesystem rejects an actionID that is empty,
+// too long, or contains any character outside the alphanumeric-safe
+// set. Action IDs flow into filesystem paths
+// (/etc/sudoers.d/<id>, /etc/ssh/sshd_config.d/<id>.conf, …) and into
+// Linux group names (pm-ssh-<id>, pm-sudo-<id>). The entry-point
+// getActionID enforces the same rule, but each action_*.go file
+// accepts actionID as a parameter and any future caller that bypasses
+// getActionID would otherwise smuggle path-meaningful characters
+// straight into a system path. Errors are split per failure mode so
+// callers can distinguish length issues from character issues.
 func validateActionIDForFilesystem(actionID string) error {
 	if actionID == "" {
 		return fmt.Errorf("action ID required for group/file naming")
 	}
-	if len(actionID) > 64 || !validActionIDRegex.MatchString(actionID) {
+	if len(actionID) > maxActionIDForFilesystem {
+		return fmt.Errorf("action ID %q exceeds %d-character limit for filesystem use", actionID, maxActionIDForFilesystem)
+	}
+	if !validActionIDRegex.MatchString(actionID) {
 		return fmt.Errorf("action ID %q contains characters that are unsafe for filesystem paths", actionID)
 	}
 	return nil
@@ -31,12 +78,11 @@ func validateActionIDForFilesystem(actionID string) error {
 
 // sshGroupName creates a valid Linux group name from the action ID for SSH access.
 // Linux group names: max 32 chars. pm-ssh- (7 chars) + up to 25 chars of action ID.
+// For longer action IDs, falls back to a hash-suffix scheme to keep
+// the mapping unique — naïve truncation could otherwise let two
+// distinct IDs sharing a 25-char prefix collide on the same group.
 func sshGroupName(actionID string) string {
-	lower := strings.ToLower(actionID)
-	if len(lower) > 25 {
-		lower = lower[:25]
-	}
-	return "pm-ssh-" + lower
+	return shortGroupName("pm-ssh-", actionID)
 }
 
 // sshConfigPath returns the path for an SSH config drop-in file.

--- a/internal/executor/action_ssh.go
+++ b/internal/executor/action_ssh.go
@@ -6,23 +6,25 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/oklog/ulid/v2"
-
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	sysuser "github.com/manchtools/power-manage/sdk/go/sys/user"
 )
 
-// validateActionIDForFilesystem rejects an actionID that isn't a
-// well-formed ULID. Action IDs flow into filesystem paths
-// (/etc/sudoers.d/<id>, /etc/ssh/sshd_config.d/<id>.conf etc.); a
-// non-ULID value containing slashes or shell metacharacters would
-// let a signed action escape the intended directory or overwrite
-// arbitrary system files. ULIDs are 26 characters, base32-Crockford,
-// no path-meaningful characters — exact match means the input can
-// be spliced into a path safely.
+// validateActionIDForFilesystem rejects an actionID that contains
+// any character outside the alphanumeric-safe set. Action IDs flow
+// into filesystem paths (/etc/sudoers.d/<id>,
+// /etc/ssh/sshd_config.d/<id>.conf, …) and into Linux group names
+// (pm-ssh-<id>, pm-sudo-<id>). The entry-point getActionID enforces
+// the same rule, but defense-in-depth at the splice point matters
+// because each action_*.go file accepts actionID as a parameter:
+// any future caller that bypasses getActionID would otherwise smuggle
+// path-meaningful characters straight into a system path.
 func validateActionIDForFilesystem(actionID string) error {
-	if _, err := ulid.Parse(actionID); err != nil {
-		return fmt.Errorf("action ID %q is not a valid ULID; refusing to splice into filesystem path", actionID)
+	if actionID == "" {
+		return fmt.Errorf("action ID required for group/file naming")
+	}
+	if len(actionID) > 64 || !validActionIDRegex.MatchString(actionID) {
+		return fmt.Errorf("action ID %q contains characters that are unsafe for filesystem paths", actionID)
 	}
 	return nil
 }

--- a/internal/executor/action_ssh.go
+++ b/internal/executor/action_ssh.go
@@ -6,9 +6,26 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/oklog/ulid/v2"
+
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	sysuser "github.com/manchtools/power-manage/sdk/go/sys/user"
 )
+
+// validateActionIDForFilesystem rejects an actionID that isn't a
+// well-formed ULID. Action IDs flow into filesystem paths
+// (/etc/sudoers.d/<id>, /etc/ssh/sshd_config.d/<id>.conf etc.); a
+// non-ULID value containing slashes or shell metacharacters would
+// let a signed action escape the intended directory or overwrite
+// arbitrary system files. ULIDs are 26 characters, base32-Crockford,
+// no path-meaningful characters — exact match means the input can
+// be spliced into a path safely.
+func validateActionIDForFilesystem(actionID string) error {
+	if _, err := ulid.Parse(actionID); err != nil {
+		return fmt.Errorf("action ID %q is not a valid ULID; refusing to splice into filesystem path", actionID)
+	}
+	return nil
+}
 
 // sshGroupName creates a valid Linux group name from the action ID for SSH access.
 // Linux group names: max 32 chars. pm-ssh- (7 chars) + up to 25 chars of action ID.
@@ -36,8 +53,8 @@ func (e *Executor) executeSsh(ctx context.Context, params *pb.SshParams, state p
 	if params == nil {
 		return nil, false, fmt.Errorf("ssh params required")
 	}
-	if actionID == "" {
-		return nil, false, fmt.Errorf("action ID required for ssh group/file naming")
+	if err := validateActionIDForFilesystem(actionID); err != nil {
+		return nil, false, err
 	}
 
 	users := sshEffectiveUsers(params)
@@ -187,8 +204,8 @@ func (e *Executor) executeSshd(ctx context.Context, params *pb.SshdParams, state
 	if len(params.Directives) == 0 && state != pb.DesiredState_DESIRED_STATE_ABSENT {
 		return nil, false, fmt.Errorf("at least one directive is required")
 	}
-	if actionID == "" {
-		return nil, false, fmt.Errorf("action ID required for sshd config file naming")
+	if err := validateActionIDForFilesystem(actionID); err != nil {
+		return nil, false, err
 	}
 
 	configPath := fmt.Sprintf("/etc/ssh/sshd_config.d/%04d-pm-%s.conf", params.Priority, actionID)

--- a/internal/executor/action_ssh.go
+++ b/internal/executor/action_ssh.go
@@ -256,7 +256,7 @@ func (e *Executor) executeSshd(ctx context.Context, params *pb.SshdParams, state
 		return nil, false, err
 	}
 
-	configPath := fmt.Sprintf("/etc/ssh/sshd_config.d/%04d-pm-%s.conf", params.Priority, actionID)
+	configPath := fmt.Sprintf("/etc/ssh/sshd_config.d/%04d-pm-%s.conf", params.Priority, strings.ToLower(actionID))
 
 	switch state {
 	case pb.DesiredState_DESIRED_STATE_ABSENT:

--- a/internal/executor/action_update.go
+++ b/internal/executor/action_update.go
@@ -3,7 +3,6 @@ package executor
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -253,31 +252,20 @@ func (e *Executor) removeStaleLockFile(ctx context.Context, path string) {
 		// Already absent — nothing to do.
 		return
 	}
-	// `fuser -s` runs silently and uses exit codes only.
-	cmd := exec.CommandContext(ctx, "fuser", "-s", path)
-	err := cmd.Run()
-	if err == nil {
-		// Exit 0 → file is held by a live process. Refuse to
-		// unlink: yanking the lock now would let a second pkg-mgr
-		// process race in on top of an in-flight transaction.
+	// `fuser -s` runs silently and uses exit codes only:
+	//   exit 0 → file is held by a live process (skip removal),
+	//   exit 1 → no holder (safe to unlink),
+	//   any other exit (incl. fuser-missing) → can't prove stale,
+	//                                          be safe and skip.
+	fuserOut, fuserErr := runSudoCmd(ctx, "fuser", "-s", path)
+	if fuserErr == nil {
 		slog.Warn("repair: lock file held by live process; refusing to unlink",
 			"path", path)
 		return
 	}
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
-		// fuser missing, ENOENT, or any other invocation problem.
-		// Be conservative — don't unlink something we couldn't
-		// prove stale.
-		slog.Warn("repair: cannot probe lock file holder (fuser unavailable or errored); skipping unlink",
-			"path", path, "error", err)
-		return
-	}
-	// fuser returned a non-zero exit. Exit 1 is the "no holder"
-	// signal we want; any other exit is unexpected — also skip.
-	if exitErr.ExitCode() != 1 {
-		slog.Warn("repair: unexpected fuser exit; skipping lock-file unlink",
-			"path", path, "exit_code", exitErr.ExitCode())
+	if fuserOut == nil || fuserOut.ExitCode != 1 {
+		slog.Warn("repair: cannot probe lock file holder; skipping unlink",
+			"path", path, "error", fuserErr)
 		return
 	}
 	if _, err := runSudoCmd(ctx, "rm", "-f", "--", path); err != nil {

--- a/internal/executor/action_update.go
+++ b/internal/executor/action_update.go
@@ -274,6 +274,64 @@ func (e *Executor) removeStaleLockFile(ctx context.Context, path string) {
 	}
 }
 
+// removeStaleZyppPidFile removes a zypper PID file ONLY if the
+// recorded PID does not belong to a running process. zypp.pid
+// records zypper's PID; the daemonized process closes the fd
+// after writing, so fuser would report no holder even when zypper
+// is mid-flight — using removeStaleLockFile here would mis-classify
+// a running zypper as stale and yank the lock from under it.
+//
+// Liveness check uses `kill -0 <pid>`: exit 0 means the process
+// exists (skip removal), nonzero means no such process (safe to
+// remove). A malformed file (no parseable PID) is treated as
+// stale and removed. We never delete a PID file we couldn't prove
+// stale via a successful kill -0 negative.
+func (e *Executor) removeStaleZyppPidFile(ctx context.Context, path string) {
+	if _, err := os.Stat(path); err != nil {
+		return
+	}
+	out, readErr := runSudoCmd(ctx, "cat", "--", path)
+	if readErr != nil || out == nil {
+		slog.Warn("repair: cannot read zypp PID file; skipping unlink",
+			"path", path, "error", readErr)
+		return
+	}
+	pid := strings.TrimSpace(out.Stdout)
+	if pid == "" {
+		// Empty PID file — no live holder to harm; remove it.
+		if _, err := runSudoCmd(ctx, "rm", "-f", "--", path); err != nil {
+			slog.Warn("repair: failed to remove empty zypp PID file",
+				"path", path, "error", err)
+		}
+		return
+	}
+	// Validate PID is purely numeric before splicing into kill.
+	for _, r := range pid {
+		if r < '0' || r > '9' {
+			slog.Warn("repair: zypp PID file contains non-numeric content; skipping unlink",
+				"path", path, "content", pid)
+			return
+		}
+	}
+	killOut, killErr := runSudoCmd(ctx, "kill", "-0", pid)
+	if killErr == nil {
+		slog.Warn("repair: zypper process is still running; refusing to unlink PID file",
+			"path", path, "pid", pid)
+		return
+	}
+	if killOut == nil || killOut.ExitCode != 1 {
+		// kill -0 returns 1 for "no such process" and 2 for permission/usage.
+		// Anything other than 1 means we couldn't prove the process is gone.
+		slog.Warn("repair: cannot probe zypp PID liveness; skipping unlink",
+			"path", path, "pid", pid, "error", killErr)
+		return
+	}
+	if _, err := runSudoCmd(ctx, "rm", "-f", "--", path); err != nil {
+		slog.Warn("repair: failed to remove confirmed-stale zypp PID file",
+			"path", path, "error", err)
+	}
+}
+
 // repairApt fixes common apt/dpkg issues:
 // - Stale lock files from interrupted operations
 // - Interrupted dpkg operations (dpkg --configure -a)
@@ -372,9 +430,11 @@ func (e *Executor) repairPacman(ctx context.Context) {
 // - Repository metadata issues
 // - Broken dependencies
 func (e *Executor) repairZypper(ctx context.Context) {
-	// Remove stale lock file if held by no live process — same
-	// liveness probe as the apt/pacman repair paths.
-	e.removeStaleLockFile(ctx, "/var/run/zypp.pid")
+	// /var/run/zypp.pid is a PID file, not a flock-style lockfile.
+	// `fuser` would report no holder even when zypper is running
+	// because the daemonized zypper writes the PID and closes the
+	// file descriptor. Use a PID-based liveness probe instead.
+	e.removeStaleZyppPidFile(ctx, "/var/run/zypp.pid")
 
 	// Clean repository metadata cache to fix stale metadata issues
 	if _, err := runSudoCmd(ctx, "zypper", "--non-interactive", "clean", "--all"); err != nil {

--- a/internal/executor/action_update.go
+++ b/internal/executor/action_update.go
@@ -3,6 +3,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -235,23 +236,72 @@ func (e *Executor) repairPackageManager(ctx context.Context) {
 	}
 }
 
+// removeStaleLockFile removes a package-manager lock file ONLY if
+// no live process currently holds it open. Unconditionally
+// `rm -f`-ing a lock while a real apt/dpkg/pacman/zypper process is
+// mid-flight corrupts the database — the running process keeps its
+// open file descriptor (POSIX semantics) but a NEW process can now
+// grab the lock and start a concurrent transaction.
+//
+// Liveness check uses `fuser <path>`: exit 0 means at least one
+// process has the file open (skip removal), exit 1 means no holder
+// (safe to remove), other exits / fuser-not-installed are treated
+// as "be safe, skip" so we never delete a lock we couldn't prove
+// stale.
+func (e *Executor) removeStaleLockFile(ctx context.Context, path string) {
+	if _, err := os.Stat(path); err != nil {
+		// Already absent — nothing to do.
+		return
+	}
+	// `fuser -s` runs silently and uses exit codes only.
+	cmd := exec.CommandContext(ctx, "fuser", "-s", path)
+	err := cmd.Run()
+	if err == nil {
+		// Exit 0 → file is held by a live process. Refuse to
+		// unlink: yanking the lock now would let a second pkg-mgr
+		// process race in on top of an in-flight transaction.
+		slog.Warn("repair: lock file held by live process; refusing to unlink",
+			"path", path)
+		return
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		// fuser missing, ENOENT, or any other invocation problem.
+		// Be conservative — don't unlink something we couldn't
+		// prove stale.
+		slog.Warn("repair: cannot probe lock file holder (fuser unavailable or errored); skipping unlink",
+			"path", path, "error", err)
+		return
+	}
+	// fuser returned a non-zero exit. Exit 1 is the "no holder"
+	// signal we want; any other exit is unexpected — also skip.
+	if exitErr.ExitCode() != 1 {
+		slog.Warn("repair: unexpected fuser exit; skipping lock-file unlink",
+			"path", path, "exit_code", exitErr.ExitCode())
+		return
+	}
+	if _, err := runSudoCmd(ctx, "rm", "-f", "--", path); err != nil {
+		slog.Warn("repair: failed to remove confirmed-stale lock file",
+			"path", path, "error", err)
+	}
+}
+
 // repairApt fixes common apt/dpkg issues:
 // - Stale lock files from interrupted operations
 // - Interrupted dpkg operations (dpkg --configure -a)
 // - Broken dependencies (apt -f install)
 // - Stale package lists
 func (e *Executor) repairApt(ctx context.Context) {
-	// Remove stale lock files that may be left from interrupted operations
-	lockFiles := []string{
+	// Remove stale lock files that may be left from interrupted operations.
+	// Each removal is gated on a fuser-based liveness probe so we never
+	// yank a lock from a live apt/dpkg process.
+	for _, lf := range []string{
 		"/var/lib/dpkg/lock-frontend",
 		"/var/lib/dpkg/lock",
 		"/var/lib/apt/lists/lock",
 		"/var/cache/apt/archives/lock",
-	}
-	for _, lf := range lockFiles {
-		if _, err := runSudoCmd(ctx, "rm", "-f", lf); err != nil {
-			slog.Warn("repairApt: failed to remove lock file", "path", lf, "error", err)
-		}
+	} {
+		e.removeStaleLockFile(ctx, lf)
 	}
 
 	// Fix any interrupted dpkg operations.
@@ -307,11 +357,10 @@ func (e *Executor) repairDnf(ctx context.Context) {
 // - Corrupted package database
 // - Keyring issues
 func (e *Executor) repairPacman(ctx context.Context) {
-	// Remove stale lock file if it exists
-	// This handles "unable to lock database" errors from interrupted operations
-	if _, err := runSudoCmd(ctx, "rm", "-f", "/var/lib/pacman/db.lck"); err != nil {
-		slog.Warn("repairPacman: failed to remove lock file", "error", err)
-	}
+	// Remove stale lock file if held by no live process — handles
+	// "unable to lock database" errors from interrupted operations
+	// without yanking the lock from a real concurrent transaction.
+	e.removeStaleLockFile(ctx, "/var/lib/pacman/db.lck")
 
 	// Refresh package database to fix potential corruption
 	// Using -Syy to force refresh even if recently updated
@@ -335,10 +384,9 @@ func (e *Executor) repairPacman(ctx context.Context) {
 // - Repository metadata issues
 // - Broken dependencies
 func (e *Executor) repairZypper(ctx context.Context) {
-	// Remove stale lock files
-	if _, err := runSudoCmd(ctx, "rm", "-f", "/var/run/zypp.pid"); err != nil {
-		slog.Warn("repairZypper: failed to remove lock file", "error", err)
-	}
+	// Remove stale lock file if held by no live process — same
+	// liveness probe as the apt/pacman repair paths.
+	e.removeStaleLockFile(ctx, "/var/run/zypp.pid")
 
 	// Clean repository metadata cache to fix stale metadata issues
 	if _, err := runSudoCmd(ctx, "zypper", "--non-interactive", "clean", "--all"); err != nil {

--- a/internal/executor/action_user.go
+++ b/internal/executor/action_user.go
@@ -224,10 +224,14 @@ func (e *Executor) createUser(ctx context.Context, params *pb.UserParams, output
 		}
 	}
 
-	// Setup SSH authorized keys
+	// Setup SSH authorized keys. Newline / control-character rejection
+	// from setupSSHKeys is fatal by design (the function comment is
+	// explicit). Surface as a real error so the action result reports
+	// FAILED — the previous "warning" path silently degraded a
+	// rejected-input failure into apparent success.
 	if len(params.SshAuthorizedKeys) > 0 {
 		if _, err := e.setupSSHKeys(ctx, params, output); err != nil {
-			output.WriteString(fmt.Sprintf("warning: failed to setup SSH keys: %v\n", err))
+			return nil, nil, fmt.Errorf("setup SSH keys: %w", err)
 		}
 	}
 
@@ -371,10 +375,12 @@ func (e *Executor) updateUser(ctx context.Context, params *pb.UserParams, output
 		}
 	}
 
-	// Setup SSH authorized keys
+	// Setup SSH authorized keys. Same fatal-on-rejection contract as
+	// in createUser — see the comment there. Newline / CR in a key
+	// must fail the action, not degrade to a warning.
 	if len(params.SshAuthorizedKeys) > 0 {
 		if keysChanged, err := e.setupSSHKeys(ctx, params, output); err != nil {
-			output.WriteString(fmt.Sprintf("warning: failed to setup SSH keys: %v\n", err))
+			return nil, changed, fmt.Errorf("setup SSH keys: %w", err)
 		} else if keysChanged {
 			changed = true
 		}

--- a/internal/executor/action_user.go
+++ b/internal/executor/action_user.go
@@ -508,7 +508,7 @@ func (e *Executor) setupSSHKeys(ctx context.Context, params *pb.UserParams, outp
 	// Build desired authorized_keys content
 	var keysContent strings.Builder
 	validKeyCount := 0
-	for _, key := range params.SshAuthorizedKeys {
+	for i, key := range params.SshAuthorizedKeys {
 		trimmedKey := strings.TrimSpace(key)
 		if trimmedKey == "" {
 			continue
@@ -523,7 +523,7 @@ func (e *Executor) setupSSHKeys(ctx context.Context, params *pb.UserParams, outp
 		// fatal — silent skip is wrong here, the caller needs to
 		// know their input was rejected.
 		if strings.ContainsAny(trimmedKey, "\n\r") {
-			return false, fmt.Errorf("authorized_keys entry contains embedded newline (key index %d for user %s); refusing to splice into file", validKeyCount, params.Username)
+			return false, fmt.Errorf("authorized_keys entry contains embedded newline (input index %d for user %s); refusing to splice into file", i, params.Username)
 		}
 		if !strings.HasPrefix(trimmedKey, "ssh-") && !strings.HasPrefix(trimmedKey, "ecdsa-") {
 			output.WriteString(fmt.Sprintf("warning: skipping invalid SSH key (doesn't start with ssh- or ecdsa-): %s...\n", trimmedKey[:min(30, len(trimmedKey))]))

--- a/internal/executor/action_user.go
+++ b/internal/executor/action_user.go
@@ -507,10 +507,23 @@ func (e *Executor) setupSSHKeys(ctx context.Context, params *pb.UserParams, outp
 
 	// Build desired authorized_keys content
 	var keysContent strings.Builder
+	validKeyCount := 0
 	for _, key := range params.SshAuthorizedKeys {
 		trimmedKey := strings.TrimSpace(key)
 		if trimmedKey == "" {
 			continue
+		}
+		// Reject keys with embedded newlines BEFORE the prefix check.
+		// Without this, a signed action could smuggle additional
+		// authorized_keys entries (extra principals, command=
+		// overrides, restrict= bypasses) by embedding "\nssh-rsa
+		// ATTACKER..." in a single key value. The prefix check on
+		// the first line would pass, and the appended lines would
+		// land in the file unfiltered. Treat embedded \n or \r as
+		// fatal — silent skip is wrong here, the caller needs to
+		// know their input was rejected.
+		if strings.ContainsAny(trimmedKey, "\n\r") {
+			return false, fmt.Errorf("authorized_keys entry contains embedded newline (key index %d for user %s); refusing to splice into file", validKeyCount, params.Username)
 		}
 		if !strings.HasPrefix(trimmedKey, "ssh-") && !strings.HasPrefix(trimmedKey, "ecdsa-") {
 			output.WriteString(fmt.Sprintf("warning: skipping invalid SSH key (doesn't start with ssh- or ecdsa-): %s...\n", trimmedKey[:min(30, len(trimmedKey))]))
@@ -518,6 +531,7 @@ func (e *Executor) setupSSHKeys(ctx context.Context, params *pb.UserParams, outp
 		}
 		keysContent.WriteString(trimmedKey)
 		keysContent.WriteString("\n")
+		validKeyCount++
 	}
 	desiredContent := keysContent.String()
 
@@ -557,7 +571,7 @@ func (e *Executor) setupSSHKeys(ctx context.Context, params *pb.UserParams, outp
 		return false, fmt.Errorf("failed to set authorized_keys permissions: %w", err)
 	}
 
-	output.WriteString(fmt.Sprintf("configured %d SSH authorized key(s)\n", len(params.SshAuthorizedKeys)))
+	output.WriteString(fmt.Sprintf("configured %d SSH authorized key(s)\n", validKeyCount))
 	return true, nil
 }
 

--- a/internal/executor/sudo.go
+++ b/internal/executor/sudo.go
@@ -29,8 +29,8 @@ func (e *Executor) executeSudo(ctx context.Context, params *pb.AdminPolicyParams
 	if params == nil {
 		return nil, false, fmt.Errorf("sudo params required")
 	}
-	if actionID == "" {
-		return nil, false, fmt.Errorf("action ID required for sudo group/file naming")
+	if err := validateActionIDForFilesystem(actionID); err != nil {
+		return nil, false, err
 	}
 
 	groupName := sanitizeSudoGroupName(actionID)

--- a/internal/executor/sudo.go
+++ b/internal/executor/sudo.go
@@ -11,12 +11,10 @@ import (
 
 // sanitizeSudoGroupName creates a valid Linux group name from the action ID.
 // Linux group names: max 32 chars. pm-sudo- (8 chars) + up to 24 chars of action ID.
+// For longer action IDs, falls back to a hash-suffix scheme to keep
+// the mapping unique — see shortGroupName.
 func sanitizeSudoGroupName(actionID string) string {
-	lower := strings.ToLower(actionID)
-	if len(lower) > 24 {
-		lower = lower[:24]
-	}
-	return "pm-sudo-" + lower
+	return shortGroupName("pm-sudo-", actionID)
 }
 
 // sudoersFilePath returns the path for a sudoers drop-in file.


### PR DESCRIPTION
## Summary

Addresses the 3 Critical findings + the Critical-adjacent ABSENT-bypass from #75, plus a related #19 minor fix that lives next to #3.

| # | Severity | File | Bug |
|---|----------|------|-----|
| #1 | Critical | \`action_ssh.go\` | \`actionID\` flows into \`/etc/ssh/sshd_config.d/<id>.conf\` and \`pm-ssh-<id>\` group name without sanitization |
| #2 | Critical | \`action_update.go\` | \`os.Remove\` of pkg-mgr lock files without staleness check — corrupts state during concurrent transactions |
| #3 | Critical | \`action_user.go\` | SSH key newline injection — embedded \`\\n\` smuggles extra authorized_keys entries |
| #7 | Major (Critical-adjacent) | \`action_file.go\` | ABSENT bypasses \`isProtectedPath\`; could delete \`/etc/shadow\`, \`/etc/sudoers\`, etc. |
| #19 | Minor | \`action_user.go\` | SSH key count reports \`len(input)\` instead of \`len(written)\` — bundled with #3 |

## Fixes

- **#1**: Add \`validateActionIDForFilesystem\` (uses \`ulid.Parse\`); call at \`executeSsh\` and \`executeSshd\` entry before any path construction.
- **#2**: Add \`removeStaleLockFile\` helper using \`fuser -s\` for liveness probe; replace all 3 unguarded \`rm -f lock\` sites in \`repairApt\`/\`repairPacman\`/\`repairZypper\`. Fail-safe: \`fuser\` missing or unexpected exit → skip removal.
- **#3**: Reject keys containing \`\\n\` or \`\\r\` as fatal validation errors (not silent skip).
- **#7**: \`isProtectedPath\` check on the ABSENT branch (covers both regular-file removal and managed-block removal).
- **#19**: Track \`validKeyCount\` alongside the new newline rejection; report the actual written count.

## Test plan

- [x] \`GOWORK=off go build ./...\` clean.
- [x] \`GOWORK=off go test ./internal/executor/...\` clean.
- [x] No PR-self-references in code; no behaviour changes outside the documented fixes.

## Tracker

Remaining items from #75 (14 Major + 2 Minor) will land as PR-2 (update flow correctness) and PR-3 (install validation + minor consistency).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overwriting or deleting critical system files and other protected paths; protections check both resolved targets and cleaned input paths.
  * SSH and sudo action identifiers are now validated and normalized for filesystem-safe names.
  * Package-manager lock and PID files are only removed after confirming no active processes hold them.
  * SSH authorized-key entries with embedded newlines are rejected; reported SSH key counts reflect only accepted keys.

* **Behavior**
  * Directory deletions now check both resolved and cleaned input paths before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->