### PR TITLE
fix(executor): Flatpak system-only + LUKS rotation hot-loop guard (#79, #80)

### DIFF
--- a/internal/executor/action_flatpak.go
+++ b/internal/executor/action_flatpak.go
@@ -34,11 +34,21 @@ func (e *Executor) executeFlatpak(ctx context.Context, params *pb.FlatpakParams,
 		remote = "flathub"
 	}
 
-	// Build base args - system-wide by default
-	systemFlag := "--system"
+	// Always install system-wide. Pre-fix #79 SystemWide=false routed
+	// to `flatpak --user`, but install/uninstall ran through sudo —
+	// `flatpak --user` resolves the installation against $HOME, and
+	// under sudo $HOME is /root, so apps landed in
+	// /root/.local/share/flatpak where no desktop user could see them.
+	// The agent isn't a desktop-session actor (it runs as a system
+	// service with no concept of "which desktop user"), so per-user
+	// installs are out of scope. Coerce SystemWide=false to a warning
+	// + system-wide so existing assignments don't silently break
+	// behavior when they upgrade across the fix.
 	if !params.SystemWide {
-		systemFlag = "--user"
+		e.logger.Warn("flatpak: SystemWide=false coerced to system-wide install — per-user flatpak is unsupported by the agent (it has no notion of which desktop user); update the assignment to SystemWide=true to silence this warning",
+			"app_id", params.AppId)
 	}
+	const systemFlag = "--system"
 
 	// Check if flatpak is installed
 	isInstalled := e.isFlatpakInstalled(params.AppId, systemFlag)

--- a/internal/executor/action_flatpak_test.go
+++ b/internal/executor/action_flatpak_test.go
@@ -1,0 +1,69 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"testing"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// TestExecuteFlatpak_SystemWideFalseLogsCoercion guards the #79 fix:
+// SystemWide=false used to route through `flatpak --user` under sudo,
+// landing apps in /root/.local/share/flatpak where no desktop user
+// could see them. The fix coerces SystemWide=false to a system-wide
+// install + a Warn line so operators see their assignment got
+// silently corrected instead of running in a broken-but-quiet state.
+//
+// Skipped on hosts without flatpak — the executor short-circuits to
+// "skipped: flatpak not available" before reaching the coercion log.
+func TestExecuteFlatpak_SystemWideFalseLogsCoercion(t *testing.T) {
+	if _, err := exec.LookPath("flatpak"); err != nil {
+		t.Skip("flatpak is not available on this system — coercion warn fires after the lookup, so skip")
+	}
+
+	var buf bytes.Buffer
+	e := NewExecutor(nil)
+	e.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	_, _, _ = e.executeFlatpak(context.Background(), &pb.FlatpakParams{
+		AppId:      "org.nonexistent.surely_does_not_exist_12345",
+		SystemWide: false,
+	}, pb.DesiredState_DESIRED_STATE_PRESENT)
+
+	got := buf.String()
+	if !strings.Contains(got, "level=WARN") {
+		t.Errorf("expected WARN-level coercion log when SystemWide=false, got:\n%s", got)
+	}
+	if !strings.Contains(got, "SystemWide=false coerced") {
+		t.Errorf("expected coercion warn body, got:\n%s", got)
+	}
+	if !strings.Contains(got, "org.nonexistent.surely_does_not_exist_12345") {
+		t.Errorf("expected app_id in the coercion warn so operators can locate the assignment, got:\n%s", got)
+	}
+}
+
+// TestExecuteFlatpak_SystemWideTrueDoesNotCoerce verifies the
+// happy-path stays silent — SystemWide=true is the supported config
+// and must not trigger the warn intended for the broken case.
+func TestExecuteFlatpak_SystemWideTrueDoesNotCoerce(t *testing.T) {
+	if _, err := exec.LookPath("flatpak"); err != nil {
+		t.Skip("flatpak is not available on this system")
+	}
+
+	var buf bytes.Buffer
+	e := NewExecutor(nil)
+	e.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	_, _, _ = e.executeFlatpak(context.Background(), &pb.FlatpakParams{
+		AppId:      "org.nonexistent.surely_does_not_exist_12345",
+		SystemWide: true,
+	}, pb.DesiredState_DESIRED_STATE_PRESENT)
+
+	if strings.Contains(buf.String(), "SystemWide=false coerced") {
+		t.Errorf("SystemWide=true must not trigger the coercion warn, got:\n%s", buf.String())
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -175,6 +175,16 @@ type Executor struct {
 	// production. Now scoped per-instance.
 	agentUpdateExecutedMu sync.Mutex
 	agentUpdateExecuted   bool
+
+	// Per-action LUKS rotation-timestamp persistence failure counter.
+	// Tracks consecutive SetLuksLastRotatedAt failures per action ID
+	// so the agent escalates from Warn to Error after
+	// luksTimestampFailureThreshold consecutive failures (#80). The
+	// failure mode it surfaces — silent rotation hot-loop or rotation
+	// never starting because the timestamp never persists — was easy
+	// to miss when buried in journald Warn-level lines.
+	luksTimestampFailMu    sync.Mutex
+	luksTimestampFailCount map[string]int
 }
 
 // NewExecutor creates a new action executor.

--- a/internal/executor/luks.go
+++ b/internal/executor/luks.go
@@ -19,6 +19,60 @@ type LuksKeyStore interface {
 	StoreKey(ctx context.Context, actionID, devicePath, passphrase string, reason pb.RotationReason) error
 }
 
+// luksTimestampFailureThreshold is the consecutive-failure count after
+// which the agent escalates SetLuksLastRotatedAt persistence failures
+// from Warn to Error. Per #80 the operational risk is a silent
+// rotation hot-loop (post-rotation timestamp never persists, so the
+// next tick re-rotates) or rotation that never starts (initial
+// timestamp never persists, so every tick re-enters the init branch);
+// either case is easy to miss at Warn-level in journald and worth
+// surfacing at Error so journald-priority filters page operators.
+const luksTimestampFailureThreshold = 3
+
+// recordLuksTimestampFailure logs a SetLuksLastRotatedAt failure and
+// bumps the per-action consecutive-failure counter. The first
+// (luksTimestampFailureThreshold-1) failures log at Warn; from the
+// threshold-th failure onward the level escalates to Error so
+// journald-priority filters surface what would otherwise be a buried
+// hot-loop or stuck-rotation hazard (#80). The site label distinguishes
+// the initial-timestamp branch from the post-rotation branch in logs.
+func (e *Executor) recordLuksTimestampFailure(actionID, site string, err error) {
+	e.luksTimestampFailMu.Lock()
+	if e.luksTimestampFailCount == nil {
+		e.luksTimestampFailCount = make(map[string]int)
+	}
+	e.luksTimestampFailCount[actionID]++
+	n := e.luksTimestampFailCount[actionID]
+	e.luksTimestampFailMu.Unlock()
+
+	if n >= luksTimestampFailureThreshold {
+		e.logger.Error("LUKS: SetLuksLastRotatedAt failing persistently — rotation may hot-loop or never start; investigate the agent store",
+			"action_id", actionID,
+			"site", site,
+			"consecutive_failures", n,
+			"error", err,
+		)
+		return
+	}
+	e.logger.Warn("LUKS: failed to persist rotation timestamp",
+		"action_id", actionID,
+		"site", site,
+		"consecutive_failures", n,
+		"error", err,
+	)
+}
+
+// clearLuksTimestampFailures resets the per-action consecutive-failure
+// counter on a successful SetLuksLastRotatedAt write. Companion to
+// recordLuksTimestampFailure (#80).
+func (e *Executor) clearLuksTimestampFailures(actionID string) {
+	e.luksTimestampFailMu.Lock()
+	if e.luksTimestampFailCount != nil {
+		delete(e.luksTimestampFailCount, actionID)
+	}
+	e.luksTimestampFailMu.Unlock()
+}
+
 // executeLuks manages LUKS disk encryption.
 //
 // Audit F003: every read of e.luksKeyStore / e.store / e.actionStore in
@@ -299,10 +353,12 @@ func (e *Executor) checkAndRotate(ctx context.Context, params *pb.EncryptionPara
 			if err := st.SetLuksLastRotatedAt(actionID, time.Now()); err != nil {
 				// First-rotation timestamp persistence failed.
 				// Subsequent ticks re-enter this branch and re-skip
-				// rotation — log so the operator can notice
-				// rotation is silently disabled.
-				e.logger.Warn("checkAndRotate: failed to set initial LUKS rotation timestamp",
-					"action_id", actionID, "error", err)
+				// rotation, so rotation never starts. Track
+				// consecutive failures so the buried-Warn case
+				// escalates to Error after the threshold (#80).
+				e.recordLuksTimestampFailure(actionID, "initial", err)
+			} else {
+				e.clearLuksTimestampFailures(actionID)
 			}
 			return false, nil
 		}
@@ -355,9 +411,14 @@ func (e *Executor) checkAndRotate(ctx context.Context, params *pb.EncryptionPara
 		e.logger.Warn("failed to remove old key after rotation (both keys work)", "error", err)
 	}
 
-	// Record rotation time locally
+	// Record rotation time locally. If this fails persistently the
+	// next tick believes nothing rotated and re-rotates — a hot loop
+	// that churns LUKS slots. Track consecutive failures so the
+	// buried-Warn case escalates to Error after the threshold (#80).
 	if err := st.SetLuksLastRotatedAt(actionID, time.Now().UTC()); err != nil {
-		e.logger.Warn("failed to record LUKS rotation time", "action_id", actionID, "error", err)
+		e.recordLuksTimestampFailure(actionID, "post_rotation", err)
+	} else {
+		e.clearLuksTimestampFailures(actionID)
 	}
 
 	return true, nil

--- a/internal/executor/luks_rotation_failures_test.go
+++ b/internal/executor/luks_rotation_failures_test.go
@@ -1,0 +1,130 @@
+package executor
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestRecordLuksTimestampFailure_EscalatesAtThreshold pins the
+// Warn→Error escalation contract for #80: a single
+// SetLuksLastRotatedAt failure must log at Warn so Bundle A's
+// silent-discard regression doesn't return; the threshold-th and
+// later consecutive failures escalate to Error so journald-priority
+// filters surface what would otherwise be a buried hot-loop or
+// stuck-rotation hazard.
+func TestRecordLuksTimestampFailure_EscalatesAtThreshold(t *testing.T) {
+	var buf bytes.Buffer
+	e := &Executor{logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))}
+
+	const actionID = "01HXTEST0000000000000ABCDE"
+	for i := 1; i <= luksTimestampFailureThreshold+1; i++ {
+		e.recordLuksTimestampFailure(actionID, "post_rotation", errors.New("disk full"))
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if got, want := len(lines), luksTimestampFailureThreshold+1; got != want {
+		t.Fatalf("expected %d log lines, got %d:\n%s", want, got, buf.String())
+	}
+
+	for i, line := range lines {
+		switch {
+		case i < luksTimestampFailureThreshold-1:
+			// First (threshold-1) failures must be Warn — staying
+			// at Error from the first failure would page operators
+			// for transient single-tick blips.
+			if !strings.Contains(line, "level=WARN") {
+				t.Errorf("line %d (consecutive=%d) expected WARN, got: %s", i+1, i+1, line)
+			}
+			if !strings.Contains(line, "consecutive_failures="+itoa(i+1)) {
+				t.Errorf("line %d expected consecutive_failures=%d, got: %s", i+1, i+1, line)
+			}
+		default:
+			// Threshold-th failure onward must be Error. The
+			// threshold-th line and the (threshold+1)-th line both
+			// fall in this branch — the escalation persists, it
+			// doesn't toggle back to Warn.
+			if !strings.Contains(line, "level=ERROR") {
+				t.Errorf("line %d (consecutive=%d) expected ERROR, got: %s", i+1, i+1, line)
+			}
+			if !strings.Contains(line, "consecutive_failures="+itoa(i+1)) {
+				t.Errorf("line %d expected consecutive_failures=%d, got: %s", i+1, i+1, line)
+			}
+			if !strings.Contains(line, "rotation may hot-loop") {
+				t.Errorf("line %d expected hot-loop hint in error msg, got: %s", i+1, line)
+			}
+		}
+	}
+}
+
+// TestClearLuksTimestampFailures_ResetsCounter verifies the success
+// path resets the per-action counter, so a recovered failure mode
+// doesn't leave the next genuine failure already at Error level.
+func TestClearLuksTimestampFailures_ResetsCounter(t *testing.T) {
+	var buf bytes.Buffer
+	e := &Executor{logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))}
+
+	const actionID = "01HXTEST0000000000000ABCDE"
+
+	// Push the counter past the threshold.
+	for i := 1; i <= luksTimestampFailureThreshold; i++ {
+		e.recordLuksTimestampFailure(actionID, "post_rotation", errors.New("disk full"))
+	}
+	// Recover.
+	e.clearLuksTimestampFailures(actionID)
+	// Reset buf so we only inspect the post-recovery failure.
+	buf.Reset()
+
+	// Next failure after a recovery must drop back to Warn — operators
+	// shouldn't be paged for a single new failure when the prior streak
+	// already resolved.
+	e.recordLuksTimestampFailure(actionID, "post_rotation", errors.New("disk full"))
+	got := buf.String()
+	if !strings.Contains(got, "level=WARN") {
+		t.Errorf("expected first post-recovery failure at WARN, got: %s", got)
+	}
+	if !strings.Contains(got, "consecutive_failures=1") {
+		t.Errorf("expected consecutive_failures=1 after recovery, got: %s", got)
+	}
+}
+
+// TestRecordLuksTimestampFailure_PerActionIsolation guards against
+// the obvious shared-counter bug: two actions failing must not
+// cross-contaminate each other's escalation state.
+func TestRecordLuksTimestampFailure_PerActionIsolation(t *testing.T) {
+	var buf bytes.Buffer
+	e := &Executor{logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))}
+
+	// Action A fails (threshold-1) times — still at Warn.
+	for i := 1; i < luksTimestampFailureThreshold; i++ {
+		e.recordLuksTimestampFailure("action-A", "post_rotation", errors.New("disk full"))
+	}
+	buf.Reset()
+
+	// Action B's first failure must NOT inherit action A's count.
+	e.recordLuksTimestampFailure("action-B", "post_rotation", errors.New("disk full"))
+	got := buf.String()
+	if !strings.Contains(got, "level=WARN") {
+		t.Errorf("action-B's first failure must be WARN, not promoted by action-A's streak; got: %s", got)
+	}
+	if !strings.Contains(got, "consecutive_failures=1") {
+		t.Errorf("action-B's first failure must show consecutive_failures=1; got: %s", got)
+	}
+}
+
+// itoa avoids pulling strconv just for these tests.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}


### PR DESCRIPTION
## Summary

Closes the two open agent issues in the v2026.06 polish bundle.

### #79 — Flatpak SystemWide=false runs --user under sudo (wrong profile)

The pre-fix path mapped \`SystemWide=false\` → \`flatpak --user\`, but install/uninstall ran through sudo. \`flatpak --user\` resolves the installation against \`\$HOME\`, and under sudo \`\$HOME\` is \`/root\`, so apps landed in \`/root/.local/share/flatpak\` where no desktop user could see them.

Per-user installs are inherently a desktop-session concept and the agent isn't a desktop-session actor (it runs as a system service with no concept of "which desktop user"), so per-user installs are out of scope. Took option 1 from the issue: always pass \`--system\`. When \`SystemWide=false\` is set on the request, log a Warn naming the \`app_id\` so operators see their assignment got coerced and can update it explicitly.

Wire compatibility: the \`SystemWide\` proto field stays so existing assignments deserialize cleanly — only the runtime path changes.

### #80 — LUKS rotation timestamp persistence escalates after 3 failures

\`checkAndRotate\` has two \`SetLuksLastRotatedAt\` call sites:
- **post-rotation** (\`luks.go:359\`) — failure makes the next tick re-rotate (hot loop, churns LUKS slots).
- **initial timestamp** (\`luks.go:299\`) — failure makes rotation never start (every tick re-enters the init branch).

Both used to log a single Warn and proceed. Operationally that's easy to miss buried in Warn-level journald lines.

Added a per-action consecutive-failure counter on \`Executor\` (\`luksTimestampFailCount\`, mutex-guarded). The first two failures stay at Warn — transient blips shouldn't page operators. The third and beyond escalate to Error with a \"rotation may hot-loop\" hint so journald-priority filters surface the issue. Success on either site clears the per-action counter.

## Test plan
- [x] \`go test -count=1 -short ./internal/executor/\` — green (incl. 5 new test cases)
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l .\` clean
- [x] \`cr review --plain --base main\` — no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Flatpak installations now only support system-wide deployments; per-user installs are unsupported and will emit a warning.

* **Improvements**
  * Enhanced failure tracking and logging for LUKS rotation timestamp persistence operations, with escalating severity levels based on consecutive failures.

* **Tests**
  * Added test coverage for Flatpak system-wide behavior validation and LUKS rotation failure escalation logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-agent/pull/87)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->