### PR TITLE
fix(executor): add -- option-injection guard to all file-op sudo calls (#64)

### DIFF
--- a/internal/executor/action_file.go
+++ b/internal/executor/action_file.go
@@ -71,7 +71,7 @@ func (e *Executor) executeFile(ctx context.Context, params *pb.FileParams, state
 			// For managed block: read existing content and append block if not present
 			// Use sudo cat to read files with restrictive permissions
 			var existingContent []byte
-			if output, err := runSudoCmd(ctx, "cat", resolvedPath); err == nil {
+			if output, err := runSudoCmd(ctx, "cat", "--", resolvedPath); err == nil {
 				existingContent = []byte(output.Stdout)
 			} else if output != nil && strings.Contains(output.Stderr, "No such file") {
 				// File doesn't exist, that's fine

--- a/internal/executor/action_repository.go
+++ b/internal/executor/action_repository.go
@@ -173,7 +173,7 @@ func (e *Executor) cleanupConflictingAptRepos(ctx context.Context, url, skipRepo
 					}
 					if keyPath != "" && strings.HasPrefix(keyPath, "/") {
 						output.WriteString(fmt.Sprintf("removing associated GPG key: %s\n", keyPath))
-						if _, err := runSudoCmd(ctx, "rm", "-f", keyPath); err != nil {
+						if _, err := runSudoCmd(ctx, "rm", "-f", "--", keyPath); err != nil {
 							e.logger.Warn("cleanupConflictingAptRepos: failed to remove conflicting GPG key",
 								"key_path", keyPath, "error", err)
 						}
@@ -195,7 +195,7 @@ func (e *Executor) cleanupConflictingAptRepos(ctx context.Context, url, skipRepo
 				}
 				if len(match) > 1 && strings.HasPrefix(keyPath, "/") {
 					output.WriteString(fmt.Sprintf("removing associated GPG key: %s\n", keyPath))
-					if _, err := runSudoCmd(ctx, "rm", "-f", keyPath); err != nil {
+					if _, err := runSudoCmd(ctx, "rm", "-f", "--", keyPath); err != nil {
 						e.logger.Warn("cleanupConflictingAptRepos: failed to remove conflicting GPG key",
 							"key_path", keyPath, "error", err)
 					}
@@ -207,7 +207,7 @@ func (e *Executor) cleanupConflictingAptRepos(ctx context.Context, url, skipRepo
 		// stale config in /etc/apt/sources.list.d/ and the next apt
 		// update would still see the conflict — surface the error so
 		// the operator can clean it up manually.
-		if _, err := runSudoCmd(ctx, "rm", "-f", filePath); err != nil {
+		if _, err := runSudoCmd(ctx, "rm", "-f", "--", filePath); err != nil {
 			e.logger.Warn("cleanupConflictingAptRepos: failed to remove conflicting repo file",
 				"file_path", filePath, "error", err)
 		}
@@ -226,21 +226,21 @@ func (e *Executor) executeAptRepository(ctx context.Context, name string, repo *
 	switch state {
 	case pb.DesiredState_DESIRED_STATE_ABSENT:
 		// Remove repository file
-		if _, err := runSudoCmd(ctx, "rm", "-f", repoFile); err != nil {
+		if _, err := runSudoCmd(ctx, "rm", "-f", "--", repoFile); err != nil {
 			return nil, false, fmt.Errorf("failed to remove repo file: %w", err)
 		}
 		// Also try to remove legacy .list format. A failed rm here
 		// leaves a stale config that apt will still parse; surface
 		// to the operator instead of silently swallowing.
 		legacyFile := fmt.Sprintf("/etc/apt/sources.list.d/%s.list", name)
-		if _, err := runSudoCmd(ctx, "rm", "-f", legacyFile); err != nil {
+		if _, err := runSudoCmd(ctx, "rm", "-f", "--", legacyFile); err != nil {
 			e.logger.Warn("apt ABSENT: failed to remove legacy repo file",
 				"file", legacyFile, "error", err)
 		}
 		// Remove GPG key. A leftover key with no .sources file is
 		// inert today but a future re-apply would compare against
 		// the wrong fingerprint — log so the divergence is visible.
-		if _, err := runSudoCmd(ctx, "rm", "-f", keyFile); err != nil {
+		if _, err := runSudoCmd(ctx, "rm", "-f", "--", keyFile); err != nil {
 			e.logger.Warn("apt ABSENT: failed to remove GPG key",
 				"key_file", keyFile, "error", err)
 		}
@@ -266,7 +266,7 @@ func (e *Executor) executeAptRepository(ctx context.Context, name string, repo *
 		legacyFile := fmt.Sprintf("/etc/apt/sources.list.d/%s.list", name)
 		if _, err := os.Stat(legacyFile); err == nil {
 			output.WriteString(fmt.Sprintf("removing legacy repository file: %s\n", legacyFile))
-			if _, err := runSudoCmd(ctx, "rm", "-f", legacyFile); err != nil {
+			if _, err := runSudoCmd(ctx, "rm", "-f", "--", legacyFile); err != nil {
 				e.logger.Warn("apt PRESENT: failed to remove legacy repo file",
 					"file", legacyFile, "error", err)
 			}
@@ -276,7 +276,7 @@ func (e *Executor) executeAptRepository(ctx context.Context, name string, repo *
 		legacyKeyFile := fmt.Sprintf("/etc/apt/trusted.gpg.d/%s.gpg", name)
 		if _, err := os.Stat(legacyKeyFile); err == nil {
 			output.WriteString(fmt.Sprintf("removing legacy GPG key: %s\n", legacyKeyFile))
-			if _, err := runSudoCmd(ctx, "rm", "-f", legacyKeyFile); err != nil {
+			if _, err := runSudoCmd(ctx, "rm", "-f", "--", legacyKeyFile); err != nil {
 				e.logger.Warn("apt PRESENT: failed to remove legacy GPG key",
 					"key_file", legacyKeyFile, "error", err)
 			}
@@ -284,7 +284,7 @@ func (e *Executor) executeAptRepository(ctx context.Context, name string, repo *
 		}
 
 		// Ensure keyrings directory exists
-		if _, err := runSudoCmd(ctx, "mkdir", "-p", "/etc/apt/keyrings"); err != nil {
+		if _, err := runSudoCmd(ctx, "mkdir", "-p", "--", "/etc/apt/keyrings"); err != nil {
 			return nil, false, fmt.Errorf("failed to create keyrings directory: %w", err)
 		}
 
@@ -446,7 +446,7 @@ func (e *Executor) updateGpgKeyIfNeeded(ctx context.Context, keyFile, keyUrl, ke
 		output.WriteString("GPG key not found, installing\n")
 	} else {
 		// Other error reading the file - try to read with sudo
-		cmdOutput, sudoErr := runSudoCmd(ctx, "cat", keyFile)
+		cmdOutput, sudoErr := runSudoCmd(ctx, "cat", "--", keyFile)
 		if sudoErr == nil && cmdOutput != nil {
 			if bytes.Equal([]byte(cmdOutput.Stdout), newKey) {
 				output.WriteString("GPG key already installed and matches\n")
@@ -459,7 +459,7 @@ func (e *Executor) updateGpgKeyIfNeeded(ctx context.Context, keyFile, keyUrl, ke
 	}
 
 	// Copy the new key to the target location with sudo
-	_, err = runSudoCmd(ctx, "cp", tempPath, keyFile)
+	_, err = runSudoCmd(ctx, "cp", "--", tempPath, keyFile)
 	if err != nil {
 		return false, fmt.Errorf("failed to install GPG key: %w", err)
 	}
@@ -468,7 +468,7 @@ func (e *Executor) updateGpgKeyIfNeeded(ctx context.Context, keyFile, keyUrl, ke
 	// dpkg with "the file is unreadable to apt", which masquerades
 	// as a repository fetch problem on the next apt update — return
 	// the error so the operator sees the real cause.
-	if _, err := runSudoCmd(ctx, "chmod", "644", keyFile); err != nil {
+	if _, err := runSudoCmd(ctx, "chmod", "644", "--", keyFile); err != nil {
 		return false, fmt.Errorf("failed to chmod GPG key %s: %w", keyFile, err)
 	}
 
@@ -489,7 +489,7 @@ func (e *Executor) executeDnfRepository(ctx context.Context, name string, repo *
 			output.WriteString(fmt.Sprintf("repository %s already absent\n", name))
 			return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, false, nil
 		}
-		if _, err := runSudoCmd(ctx, "rm", "-f", repoFile); err != nil {
+		if _, err := runSudoCmd(ctx, "rm", "-f", "--", repoFile); err != nil {
 			return nil, false, fmt.Errorf("failed to remove repo file: %w", err)
 		}
 		output.WriteString(fmt.Sprintf("removed repository: %s\n", name))
@@ -536,7 +536,7 @@ func (e *Executor) executeDnfRepository(ctx context.Context, name string, repo *
 		// (handles previous configurations with different settings).
 		if _, err := os.Stat(repoFile); err == nil {
 			output.WriteString(fmt.Sprintf("replacing existing repository: %s\n", name))
-			if _, err := runSudoCmd(ctx, "rm", "-f", repoFile); err != nil {
+			if _, err := runSudoCmd(ctx, "rm", "-f", "--", repoFile); err != nil {
 				e.logger.Warn("dnf PRESENT: failed to remove existing repo file before rewrite",
 					"file", repoFile, "error", err)
 			}

--- a/internal/executor/action_user.go
+++ b/internal/executor/action_user.go
@@ -333,17 +333,17 @@ func (e *Executor) updateUser(ctx context.Context, params *pb.UserParams, output
 			homeDir = "/home/" + params.Username
 		}
 		if _, err := os.Stat(homeDir); os.IsNotExist(err) {
-			if _, mkErr := runSudoCmd(ctx, "mkdir", "-p", homeDir); mkErr != nil {
+			if _, mkErr := runSudoCmd(ctx, "mkdir", "-p", "--", homeDir); mkErr != nil {
 				output.WriteString(fmt.Sprintf("warning: failed to create home directory: %v\n", mkErr))
 			} else {
-				runSudoCmd(ctx, "cp", "-a", "/etc/skel/.", homeDir)
+				runSudoCmd(ctx, "cp", "-a", "--", "/etc/skel/.", homeDir)
 				if chownResult, chownErr := sysuser.ChownRecursive(ctx, homeDir, params.Username, homeGroupFor(params)); chownErr != nil {
 					output.WriteString(fmt.Sprintf("warning: failed to chown home directory: %v\n", chownErr))
 					if chownResult != nil {
 						output.WriteString(chownResult.Stderr)
 					}
 				}
-				runSudoCmd(ctx, "chmod", "0700", homeDir)
+				runSudoCmd(ctx, "chmod", "0700", "--", homeDir)
 				output.WriteString(fmt.Sprintf("created missing home directory: %s\n", homeDir))
 				changed = true
 			}
@@ -549,7 +549,7 @@ func (e *Executor) setupSSHKeys(ctx context.Context, params *pb.UserParams, outp
 	}
 
 	// Create .ssh directory
-	if _, err := runSudoCmd(ctx, "mkdir", "-p", sshDir); err != nil {
+	if _, err := runSudoCmd(ctx, "mkdir", "-p", "--", sshDir); err != nil {
 		return false, fmt.Errorf("failed to create .ssh directory: %w", err)
 	}
 
@@ -558,10 +558,10 @@ func (e *Executor) setupSSHKeys(ctx context.Context, params *pb.UserParams, outp
 	// users created with Gid / PrimaryGroup don't end up with the wrong
 	// group on .ssh and fail authorized_keys writes.
 	ownership := params.Username + ":" + homeGroupFor(params)
-	if _, err := runSudoCmd(ctx, "chown", ownership, sshDir); err != nil {
+	if _, err := runSudoCmd(ctx, "chown", "--", ownership, sshDir); err != nil {
 		return false, fmt.Errorf("failed to set .ssh ownership: %w", err)
 	}
-	if _, err := runSudoCmd(ctx, "chmod", "700", sshDir); err != nil {
+	if _, err := runSudoCmd(ctx, "chmod", "700", "--", sshDir); err != nil {
 		return false, fmt.Errorf("failed to set .ssh permissions: %w", err)
 	}
 
@@ -582,7 +582,7 @@ func (e *Executor) setupSSHKeys(ctx context.Context, params *pb.UserParams, outp
 	// Set ownership on authorized_keys. SafeReplaceFile leaves the
 	// file owned by the agent process (root); a separate chown brings
 	// it back to the target user without re-introducing the tee race.
-	if _, err := runSudoCmd(ctx, "chown", ownership, authKeysFile); err != nil {
+	if _, err := runSudoCmd(ctx, "chown", "--", ownership, authKeysFile); err != nil {
 		return false, fmt.Errorf("failed to set authorized_keys ownership: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
PR #63 added the \`--\` separator to six sudo invocations in \`internal/executor/agent_update.go\` after CR caught one occurrence. This sweep applies the same defense-in-depth across the rest of the agent's sudo'd file/path operations.

## Changes
**22 sites guarded across 3 files:**
| File | Sites | Pattern |
|---|---|---|
| \`internal/executor/action_user.go\` | 7 | mkdir/cp/chmod/chown for home-dir + ssh-dir + authorized-keys file |
| \`internal/executor/action_repository.go\` | 14 | rm/mkdir/cat/cp/chmod for apt/dnf/zypper/pacman keyrings + repo files |
| \`internal/executor/action_file.go\` | 1 | cat for sudo'd file read |

Pattern: \`--\` inserted between flags and path operands. For \`rm -f path\` becomes \`rm -f -- path\`; for \`chown owner path\` becomes \`chown -- owner path\` (defensive even though owner can't begin with \`-\`); etc.

Most current call sites use trusted constants or path strings validated upstream, so the change is **no-op hardening for today**. The cost is zero and the mechanical uniformity reduces the chance of a future call site forgetting the guard.

## Notes
- \`internal/executor/action_update.go\` (4 sites) already has the guard from PR #63 — left unchanged.
- No other \`runSudoCmd\` sites in \`internal/executor/\` are file-op calls (the rest are package-manager invocations: \`dpkg\`, \`rpm\`, \`flatpak\`, \`dnf\`, \`pacman\`, \`zypper\` — different threat surface, separate concern).

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test -short ./internal/executor/\` passes
- [x] \`go vet\` + gofmt clean
- [x] grep audit confirms zero unguarded sites remain
- [ ] CI gate

Closes manchtools/power-manage-agent#64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened overall system reliability and robustness by enhancing command-line argument handling to prevent file paths from being misinterpreted as command-line options. These improvements apply to repository management operations (APT and DNF), file operations in managed blocks, user home directory setup and configuration, and SSH key management procedures throughout the system.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-agent/pull/86)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->