### PR TITLE
feat: emit RotationReason enum constants for LUKS rotations (PR C of cleanup)

### DIFF
--- a/cmd/power-manage-agent/luks_store.go
+++ b/cmd/power-manage-agent/luks_store.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	sdk "github.com/manchtools/power-manage/sdk/go"
 )
 
@@ -16,6 +17,6 @@ func (s *clientLuksKeyStore) GetKey(ctx context.Context, actionID string) (strin
 	return s.client.GetLuksKey(ctx, actionID)
 }
 
-func (s *clientLuksKeyStore) StoreKey(ctx context.Context, actionID, devicePath, passphrase, reason string) error {
+func (s *clientLuksKeyStore) StoreKey(ctx context.Context, actionID, devicePath, passphrase string, reason pb.RotationReason) error {
 	return s.client.StoreLuksKey(ctx, actionID, devicePath, passphrase, reason)
 }

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see agent/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260507091909-dea8b3864f6d
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260509150403-fedab9d3ade5
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260507091909-dea8b3864f6d h1:x0JpouAKvWAwS8hCRLigYdasvNz9aVyAkR1J/Z+7HzM=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260507091909-dea8b3864f6d/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260509150403-fedab9d3ade5 h1:JXNxuNC7/GL4QhJc9ZQ/j1cGX0ltt3xo1OabaqOgz3A=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260509150403-fedab9d3ade5/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/executor/luks.go
+++ b/internal/executor/luks.go
@@ -15,7 +15,7 @@ import (
 // LuksKeyStore is the interface for LUKS key operations via the agent stream.
 type LuksKeyStore interface {
 	GetKey(ctx context.Context, actionID string) (string, error)
-	StoreKey(ctx context.Context, actionID, devicePath, passphrase, reason string) error
+	StoreKey(ctx context.Context, actionID, devicePath, passphrase string, reason pb.RotationReason) error
 }
 
 // executeLuks manages LUKS disk encryption.
@@ -227,7 +227,7 @@ func (e *Executor) takeOwnership(ctx context.Context, params *pb.EncryptionParam
 	}
 
 	// Store on server — must succeed before removing PSK
-	if err := e.luksKeyStore.StoreKey(ctx, actionID, devicePath, passphrase, "initial"); err != nil {
+	if err := e.luksKeyStore.StoreKey(ctx, actionID, devicePath, passphrase, pb.RotationReason_ROTATION_REASON_INITIAL); err != nil {
 		// Rollback: remove the managed key we just added
 		sysenc.RemoveKey(ctx, devicePath, passphrase)
 		return fmt.Errorf("store key on server: %w", err)
@@ -294,7 +294,7 @@ func (e *Executor) checkAndRotate(ctx context.Context, params *pb.EncryptionPara
 	}
 
 	// Store on server — must succeed before removing old key
-	if err := e.luksKeyStore.StoreKey(ctx, actionID, devicePath, newPassphrase, "scheduled"); err != nil {
+	if err := e.luksKeyStore.StoreKey(ctx, actionID, devicePath, newPassphrase, pb.RotationReason_ROTATION_REASON_SCHEDULED); err != nil {
 		// Rollback: remove the new key we just added
 		sysenc.RemoveKey(ctx, devicePath, newPassphrase)
 		return false, fmt.Errorf("store new key on server: %w", err)


### PR DESCRIPTION
## Summary

Companion to power-manage-sdk PR #55 (already merged) + matching server PR.

- `internal/executor/luks.go`: `LuksKeyStore.StoreKey` interface reason param retyped to `pb.RotationReason`; the two emit sites (`takeOwnership` initial, `checkAndRotate` scheduled) use `pb.RotationReason_ROTATION_REASON_INITIAL/SCHEDULED`.
- `cmd/power-manage-agent/luks_store.go`: adapter signature retyped accordingly; added `pb` import.

## AUTH_GRACE note

The LUKS path never emits `AUTH_GRACE` — the `@gotags validate:"oneof=1 2"` on `StoreLuksKeyRequest.rotation_reason` explicitly excludes it. `AUTH_GRACE` remains valid for LPS via `LpsPasswordRotation.reason` (no `oneof` constraint), used by `shouldRotateLps`.

## Deps

- `power-manage-sdk` bumped to `fedab9d`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `staticcheck ./...` clean (with bumped SDK).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal type definitions for LUKS key storage operations to improve code reliability.
  * Updated dependency versions to the latest available releases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-agent/pull/82)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->