### PR TITLE
fix: executor update-flow correctness (issue #75 items 15-18)

### DIFF
--- a/internal/executor/action_service.go
+++ b/internal/executor/action_service.go
@@ -101,12 +101,18 @@ func (e *Executor) executeService(ctx context.Context, params *pb.ServiceParams)
 		changed = true
 	} else if !params.Enable && isEnabled {
 		if err := sysservice.Disable(ctx, params.UnitName); err != nil {
-			// Ignore errors for disable (unit might not exist)
-			output.WriteString("disable failed (unit may not exist)\n")
-		} else {
-			output.WriteString("disabled unit\n")
-			changed = true
+			// Don't swallow real disable failures. The earlier
+			// shape blanket-suppressed every error with "unit may
+			// not exist" — but isEnabled was just true, so a
+			// missing-unit explanation contradicts the precondition.
+			// A real failure here (permissions, masked, systemd
+			// not responding) means the unit stays enabled
+			// against the operator's intent; surface it so the
+			// caller sees a failed action and can investigate.
+			return nil, false, fmt.Errorf("disable %s: %w", params.UnitName, err)
 		}
+		output.WriteString("disabled unit\n")
+		changed = true
 	}
 
 	// Handle running state

--- a/internal/executor/action_update.go
+++ b/internal/executor/action_update.go
@@ -478,7 +478,6 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 	if rebootRequiredAfter {
 		allOutput.WriteString("\n*** REBOOT REQUIRED ***\n")
 		if newRebootRequired && params != nil && params.RebootIfRequired {
-			sysnotify.NotifyAll(ctx, "System Reboot", "A system update requires a reboot. This system will reboot in 1 minute.")
 			// Issue the shutdown FIRST and only report success if
 			// it actually went out — the prior shape printed
 			// "Scheduling reboot..." regardless of whether
@@ -486,7 +485,9 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 			// would see "scheduled" in the action result while
 			// the host stayed up. Failure to schedule a reboot
 			// the operator explicitly asked for is a real action
-			// failure, not a logged warning.
+			// failure, not a logged warning. The desktop
+			// notification is also gated on success so we don't
+			// tell users "your system will reboot" when it won't.
 			if out, err := runSudoCmd(ctx, "shutdown", "-r", "+1", "System update requires reboot"); err != nil {
 				if out != nil {
 					allOutput.WriteString(out.Stdout)
@@ -497,6 +498,7 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 					lastErr = fmt.Errorf("schedule reboot: %w", err)
 				}
 			} else {
+				sysnotify.NotifyAll(ctx, "System Reboot", "A system update requires a reboot. This system will reboot in 1 minute.")
 				allOutput.WriteString("Scheduled reboot in 1 minute.\n")
 			}
 		}

--- a/internal/executor/action_update.go
+++ b/internal/executor/action_update.go
@@ -3,6 +3,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -494,9 +495,13 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 					allOutput.WriteString(out.Stderr)
 				}
 				allOutput.WriteString(fmt.Sprintf("FAILED to schedule reboot: %v\n", err))
-				if lastErr == nil {
-					lastErr = fmt.Errorf("schedule reboot: %w", err)
-				}
+				// Always join the reboot failure into lastErr — the
+				// preceding comment claims this is a real action
+				// failure, but a first-error-wins guard would silently
+				// demote it whenever an earlier upgrade error already
+				// occupied lastErr. errors.Join keeps both visible to
+				// the caller.
+				lastErr = errors.Join(lastErr, fmt.Errorf("schedule reboot: %w", err))
 			} else {
 				sysnotify.NotifyAll(ctx, "System Reboot", "A system update requires a reboot. This system will reboot in 1 minute.")
 				allOutput.WriteString("Scheduled reboot in 1 minute.\n")

--- a/internal/executor/action_update.go
+++ b/internal/executor/action_update.go
@@ -439,22 +439,37 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 	if params != nil && params.Autoremove {
 		allOutput.WriteString("\n=== Autoremove Unused Packages ===\n")
 		countBefore := installedPackageCount()
+		// Capture autoremove errors so the action result reflects
+		// "we tried to autoremove and the call itself failed", not
+		// "everything succeeded but stale packages quietly remain".
+		// The previous shape only wrote stderr to the buffer and
+		// dropped the err on the floor.
+		var autoremoveErr error
 		if pkg.IsApt() {
 			apt := pkg.NewAptWithContext(ctx)
-			if output, err := apt.Autoremove(); err == nil {
+			output, err := apt.Autoremove()
+			if output != nil {
 				allOutput.WriteString(output.Stdout)
-			} else if output != nil {
-				allOutput.WriteString(output.Stderr)
+				if err != nil {
+					allOutput.WriteString(output.Stderr)
+				}
 			}
+			autoremoveErr = err
 		} else if pkg.IsDnf() {
-			if output, err := dnfAutoremove(ctx); err == nil {
+			output, err := dnfAutoremove(ctx)
+			if output != nil {
 				allOutput.WriteString(output.Stdout)
-			} else if output != nil {
-				allOutput.WriteString(output.Stderr)
+				if err != nil {
+					allOutput.WriteString(output.Stderr)
+				}
 			}
+			autoremoveErr = err
 		}
 		countAfter := installedPackageCount()
 		autoremoved = countBefore > 0 && countAfter > 0 && countBefore != countAfter
+		if autoremoveErr != nil && lastErr == nil {
+			lastErr = fmt.Errorf("autoremove: %w", autoremoveErr)
+		}
 	}
 
 	// Check if this run created a new reboot requirement.
@@ -464,8 +479,26 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 		allOutput.WriteString("\n*** REBOOT REQUIRED ***\n")
 		if newRebootRequired && params != nil && params.RebootIfRequired {
 			sysnotify.NotifyAll(ctx, "System Reboot", "A system update requires a reboot. This system will reboot in 1 minute.")
-			allOutput.WriteString("Scheduling reboot in 1 minute...\n")
-			runSudoCmd(ctx, "shutdown", "-r", "+1", "System update requires reboot")
+			// Issue the shutdown FIRST and only report success if
+			// it actually went out — the prior shape printed
+			// "Scheduling reboot..." regardless of whether
+			// shutdown(8) accepted the request, so an operator
+			// would see "scheduled" in the action result while
+			// the host stayed up. Failure to schedule a reboot
+			// the operator explicitly asked for is a real action
+			// failure, not a logged warning.
+			if out, err := runSudoCmd(ctx, "shutdown", "-r", "+1", "System update requires reboot"); err != nil {
+				if out != nil {
+					allOutput.WriteString(out.Stdout)
+					allOutput.WriteString(out.Stderr)
+				}
+				allOutput.WriteString(fmt.Sprintf("FAILED to schedule reboot: %v\n", err))
+				if lastErr == nil {
+					lastErr = fmt.Errorf("schedule reboot: %w", err)
+				}
+			} else {
+				allOutput.WriteString("Scheduled reboot in 1 minute.\n")
+			}
 		}
 	}
 
@@ -484,7 +517,7 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 // executeAptUpgrade performs apt-specific upgrade.
 func (e *Executor) executeAptUpgrade(ctx context.Context, params *pb.UpdateParams, output *strings.Builder) error {
 	if params != nil && params.SecurityOnly {
-		// Use unattended-upgrades for security-only updates if available
+		// Use unattended-upgrades for security-only updates if available.
 		if _, err := exec.LookPath("unattended-upgrade"); err == nil {
 			cmdOutput, err := runSudoCmd(ctx, "unattended-upgrade", "-v")
 			if cmdOutput != nil {
@@ -493,9 +526,15 @@ func (e *Executor) executeAptUpgrade(ctx context.Context, params *pb.UpdateParam
 			}
 			return err
 		}
-		// Fallback: try apt with security pocket only
-		// This is distribution-specific and may not work everywhere
-		output.WriteString("Note: security-only updates requested but unattended-upgrade not available\n")
+		// No security-only path on this host. Fail closed instead
+		// of silently falling through to a full apt.Upgrade() —
+		// the caller asked for security-only because their
+		// compliance posture forbids the broader upgrade, and
+		// quietly delivering it anyway is a real compliance
+		// violation. Operators can install unattended-upgrades or
+		// switch the action to allow full upgrades.
+		output.WriteString("ERROR: security-only updates requested but no security-only path is available on this host (install unattended-upgrades, or set SecurityOnly=false to allow full upgrades).\n")
+		return fmt.Errorf("security-only apt updates requested but unattended-upgrade is not installed")
 	}
 
 	// Use the SDK Apt abstraction which sets DEBIAN_FRONTEND=noninteractive.


### PR DESCRIPTION
## Summary
Four update-flow correctness fixes from agent#75 — all in the "we returned success while the underlying operation either failed silently or did something the caller didn't ask for" family.

- **#15 — service disable**: surface real disable errors instead of masking with "unit may not exist" (the precondition already confirmed the unit was enabled).
- **#16 — autoremove**: capture and propagate `apt-get autoremove` / `dnf autoremove` errors instead of swallowing them.
- **#17 — reboot reporting**: only print "Scheduling reboot" after `shutdown(8)` returns 0; surface failures into the action result.
- **#18 — SecurityOnly APT fallthrough**: when `unattended-upgrade` is missing, fail closed instead of silently falling through to a full upgrade (compliance violation).

## Test plan
- [ ] `go test ./internal/executor/...`
- [ ] On Debian VM: trigger `disable` against a masked unit — action should report failure
- [ ] On Debian VM: request SecurityOnly without `unattended-upgrades` installed — action should fail with actionable message, not perform full upgrade
- [ ] Reboot path manual smoke: pass an invalid shutdown arg via test harness to confirm the failure surfaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Service disable failures are now surfaced as errors when a service is detected as enabled, preventing silent suppression.
  * Package autoremove operations (apt/dnf) now capture and report stdout/stderr and correctly recompute install-state changes.
  * Reboot scheduling reports success or failure and records scheduling errors appropriately.
  * Security-only apt upgrades now fail with a clear error when required components are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->