### PR TITLE
fix: install + repo + minor correctness from #75 review

### DIFF
--- a/internal/executor/action_appimage.go
+++ b/internal/executor/action_appimage.go
@@ -61,7 +61,9 @@ func (e *Executor) executeAppImage(ctx context.Context, params *pb.AppInstallPar
 		return nil, false, fmt.Errorf("invalid appimage URL: %q", params.Url)
 	}
 	filename := filepath.Base(parsedURL.Path)
-	if filename == "." || filename == "/" || filename == "" || strings.ContainsAny(filename, `/\`) {
+	// Reject ".." too — filepath.Base of e.g. https://x.example/.. returns
+	// "..", which would land at the parent of installPath when joined.
+	if filename == "." || filename == ".." || filename == "/" || filename == "" || strings.ContainsAny(filename, `/\`) {
 		return nil, false, fmt.Errorf("appimage URL %q does not yield a usable filename", params.Url)
 	}
 	fullPath := filepath.Join(installPath, filename)

--- a/internal/executor/action_appimage.go
+++ b/internal/executor/action_appimage.go
@@ -6,12 +6,34 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	sysfs "github.com/manchtools/power-manage/sdk/go/sys/fs"
 )
+
+// sha256File streams the file at path through sha256 and returns
+// the hex digest. Used by checksum-gated install paths so AppImage
+// (and any other large-file action) can verify identity without
+// buffering the entire payload — an io.ReadAll + sha256.Sum256
+// pattern would push tens-to-hundreds of megabytes through the
+// heap on every idempotency check.
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
 
 func (e *Executor) executeAppImage(ctx context.Context, params *pb.AppInstallParams, state pb.DesiredState) (*pb.CommandOutput, bool, error) {
 	if params == nil {
@@ -23,7 +45,25 @@ func (e *Executor) executeAppImage(ctx context.Context, params *pb.AppInstallPar
 		installPath = "/opt/appimages"
 	}
 
-	filename := filepath.Base(params.Url)
+	// Validate the download URL BEFORE deriving the on-disk
+	// filename. The previous shape ran filepath.Base(params.Url)
+	// directly, so a URL like "https://evil.example/../../etc/" or
+	// a malformed input could produce a path-meaningful filename
+	// and either escape installPath or land on an unexpected name.
+	// Require a parseable https/http URL with a non-empty host;
+	// derive the filename from a path segment that has no slashes
+	// or other directory components.
+	parsedURL, err := url.Parse(strings.TrimSpace(params.Url))
+	if err != nil ||
+		(parsedURL.Scheme != "https" && parsedURL.Scheme != "http") ||
+		parsedURL.Opaque != "" ||
+		parsedURL.Host == "" {
+		return nil, false, fmt.Errorf("invalid appimage URL: %q", params.Url)
+	}
+	filename := filepath.Base(parsedURL.Path)
+	if filename == "." || filename == "/" || filename == "" || strings.ContainsAny(filename, `/\`) {
+		return nil, false, fmt.Errorf("appimage URL %q does not yield a usable filename", params.Url)
+	}
 	fullPath := filepath.Join(installPath, filename)
 
 	// Resolve symlinks to prevent traversal attacks
@@ -34,11 +74,14 @@ func (e *Executor) executeAppImage(ctx context.Context, params *pb.AppInstallPar
 
 	switch state {
 	case pb.DesiredState_DESIRED_STATE_PRESENT:
-		// Check if file already exists with correct checksum
+		// Check if file already exists with correct checksum.
+		// Stream-hash the existing file rather than os.ReadFile +
+		// sha256.Sum256 — AppImages are routinely tens to hundreds
+		// of megabytes; buffering the entire payload to derive a
+		// hash that's compared once is wasteful and risks tipping
+		// the agent into OOM territory on small VMs.
 		if params.ChecksumSha256 != "" {
-			if content, err := os.ReadFile(resolvedPath); err == nil {
-				h := sha256.Sum256(content)
-				actualHash := hex.EncodeToString(h[:])
+			if actualHash, hashErr := sha256File(resolvedPath); hashErr == nil {
 				if actualHash == params.ChecksumSha256 {
 					return &pb.CommandOutput{
 						ExitCode: 0,

--- a/internal/executor/action_appimage.go
+++ b/internal/executor/action_appimage.go
@@ -84,7 +84,13 @@ func (e *Executor) executeAppImage(ctx context.Context, params *pb.AppInstallPar
 		// the agent into OOM territory on small VMs.
 		if params.ChecksumSha256 != "" {
 			if actualHash, hashErr := sha256File(resolvedPath); hashErr == nil {
-				if actualHash == params.ChecksumSha256 {
+				// EqualFold + TrimSpace: sha256File returns lowercase
+				// hex, but operators commonly paste uppercase hashes
+				// from `sha256sum` output / web pages / clipboard
+				// trimming. Without case-insensitive compare an
+				// uppercase-but-correct checksum forces a redownload
+				// on every run.
+				if strings.EqualFold(actualHash, strings.TrimSpace(params.ChecksumSha256)) {
 					return &pb.CommandOutput{
 						ExitCode: 0,
 						Stdout:   fmt.Sprintf("appimage %s already installed with correct checksum", filename),

--- a/internal/executor/action_deb.go
+++ b/internal/executor/action_deb.go
@@ -60,11 +60,29 @@ func (e *Executor) executeDeb(ctx context.Context, params *pb.AppInstallParams, 
 			return nil, false, fmt.Errorf("download: %w", err)
 		}
 
-		// Install with dpkg (requires sudo)
+		// Install with dpkg (requires sudo). On failure, retry via
+		// `apt --fix-broken install` which can complete a half-done
+		// dpkg invocation. If the retry succeeds, clear the
+		// original dpkg error — the action recovered. The previous
+		// shape ran FixBroken but propagated the original error
+		// regardless, so callers saw "install failed" even when the
+		// recovery path resolved it. Verify the final state by
+		// re-checking installation rather than trusting either
+		// command's exit alone, since FixBroken can succeed without
+		// having installed the requested package.
 		output, err := runSudoCmd(ctx, "dpkg", "-i", tmpFile.Name())
 		if err != nil {
-			// Try to fix dependencies
-			pkg.NewAptWithContext(ctx).FixBroken()
+			fbOutput, fbErr := pkg.NewAptWithContext(ctx).FixBroken()
+			if fbOutput != nil {
+				if output == nil {
+					output = &pb.CommandOutput{}
+				}
+				output.Stdout += "\n=== apt --fix-broken install ===\n" + fbOutput.Stdout
+				output.Stderr += fbOutput.Stderr
+			}
+			if fbErr == nil && e.isDebInstalled(pkgName) {
+				err = nil
+			}
 		}
 		return output, true, err
 

--- a/internal/executor/action_directory.go
+++ b/internal/executor/action_directory.go
@@ -106,17 +106,20 @@ func (e *Executor) directoryMatchesDesired(path string, params *pb.DirectoryPara
 		}
 	}
 
-	// Check owner/group if specified
+	// Check owner/group if specified. See fileMatchesDesired for
+	// the full rationale — same group-only mismatch bug lived
+	// here too and made directoryMatchesDesired never return true
+	// when only the group was requested, so the action rechowned
+	// on every run.
 	if params.Owner != "" || params.Group != "" {
 		currentOwner, currentGroup := getFileOwnership(path)
 		if currentOwner == "" && currentGroup == "" {
 			return false
 		}
-		if params.Group == "" {
-			if currentOwner != params.Owner {
-				return false
-			}
-		} else if currentOwner != params.Owner || currentGroup != params.Group {
+		if params.Owner != "" && currentOwner != params.Owner {
+			return false
+		}
+		if params.Group != "" && currentGroup != params.Group {
 			return false
 		}
 	}

--- a/internal/executor/action_file.go
+++ b/internal/executor/action_file.go
@@ -191,18 +191,22 @@ func (e *Executor) fileMatchesDesired(path string, params *pb.FileParams) bool {
 		}
 	}
 
-	// Check owner/group if specified
+	// Check owner/group if specified. Compare ONLY the requested
+	// fields: a group-only request (Owner=="") used to fall through
+	// the else-branch and compare currentOwner against the empty
+	// requested owner, so fileMatchesDesired could never return
+	// true and the action rewrote/chowned the file on every run.
+	// Three cases — owner-only, group-only, both — each compares
+	// only what was asked for.
 	if params.Owner != "" || params.Group != "" {
 		currentOwner, currentGroup := getFileOwnership(path)
 		if currentOwner == "" && currentGroup == "" {
 			return false
 		}
-		// Handle case where only owner is specified
-		if params.Group == "" {
-			if currentOwner != params.Owner {
-				return false
-			}
-		} else if currentOwner != params.Owner || currentGroup != params.Group {
+		if params.Owner != "" && currentOwner != params.Owner {
+			return false
+		}
+		if params.Group != "" && currentGroup != params.Group {
 			return false
 		}
 	}

--- a/internal/executor/action_package.go
+++ b/internal/executor/action_package.go
@@ -64,7 +64,15 @@ func (e *Executor) ensurePackagePresent(ctx context.Context, params *pb.PackageP
 
 	if err == nil && params.Pin {
 		if _, pinErr := e.pinPackage(pkgName); pinErr != nil {
-			result.Stderr += fmt.Sprintf("\nwarning: failed to pin package: %v", pinErr)
+			// Pin is part of the requested state. The previous shape
+			// degraded to a stderr warning while the action result
+			// stayed success — operators saw "installed and pinned"
+			// when only install happened, and the package would
+			// upgrade out from under the next maintenance window.
+			// Surface as a real failure: the install is durable, but
+			// the action did not reach the requested state.
+			result.Stderr += fmt.Sprintf("\nfailed to pin package: %v", pinErr)
+			err = fmt.Errorf("install succeeded but pin failed: %w", pinErr)
 		}
 	}
 	return packageResult(result, err)
@@ -164,17 +172,14 @@ func (e *Executor) getPackageNameForManager(params *pb.PackageParams) string {
 		}
 	}
 
-	// Check if any manager-specific names are set
-	// If so, and we don't have one for this manager, return empty (skip)
-	hasManagerSpecificNames := params.AptName != "" || params.DnfName != "" ||
-		params.PacmanName != "" || params.ZypperName != ""
-
-	if hasManagerSpecificNames {
-		// Manager-specific names are being used, but none for this manager
-		return ""
-	}
-
-	// Fall back to generic name
+	// Fall back to the generic name even when other managers have
+	// overrides set. The previous shape returned "" (skip) when ANY
+	// manager-specific name was present but no override existed for
+	// THIS manager — a curl action specifying just AptName="curl"
+	// would silently no-op on dnf/zypper/pacman hosts even though
+	// the generic Name=curl is the right answer for those managers
+	// too. The override-only-when-set semantics belong on a
+	// per-manager basis, not as a cross-manager kill switch.
 	return params.Name
 }
 

--- a/internal/executor/action_repository.go
+++ b/internal/executor/action_repository.go
@@ -47,15 +47,12 @@ func (e *Executor) executeRepository(ctx context.Context, params *pb.RepositoryP
 		return nil, false, err
 	}
 
-	// Repair filesystem if mounted read-only. Only reached once the
-	// action has passed every structural check, so the sudo-backed
-	// remount never fires for a payload we were going to refuse.
-	if out, err := e.requireWritableFS(ctx); err != nil {
-		return out, false, err
-	}
-
-	// Detect package manager and execute the appropriate configuration
-	// Repository actions always report changed=true since they write config files
+	// Per-manager skip-check moved BEFORE requireWritableFS: if
+	// the action carries no config for the host's package manager,
+	// it's a no-op and shouldn't trigger a sudo-backed remount on
+	// a read-only root just to bail out on the first line of the
+	// dispatcher. The skip path returns changed=false; remount
+	// only fires when we're about to actually mutate state.
 	switch {
 	case pkg.IsApt():
 		if params.Apt == nil || params.Apt.Disabled {
@@ -64,8 +61,6 @@ func (e *Executor) executeRepository(ctx context.Context, params *pb.RepositoryP
 				Stdout:   "skipped: no APT repository configuration provided",
 			}, false, nil
 		}
-		return e.executeAptRepository(ctx, params.Name, params.Apt, state)
-
 	case pkg.IsDnf():
 		if params.Dnf == nil || params.Dnf.Disabled {
 			return &pb.CommandOutput{
@@ -73,9 +68,6 @@ func (e *Executor) executeRepository(ctx context.Context, params *pb.RepositoryP
 				Stdout:   "skipped: no DNF repository configuration provided",
 			}, false, nil
 		}
-		output, err := e.executeDnfRepository(ctx, params.Name, params.Dnf, state)
-		return output, err == nil, err
-
 	case pkg.IsPacman():
 		if params.Pacman == nil || params.Pacman.Disabled {
 			return &pb.CommandOutput{
@@ -83,9 +75,6 @@ func (e *Executor) executeRepository(ctx context.Context, params *pb.RepositoryP
 				Stdout:   "skipped: no Pacman repository configuration provided",
 			}, false, nil
 		}
-		output, err := e.executePacmanRepository(ctx, params.Name, params.Pacman, state)
-		return output, err == nil, err
-
 	case pkg.IsZypper():
 		if params.Zypper == nil || params.Zypper.Disabled {
 			return &pb.CommandOutput{
@@ -93,10 +82,29 @@ func (e *Executor) executeRepository(ctx context.Context, params *pb.RepositoryP
 				Stdout:   "skipped: no Zypper repository configuration provided",
 			}, false, nil
 		}
-		output, err := e.executeZypperRepository(ctx, params.Name, params.Zypper, state)
-		return output, err == nil, err
-
 	default:
+		return nil, false, fmt.Errorf("no supported package manager found for repository configuration")
+	}
+
+	// Repair filesystem if mounted read-only. Only reached once we
+	// know we have actual work to do for THIS host's package
+	// manager — a no-op skip never triggers it.
+	if out, err := e.requireWritableFS(ctx); err != nil {
+		return out, false, err
+	}
+
+	switch {
+	case pkg.IsApt():
+		return e.executeAptRepository(ctx, params.Name, params.Apt, state)
+	case pkg.IsDnf():
+		return e.executeDnfRepository(ctx, params.Name, params.Dnf, state)
+	case pkg.IsPacman():
+		return e.executePacmanRepository(ctx, params.Name, params.Pacman, state)
+	case pkg.IsZypper():
+		return e.executeZypperRepository(ctx, params.Name, params.Zypper, state)
+	default:
+		// Unreachable: the per-manager skip switch above already
+		// rejects unknown managers. Defensive return.
 		return nil, false, fmt.Errorf("no supported package manager found for repository configuration")
 	}
 }
@@ -107,12 +115,18 @@ func (e *Executor) executeRepository(ctx context.Context, params *pb.RepositoryP
 // repository URL was previously configured under a different name or with different keys.
 // The skipRepoFile and skipKeyFile parameters specify files that should NOT be deleted
 // (typically the target repository being configured).
-func (e *Executor) cleanupConflictingAptRepos(ctx context.Context, url, skipRepoFile, skipKeyFile string, output *strings.Builder) {
+//
+// Returns true if any conflicting file was removed so the caller can
+// flip the action's `changed` flag — silently removing config files
+// while reporting `changed=false` would make compliance projections
+// miss real on-disk state mutations.
+func (e *Executor) cleanupConflictingAptRepos(ctx context.Context, url, skipRepoFile, skipKeyFile string, output *strings.Builder) bool {
 	sourcesDir := "/etc/apt/sources.list.d"
 	entries, err := os.ReadDir(sourcesDir)
 	if err != nil {
-		return // Directory might not exist, that's fine
+		return false // Directory might not exist, that's fine
 	}
+	cleanedUp := false
 
 	for _, entry := range entries {
 		if entry.IsDir() {
@@ -145,6 +159,7 @@ func (e *Executor) cleanupConflictingAptRepos(ctx context.Context, url, skipRepo
 		}
 
 		output.WriteString(fmt.Sprintf("removing conflicting repository config: %s\n", filePath))
+		cleanedUp = true
 
 		// Extract Signed-By path from DEB822 format (.sources files)
 		if strings.HasSuffix(filename, ".sources") {
@@ -185,6 +200,7 @@ func (e *Executor) cleanupConflictingAptRepos(ctx context.Context, url, skipRepo
 		// Remove the repository file
 		runSudoCmd(ctx, "rm", "-f", filePath)
 	}
+	return cleanedUp
 }
 
 // executeAptRepository configures an APT repository.
@@ -215,8 +231,14 @@ func (e *Executor) executeAptRepository(ctx context.Context, name string, repo *
 		// First, scan for and remove any existing repository configs that use the same URL
 		// This prevents "conflicting values set for option Signed-By" errors when the same
 		// repository was previously configured under a different name or with different keys
-		// We skip our own repo file and key file to allow the comparison logic to work
-		e.cleanupConflictingAptRepos(ctx, repo.Url, repoFile, keyFile, &output)
+		// We skip our own repo file and key file to allow the comparison logic to work.
+		// Track whether anything was removed so the action's `changed`
+		// flag reflects the on-disk mutation — without this, an
+		// idempotent re-apply that quietly resolves a conflict would
+		// look like a no-op to compliance projections.
+		if e.cleanupConflictingAptRepos(ctx, repo.Url, repoFile, keyFile, &output) {
+			changed = true
+		}
 
 		// Clean up legacy .list file if it exists
 		legacyFile := fmt.Sprintf("/etc/apt/sources.list.d/%s.list", name)
@@ -407,44 +429,42 @@ func (e *Executor) updateGpgKeyIfNeeded(ctx context.Context, keyFile, keyUrl, ke
 }
 
 // executeDnfRepository configures a DNF/YUM repository.
-func (e *Executor) executeDnfRepository(ctx context.Context, name string, repo *pb.DnfRepository, state pb.DesiredState) (*pb.CommandOutput, error) {
+func (e *Executor) executeDnfRepository(ctx context.Context, name string, repo *pb.DnfRepository, state pb.DesiredState) (*pb.CommandOutput, bool, error) {
 	var output strings.Builder
 	repoFile := fmt.Sprintf("/etc/yum.repos.d/%s.repo", name)
 
 	switch state {
 	case pb.DesiredState_DESIRED_STATE_ABSENT:
+		// No-op when the repo file is already absent. Reporting
+		// changed=true here used to flood operators with spurious
+		// state-change events for actions that did nothing.
+		if _, err := os.Stat(repoFile); os.IsNotExist(err) {
+			output.WriteString(fmt.Sprintf("repository %s already absent\n", name))
+			return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, false, nil
+		}
 		if _, err := runSudoCmd(ctx, "rm", "-f", repoFile); err != nil {
-			return nil, fmt.Errorf("failed to remove repo file: %w", err)
+			return nil, false, fmt.Errorf("failed to remove repo file: %w", err)
 		}
 		output.WriteString(fmt.Sprintf("removed repository: %s\n", name))
-		return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, nil
+		return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, true, nil
 
 	case pb.DesiredState_DESIRED_STATE_PRESENT:
-		// Clean up any existing repository configuration to ensure clean state
-		// This handles cases where the repository was previously configured with different settings
-		if _, err := os.Stat(repoFile); err == nil {
-			output.WriteString(fmt.Sprintf("replacing existing repository: %s\n", name))
-			runSudoCmd(ctx, "rm", "-f", repoFile)
-		}
-
-		// Build repo file content
+		// Build the desired repo file content first so we can
+		// compare against on-disk state and skip the rewrite when
+		// the file already matches.
 		var content strings.Builder
 		content.WriteString(fmt.Sprintf("[%s]\n", name))
-
 		if repo.Description != "" {
 			content.WriteString(fmt.Sprintf("name=%s\n", repo.Description))
 		} else {
 			content.WriteString(fmt.Sprintf("name=%s\n", name))
 		}
-
 		content.WriteString(fmt.Sprintf("baseurl=%s\n", repo.Baseurl))
-
 		if repo.Enabled {
 			content.WriteString("enabled=1\n")
 		} else {
 			content.WriteString("enabled=0\n")
 		}
-
 		if repo.Gpgcheck {
 			content.WriteString("gpgcheck=1\n")
 			if repo.Gpgkey != "" {
@@ -453,20 +473,32 @@ func (e *Executor) executeDnfRepository(ctx context.Context, name string, repo *
 		} else {
 			content.WriteString("gpgcheck=0\n")
 		}
-
 		if repo.ModuleHotfixes {
 			content.WriteString("module_hotfixes=1\n")
 		}
+		desired := content.String()
 
-		// Write the repo file
-		if _, err := writeFileWithSudo(ctx, repoFile, content.String()); err != nil {
-			return nil, fmt.Errorf("failed to write repo file: %w", err)
+		// Idempotency: if the existing file matches byte-for-byte,
+		// don't rewrite + report changed.
+		if existing, err := os.ReadFile(repoFile); err == nil && string(existing) == desired {
+			output.WriteString(fmt.Sprintf("repository %s already up to date\n", name))
+			return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, false, nil
 		}
 
+		// Cleanup any existing repository configuration first
+		// (handles previous configurations with different settings).
+		if _, err := os.Stat(repoFile); err == nil {
+			output.WriteString(fmt.Sprintf("replacing existing repository: %s\n", name))
+			runSudoCmd(ctx, "rm", "-f", repoFile)
+		}
+
+		if _, err := writeFileWithSudo(ctx, repoFile, desired); err != nil {
+			return nil, false, fmt.Errorf("failed to write repo file: %w", err)
+		}
 		output.WriteString(fmt.Sprintf("configured repository: %s\n", name))
 
-		// Import GPG key if provided
-		// rpm --import is idempotent - re-importing an existing key is a no-op
+		// Import GPG key if provided.
+		// rpm --import is idempotent - re-importing an existing key is a no-op.
 		if repo.Gpgkey != "" {
 			keyOutput, _ := runSudoCmd(ctx, "rpm", "--import", repo.Gpgkey)
 			if keyOutput != nil && keyOutput.Stdout != "" {
@@ -474,16 +506,16 @@ func (e *Executor) executeDnfRepository(ctx context.Context, name string, repo *
 			}
 		}
 
-		// Refresh metadata (use -y for non-interactive mode)
+		// Refresh metadata (use -y for non-interactive mode).
 		refreshOutput, _ := runSudoCmd(ctx, "dnf", "-y", "makecache", "--repo", name)
 		if refreshOutput != nil {
 			output.WriteString(refreshOutput.Stdout)
 		}
 
-		return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, nil
+		return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, true, nil
 
 	default:
-		return nil, fmt.Errorf("unknown desired state: %v", state)
+		return nil, false, fmt.Errorf("unknown desired state: %v", state)
 	}
 }
 
@@ -511,14 +543,14 @@ func removePacmanSection(content, name string) string {
 }
 
 // executePacmanRepository configures a Pacman repository.
-func (e *Executor) executePacmanRepository(ctx context.Context, name string, repo *pb.PacmanRepository, state pb.DesiredState) (*pb.CommandOutput, error) {
+func (e *Executor) executePacmanRepository(ctx context.Context, name string, repo *pb.PacmanRepository, state pb.DesiredState) (*pb.CommandOutput, bool, error) {
 	var output strings.Builder
 	confFile := "/etc/pacman.conf"
 
 	// Read current pacman.conf
 	confContent, err := os.ReadFile(confFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read pacman.conf: %w", err)
+		return nil, false, fmt.Errorf("failed to read pacman.conf: %w", err)
 	}
 	confStr := string(confContent)
 
@@ -530,17 +562,17 @@ func (e *Executor) executePacmanRepository(ctx context.Context, name string, rep
 	case pb.DesiredState_DESIRED_STATE_ABSENT:
 		if !hasRepo {
 			output.WriteString(fmt.Sprintf("repository %s not found, nothing to remove\n", name))
-			return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, nil
+			return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, false, nil
 		}
 
 		// Remove the repository section in Go (no sed, no shell injection risk)
 		newConf := removePacmanSection(confStr, name)
 		if _, err := writeFileWithSudo(ctx, confFile, newConf); err != nil {
-			return nil, fmt.Errorf("failed to update pacman.conf: %w", err)
+			return nil, false, fmt.Errorf("failed to update pacman.conf: %w", err)
 		}
 
 		output.WriteString(fmt.Sprintf("removed repository: %s\n", name))
-		return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, nil
+		return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, true, nil
 
 	case pb.DesiredState_DESIRED_STATE_PRESENT:
 		// Build new repo section
@@ -558,8 +590,15 @@ func (e *Executor) executePacmanRepository(ctx context.Context, name string, rep
 		}
 		newConf += section.String()
 
+		// Idempotency: skip the write + db-sync if pacman.conf
+		// already matches.
+		if newConf == confStr {
+			output.WriteString(fmt.Sprintf("repository %s already configured\n", name))
+			return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, false, nil
+		}
+
 		if _, err := writeFileWithSudo(ctx, confFile, newConf); err != nil {
-			return nil, fmt.Errorf("failed to write pacman.conf: %w", err)
+			return nil, false, fmt.Errorf("failed to write pacman.conf: %w", err)
 		}
 
 		output.WriteString(fmt.Sprintf("configured repository: %s\n", name))
@@ -570,30 +609,32 @@ func (e *Executor) executePacmanRepository(ctx context.Context, name string, rep
 			output.WriteString(syncOutput.Stdout)
 		}
 
-		return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, nil
+		return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, true, nil
 
 	default:
-		return nil, fmt.Errorf("unknown desired state: %v", state)
+		return nil, false, fmt.Errorf("unknown desired state: %v", state)
 	}
 }
 
 // executeZypperRepository configures a Zypper repository.
-func (e *Executor) executeZypperRepository(ctx context.Context, name string, repo *pb.ZypperRepository, state pb.DesiredState) (*pb.CommandOutput, error) {
+func (e *Executor) executeZypperRepository(ctx context.Context, name string, repo *pb.ZypperRepository, state pb.DesiredState) (*pb.CommandOutput, bool, error) {
 	var output strings.Builder
 
 	switch state {
 	case pb.DesiredState_DESIRED_STATE_ABSENT:
 		cmdOutput, err := runSudoCmd(ctx, "zypper", "--non-interactive", "removerepo", name)
 		if err != nil {
-			// Ignore if repo doesn't exist
+			// Already-absent is the no-op case — surface as
+			// changed=false so operators don't see spurious
+			// state-change events.
 			if cmdOutput != nil && strings.Contains(cmdOutput.Stderr, "not found") {
 				output.WriteString(fmt.Sprintf("repository %s not found, nothing to remove\n", name))
-				return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, nil
+				return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, false, nil
 			}
-			return nil, fmt.Errorf("failed to remove repository: %w", err)
+			return nil, false, fmt.Errorf("failed to remove repository: %w", err)
 		}
 		output.WriteString(fmt.Sprintf("removed repository: %s\n", name))
-		return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, nil
+		return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, true, nil
 
 	case pb.DesiredState_DESIRED_STATE_PRESENT:
 		// Build zypper addrepo command
@@ -616,7 +657,7 @@ func (e *Executor) executeZypperRepository(ctx context.Context, name string, rep
 			if cmdOutput != nil {
 				output.WriteString(cmdOutput.Stderr)
 			}
-			return nil, fmt.Errorf("failed to add repository: %w", err)
+			return nil, false, fmt.Errorf("failed to add repository: %w", err)
 		}
 
 		output.WriteString(fmt.Sprintf("configured repository: %s\n", name))
@@ -652,9 +693,9 @@ func (e *Executor) executeZypperRepository(ctx context.Context, name string, rep
 			output.WriteString(refreshOutput.Stdout)
 		}
 
-		return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, nil
+		return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, true, nil
 
 	default:
-		return nil, fmt.Errorf("unknown desired state: %v", state)
+		return nil, false, fmt.Errorf("unknown desired state: %v", state)
 	}
 }

--- a/internal/executor/action_rpm.go
+++ b/internal/executor/action_rpm.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -26,28 +25,22 @@ func (e *Executor) executeRpm(ctx context.Context, params *pb.AppInstallParams, 
 		return nil, false, fmt.Errorf("rpm lookup: %w", err)
 	}
 
-	// Extract package name from URL for checking
-	filename := filepath.Base(params.Url)
-	pkgName := strings.Split(filename, "-")[0]
-
-	// Check if package is already installed
-	isInstalled := e.isRpmInstalled(pkgName)
-
 	switch state {
 	case pb.DesiredState_DESIRED_STATE_PRESENT:
-		if isInstalled {
-			return &pb.CommandOutput{
-				ExitCode: 0,
-				Stdout:   fmt.Sprintf("rpm package %s is already installed", pkgName),
-			}, false, nil
-		}
-
-		// Repair filesystem if mounted read-only
+		// Repair filesystem if mounted read-only.
+		// Done before the download so a remount failure short-circuits
+		// the network round-trip on a host that can't accept writes.
 		if out, err := e.requireWritableFS(ctx); err != nil {
 			return out, false, err
 		}
 
-		// Download to temp file
+		// Download to temp file. We need the file in hand before
+		// we can ask the package what its real NAME is — the
+		// previous shape derived the name by splitting the URL
+		// filename on '-', which is wrong for any package whose
+		// upstream name itself contains a dash (mypkg-utils-1.2.3.rpm
+		// would parse as "mypkg" and the install would silently
+		// skip-or-reapply against the wrong package).
 		tmpFile, err := os.CreateTemp("", "*.rpm")
 		if err != nil {
 			return nil, false, fmt.Errorf("create temp file: %w", err)
@@ -59,21 +52,60 @@ func (e *Executor) executeRpm(ctx context.Context, params *pb.AppInstallParams, 
 			return nil, false, fmt.Errorf("download: %w", err)
 		}
 
+		// Ask rpm itself for the canonical package NAME from the
+		// downloaded file — authoritative across naming conventions.
+		queryOut, _, qErr := queryCmdOutput("rpm", "-qp", "--qf", "%{NAME}", tmpFile.Name())
+		if qErr != nil {
+			return nil, false, fmt.Errorf("rpm -qp NAME: %w", qErr)
+		}
+		pkgName := strings.TrimSpace(queryOut)
+		if pkgName == "" {
+			return nil, false, fmt.Errorf("rpm -qp NAME returned empty for %s", params.Url)
+		}
+
+		if e.isRpmInstalled(pkgName) {
+			return &pb.CommandOutput{
+				ExitCode: 0,
+				Stdout:   fmt.Sprintf("rpm package %s is already installed", pkgName),
+			}, false, nil
+		}
+
 		// Install with rpm (requires sudo)
 		output, err := runSudoCmd(ctx, "rpm", "-i", tmpFile.Name())
 		return output, true, err
 
 	case pb.DesiredState_DESIRED_STATE_ABSENT:
-		if !isInstalled {
+		// For ABSENT the URL is the only handle we have; we must
+		// download to learn the real NAME before asking rpm whether
+		// it's installed. This is wasteful when the package is
+		// already absent, but the alternative (the prior dash-split
+		// heuristic) was *unsound* — operator-correctness over
+		// network round-trip.
+		if out, err := e.requireWritableFS(ctx); err != nil {
+			return out, false, err
+		}
+		tmpFile, err := os.CreateTemp("", "*.rpm")
+		if err != nil {
+			return nil, false, fmt.Errorf("create temp file: %w", err)
+		}
+		defer os.Remove(tmpFile.Name())
+		_ = tmpFile.Close()
+		if err := e.downloadFile(ctx, params.Url, tmpFile.Name(), params.ChecksumSha256); err != nil {
+			return nil, false, fmt.Errorf("download: %w", err)
+		}
+		queryOut, _, qErr := queryCmdOutput("rpm", "-qp", "--qf", "%{NAME}", tmpFile.Name())
+		if qErr != nil {
+			return nil, false, fmt.Errorf("rpm -qp NAME: %w", qErr)
+		}
+		pkgName := strings.TrimSpace(queryOut)
+		if pkgName == "" {
+			return nil, false, fmt.Errorf("rpm -qp NAME returned empty for %s", params.Url)
+		}
+		if !e.isRpmInstalled(pkgName) {
 			return &pb.CommandOutput{
 				ExitCode: 0,
 				Stdout:   fmt.Sprintf("rpm package %s is already not installed", pkgName),
 			}, false, nil
-		}
-
-		// Repair filesystem if mounted read-only
-		if out, err := e.requireWritableFS(ctx); err != nil {
-			return out, false, err
 		}
 
 		output, err := runSudoCmd(ctx, "rpm", "-e", pkgName)

--- a/internal/executor/integration_test.go
+++ b/internal/executor/integration_test.go
@@ -1634,9 +1634,19 @@ func TestIntegration_Rpm(t *testing.T) {
 	})
 
 	t.Run("Remove", func(t *testing.T) {
+		// PR #77 changed RPM ABSENT to download the package and ask
+		// `rpm -qp NAME` for the canonical package name (the prior
+		// dash-split heuristic was unsound for any package whose
+		// upstream name contains a dash). The URL therefore needs to
+		// resolve, not 404 — give Remove a real local file server.
+		rpmData := createTestRpm(t)
+		ts := startFileServer(t, map[string][]byte{
+			"/pmtestrpm-1.0.0-1.noarch.rpm": rpmData,
+		})
+
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_RPM, pb.DesiredState_DESIRED_STATE_ABSENT)
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
-			Url: "http://example.com/pmtestrpm-1.0.0-1.noarch.rpm",
+			Url: ts.URL + "/pmtestrpm-1.0.0-1.noarch.rpm",
 		}}
 		result := e.Execute(ctx, action)
 		assertSuccess(t, result)
@@ -1647,9 +1657,16 @@ func TestIntegration_Rpm(t *testing.T) {
 	})
 
 	t.Run("RemoveAbsent", func(t *testing.T) {
+		// Same reason as Remove above — must download to learn the
+		// canonical NAME before asking rpm whether it's installed.
+		rpmData := createTestRpm(t)
+		ts := startFileServer(t, map[string][]byte{
+			"/pmtestrpm-1.0.0-1.noarch.rpm": rpmData,
+		})
+
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_RPM, pb.DesiredState_DESIRED_STATE_ABSENT)
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
-			Url: "http://example.com/pmtestrpm-1.0.0-1.noarch.rpm",
+			Url: ts.URL + "/pmtestrpm-1.0.0-1.noarch.rpm",
 		}}
 		result := e.Execute(ctx, action)
 		assertSuccess(t, result)


### PR DESCRIPTION
## Summary

Addresses 11 of the remaining items from #75 — all install-action and repository-action correctness, plus the two group-only ownership minors.

| # | Severity | File | Bug → Fix |
|---|----------|------|-----------|
| #4 | Major | \`action_appimage.go\` | URL not validated before deriving filename → require parseable http/https URL with non-empty Host + non-opaque, sanitise the filename |
| #5 | Major | \`action_appimage.go\` | \`os.ReadFile + sha256.Sum256\` of multi-hundred-MB AppImage → new \`sha256File\` streams via \`io.Copy\` |
| #6 | Major | \`action_deb.go\` | dpkg error propagated even when FixBroken recovered → clear err iff FixBroken returned cleanly AND \`isDebInstalled\` confirms the package landed |
| #9 | Major | \`action_package.go\` | Pin failure logged as warning, action still reported success → surface as real failure |
| #10 | Major | \`action_package.go\` | Generic \`Name\` skipped on hosts whose manager has no override but others do → drop cross-manager kill switch, fall back per-host |
| #11 | Major | \`action_repository.go\` | \`requireWritableFS\` fired before per-manager skip check → reorder so a no-op skip never triggers a sudo-backed remount |
| #12 | Major | \`action_repository.go\` | \`changed = err == nil\` lied about no-op success → per-impl \`(output, changed, error)\` signatures; Dnf has full byte-for-byte idempotency, Pacman + Zypper short-circuit already-absent / already-configured |
| #13 | Major | \`action_repository.go\` | \`cleanupConflictingAptRepos\` was void; APT conflict resolution invisible to \`changed\` flag → return \`bool\`, propagate via \`\|=\` |
| #14 | Major | \`action_rpm.go\` | \`strings.Split(filename, \"-\")[0]\` truncated dashed package names → download first, query authoritative NAME via \`rpm -qp --qf '%{NAME}'\` |
| #20 | Minor | \`action_file.go\` | \`fileMatchesDesired\` compared currentOwner against empty Owner when only Group set → compare ONLY the requested fields |
| #21 | Minor | \`action_directory.go\` | Same bug + same fix in \`directoryMatchesDesired\` |

## Test plan

- [x] \`GOWORK=off go build ./...\` clean.
- [x] \`GOWORK=off go test ./internal/executor/...\` clean.

## Notes

- Pacman + Zypper got minimal idempotency (already-absent + already-configured short-circuits) rather than full byte-comparison since their on-disk state isn't a single file we own. Dnf's idempotency is byte-for-byte.
- \`action_rpm.go\` ABSENT path now incurs a download round-trip. The previous shape's dash-split heuristic was unsound (could quietly skip-or-reapply against the wrong package), so correctness wins over the round-trip cost.

## Tracker

Last open #75 item: #8 Flatpak \`--user\` runs against root profile — needs a small design discussion (drop the option, or scope it via \`runuser\`). Will file as its own design issue rather than fix here.

PR-1 (#76) covers the 3 Criticals + ABSENT bypass + key-counter Minor. PR-2 (update-flow correctness — #15/#16/#17/#18) is staged locally and will land after #76.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ownership/group matching for files and directories.
  * Improved package install recovery: dependency-repair output is preserved and success/failure reporting is more accurate.
  * More accurate RPM package name detection during install/remove.
  * Safer AppImage checksum verification via streaming hash and case-insensitive compare.

* **Improvements**
  * Stricter URL validation and filename safety for AppImage downloads.
  * Repository operations: skip checks avoid unnecessary filesystem fixes; idempotency and precise change reporting improved.
  * Pin failures now surface as errors.

* **Tests**
  * RPM removal tests use a local test server to exercise download-and-lookup flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->