### PR TITLE
feat(executor): user-scoped actions fan out to signed-in desktop users (#79)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 // it. There is no automatic floating tag — that's intentional, because
 // SDK proto/Go API drifts between commits should be reviewable in the
 // same PR as the agent change that consumes them.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260510121227-91c29e053454
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260513201103-e2168be4d3c5
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 // it. There is no automatic floating tag — that's intentional, because
 // SDK proto/Go API drifts between commits should be reviewable in the
 // same PR as the agent change that consumes them.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260513201103-e2168be4d3c5
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260513204052-0ead77368a61
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260510121227-91c29e053454 h1:rClJEVGy2Mq7pEgpctZUTdhNjfvD9lwwRoOZyz6q0Iw=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260510121227-91c29e053454/go.mod h1:hG7NcdIGAG0VzhLL/W12FDAgVQJxeK+jHFtHb2eF3A8=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260513201103-e2168be4d3c5 h1:8XWx9foQyF03iz+4wXQ1wK6JSyFMGu2fA62ft5icXCE=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260513201103-e2168be4d3c5/go.mod h1:hG7NcdIGAG0VzhLL/W12FDAgVQJxeK+jHFtHb2eF3A8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260513201103-e2168be4d3c5 h1:8XWx9foQyF03iz+4wXQ1wK6JSyFMGu2fA62ft5icXCE=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260513201103-e2168be4d3c5/go.mod h1:hG7NcdIGAG0VzhLL/W12FDAgVQJxeK+jHFtHb2eF3A8=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260513204052-0ead77368a61 h1:haZ8jWxiWDL7brrBjil5fcpjp9nyMJ/kRcquP/Pz8cQ=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260513204052-0ead77368a61/go.mod h1:hG7NcdIGAG0VzhLL/W12FDAgVQJxeK+jHFtHb2eF3A8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/executor/action_flatpak.go
+++ b/internal/executor/action_flatpak.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"strings"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/sys/desktop"
 )
 
 func (e *Executor) executeFlatpak(ctx context.Context, params *pb.FlatpakParams, state pb.DesiredState) (*pb.CommandOutput, bool, error) {
@@ -34,23 +36,18 @@ func (e *Executor) executeFlatpak(ctx context.Context, params *pb.FlatpakParams,
 		remote = "flathub"
 	}
 
-	// Always install system-wide. Pre-fix #79 SystemWide=false routed
-	// to `flatpak --user`, but install/uninstall ran through sudo —
-	// `flatpak --user` resolves the installation against $HOME, and
-	// under sudo $HOME is /root, so apps landed in
-	// /root/.local/share/flatpak where no desktop user could see them.
-	// The agent isn't a desktop-session actor (it runs as a system
-	// service with no concept of "which desktop user"), so per-user
-	// installs are out of scope. Coerce SystemWide=false to a warning
-	// + system-wide so existing assignments don't silently break
-	// behavior when they upgrade across the fix.
-	if !params.SystemWide {
-		e.logger.Warn("flatpak: SystemWide=false coerced to system-wide install — per-user flatpak is unsupported by the agent (it has no notion of which desktop user); update the assignment to SystemWide=true to silence this warning",
-			"app_id", params.AppId)
+	if params.SystemWide {
+		return e.executeFlatpakSystem(ctx, params, state, remote)
 	}
-	const systemFlag = "--system"
+	return e.executeFlatpakPerUser(ctx, params, state, remote)
+}
 
-	// Check if flatpak is installed
+// executeFlatpakSystem implements the system-wide install/uninstall
+// path. Behavior matches the pre-#79 codepath verbatim — only the
+// SystemWide=true case routes here, so existing assignments are
+// untouched.
+func (e *Executor) executeFlatpakSystem(ctx context.Context, params *pb.FlatpakParams, state pb.DesiredState, remote string) (*pb.CommandOutput, bool, error) {
+	const systemFlag = "--system"
 	isInstalled := e.isFlatpakInstalled(params.AppId, systemFlag)
 
 	switch state {
@@ -62,21 +59,18 @@ func (e *Executor) executeFlatpak(ctx context.Context, params *pb.FlatpakParams,
 			}, false, nil
 		}
 
-		// Repair filesystem if mounted read-only
 		if out, err := e.requireWritableFS(ctx); err != nil {
 			return out, false, err
 		}
 
-		// Install the flatpak application
 		output, err := runSudoCmd(ctx, "flatpak", "install", "-y", "--noninteractive", systemFlag, remote, params.AppId)
 		if err != nil {
 			return output, false, fmt.Errorf("flatpak install failed: %w", err)
 		}
 
-		// Pin if requested (mask prevents updates). The SDK can
-		// return (nil, nil) on success — guard the dereference so a
-		// successful install + successful pin doesn't segfault on the
-		// Stdout += assignment below. Audit F056(a).
+		// Pin if requested (mask prevents updates). Audit F056(a) —
+		// guard the dereference so a successful install + successful
+		// pin doesn't segfault on the Stdout += assignment.
 		if params.Pin {
 			pinOutput, pinErr := runSudoCmd(ctx, "flatpak", "mask", systemFlag, params.AppId)
 			if output == nil {
@@ -88,7 +82,6 @@ func (e *Executor) executeFlatpak(ctx context.Context, params *pb.FlatpakParams,
 				output.Stdout += "\n" + pinOutput.Stdout
 			}
 		}
-
 		return output, true, nil
 
 	case pb.DesiredState_DESIRED_STATE_ABSENT:
@@ -99,25 +92,157 @@ func (e *Executor) executeFlatpak(ctx context.Context, params *pb.FlatpakParams,
 			}, false, nil
 		}
 
-		// Repair filesystem if mounted read-only
 		if out, err := e.requireWritableFS(ctx); err != nil {
 			return out, false, err
 		}
 
-		// Remove pin first if it exists. The mask may not have been
-		// set, so a non-zero exit is expected and benign — but log
-		// at Debug so the operator can correlate if uninstall later
-		// fails. Audit F056(b).
+		// Audit F056(b) — mask removal can fail benignly if the app
+		// was never pinned; log at Debug so the operator can correlate
+		// if uninstall later fails.
 		if _, err := runSudoCmd(ctx, "flatpak", "mask", "--remove", systemFlag, params.AppId); err != nil {
 			e.logger.Debug("flatpak ABSENT: unmask before uninstall failed (often expected if not pinned)",
 				"app_id", params.AppId, "error", err)
 		}
 
-		// Uninstall the flatpak application
 		output, err := runSudoCmd(ctx, "flatpak", "uninstall", "-y", "--noninteractive", systemFlag, params.AppId)
 		return output, true, err
 	}
 
+	return nil, false, fmt.Errorf("unknown desired state: %v", state)
+}
+
+// executeFlatpakPerUser implements the per-user install/uninstall
+// path (#79). The PRESENT branch installs for every currently
+// signed-in graphical session; the ABSENT branch uninstalls from
+// every account on the box that has the app under
+// ~/.local/share/flatpak/. The asymmetry is deliberate: install
+// requires a live session (we want the new app visible immediately
+// to a user who's at the keyboard), uninstall must reach dormant
+// accounts to actually converge the policy.
+//
+// Empty-set policy (no signed-in users for PRESENT, no installs to
+// remove for ABSENT) is "log Warn, return success no-op" rather
+// than fail — pre-fix the action would have silently installed into
+// /root/.local/share/flatpak, so success-no-op is strictly better
+// and keeps the action retry-friendly until a session appears.
+func (e *Executor) executeFlatpakPerUser(ctx context.Context, params *pb.FlatpakParams, state pb.DesiredState, remote string) (*pb.CommandOutput, bool, error) {
+	switch state {
+	case pb.DesiredState_DESIRED_STATE_PRESENT:
+		sessions, err := desktop.ActiveSessions(ctx)
+		if err != nil {
+			return nil, false, fmt.Errorf("enumerate active desktop sessions: %w", err)
+		}
+		if len(sessions) == 0 {
+			e.logger.Warn("flatpak PRESENT: no active desktop sessions; per-user install deferred until a user signs in",
+				"app_id", params.AppId)
+			return &pb.CommandOutput{
+				ExitCode: 0,
+				Stdout:   fmt.Sprintf("skipped: no signed-in desktop users to install %s for; will run again on next reconciliation", params.AppId),
+			}, false, nil
+		}
+
+		if out, err := e.requireWritableFS(ctx); err != nil {
+			return out, false, err
+		}
+
+		var (
+			anyChanged   bool
+			perUserOut   = &strings.Builder{}
+			firstFailure error
+		)
+		for _, s := range sessions {
+			line := func(prefix, body string) {
+				perUserOut.WriteString(prefix)
+				perUserOut.WriteString(s.Username)
+				perUserOut.WriteString(": ")
+				perUserOut.WriteString(body)
+				perUserOut.WriteString("\n")
+			}
+
+			if runAsUserCheck(ctx, s, "flatpak", "info", "--user", params.AppId) {
+				line("user=", fmt.Sprintf("flatpak %s already installed; skipped", params.AppId))
+				continue
+			}
+
+			out, runErr := runAsUserCmd(ctx, s, nil, "flatpak", "install", "-y", "--noninteractive", "--user", remote, params.AppId)
+			if runErr != nil {
+				if firstFailure == nil {
+					firstFailure = fmt.Errorf("user %s: install failed: %w", s.Username, runErr)
+				}
+				e.logger.Warn("flatpak PRESENT: per-user install failed",
+					"user", s.Username, "app_id", params.AppId, "error", runErr)
+				if out != nil {
+					line("user=", strings.TrimSpace(out.Stderr))
+				}
+				continue
+			}
+			anyChanged = true
+			line("user=", fmt.Sprintf("installed %s", params.AppId))
+
+			if params.Pin {
+				if _, pinErr := runAsUserCmd(ctx, s, nil, "flatpak", "mask", "--user", params.AppId); pinErr != nil {
+					e.logger.Warn("flatpak PRESENT: per-user pin (mask) failed (install succeeded)",
+						"user", s.Username, "app_id", params.AppId, "error", pinErr)
+					line("user=", "pin failed: "+pinErr.Error())
+				}
+			}
+		}
+
+		return &pb.CommandOutput{Stdout: perUserOut.String()}, anyChanged, firstFailure
+
+	case pb.DesiredState_DESIRED_STATE_ABSENT:
+		users, err := desktop.UsersWithFlatpakInstall(params.AppId)
+		if err != nil {
+			return nil, false, fmt.Errorf("enumerate per-user flatpak installs: %w", err)
+		}
+		if len(users) == 0 {
+			return &pb.CommandOutput{
+				ExitCode: 0,
+				Stdout:   fmt.Sprintf("flatpak %s is already not installed for any user", params.AppId),
+			}, false, nil
+		}
+
+		if out, err := e.requireWritableFS(ctx); err != nil {
+			return out, false, err
+		}
+
+		var (
+			anyChanged   bool
+			perUserOut   = &strings.Builder{}
+			firstFailure error
+		)
+		for _, u := range users {
+			// Mask removal is best-effort, same rationale as the
+			// system-wide path. Log only if loud.
+			if _, err := runAsUserCmd(ctx, u, nil, "flatpak", "mask", "--remove", "--user", params.AppId); err != nil {
+				e.logger.Debug("flatpak ABSENT: per-user unmask before uninstall failed (often expected if not pinned)",
+					"user", u.Username, "app_id", params.AppId, "error", err)
+			}
+
+			out, runErr := runAsUserCmd(ctx, u, nil, "flatpak", "uninstall", "-y", "--noninteractive", "--user", params.AppId)
+			perUserOut.WriteString("user=")
+			perUserOut.WriteString(u.Username)
+			perUserOut.WriteString(": ")
+			if runErr != nil {
+				if firstFailure == nil {
+					firstFailure = fmt.Errorf("user %s: uninstall failed: %w", u.Username, runErr)
+				}
+				e.logger.Warn("flatpak ABSENT: per-user uninstall failed",
+					"user", u.Username, "app_id", params.AppId, "error", runErr)
+				if out != nil {
+					perUserOut.WriteString(strings.TrimSpace(out.Stderr))
+				} else {
+					perUserOut.WriteString(runErr.Error())
+				}
+				perUserOut.WriteString("\n")
+				continue
+			}
+			anyChanged = true
+			perUserOut.WriteString("uninstalled\n")
+		}
+
+		return &pb.CommandOutput{Stdout: perUserOut.String()}, anyChanged, firstFailure
+	}
 	return nil, false, fmt.Errorf("unknown desired state: %v", state)
 }
 

--- a/internal/executor/action_flatpak_test.go
+++ b/internal/executor/action_flatpak_test.go
@@ -9,61 +9,141 @@ import (
 	"testing"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/sys/desktop"
 )
 
-// TestExecuteFlatpak_SystemWideFalseLogsCoercion guards the #79 fix:
-// SystemWide=false used to route through `flatpak --user` under sudo,
-// landing apps in /root/.local/share/flatpak where no desktop user
-// could see them. The fix coerces SystemWide=false to a system-wide
-// install + a Warn line so operators see their assignment got
-// silently corrected instead of running in a broken-but-quiet state.
+// TestExecuteFlatpak_PerUserPresentNoSessions guards the empty-set
+// policy for #79's per-user install path: when SystemWide=false and
+// no graphical session is signed in, the action returns success
+// no-op + a Warn naming the app, NOT a silent install into
+// /root/.local/share/flatpak (which is what the pre-fix path did).
 //
-// Skipped on hosts without flatpak — the executor short-circuits to
-// "skipped: flatpak not available" before reaching the coercion log.
-func TestExecuteFlatpak_SystemWideFalseLogsCoercion(t *testing.T) {
+// Skipped on hosts without flatpak (the lookup short-circuit fires
+// before the per-user branch) and on hosts that DO have an active
+// graphical session — in that case the action correctly enters the
+// per-user fan-out loop and the empty-set branch isn't exercised.
+// The fan-out loop itself is exercised by the SDK-level tests
+// (sdk/go/sys/desktop) and a future end-to-end integration test;
+// what matters here is the dispatch + empty-set policy.
+func TestExecuteFlatpak_PerUserPresentNoSessions(t *testing.T) {
 	if _, err := exec.LookPath("flatpak"); err != nil {
-		t.Skip("flatpak is not available on this system — coercion warn fires after the lookup, so skip")
+		t.Skip("flatpak is not available on this system; the per-user empty-set branch fires after the lookup")
+	}
+	sessions, err := desktop.ActiveSessions(context.Background())
+	if err != nil {
+		t.Skipf("loginctl probe failed (%v) — skipping rather than asserting against an unknown session state", err)
+	}
+	if len(sessions) > 0 {
+		t.Skipf("host has %d active desktop session(s) — empty-set branch not reachable here", len(sessions))
 	}
 
 	var buf bytes.Buffer
 	e := NewExecutor(nil)
 	e.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	_, _, _ = e.executeFlatpak(context.Background(), &pb.FlatpakParams{
-		AppId:      "org.nonexistent.surely_does_not_exist_12345",
+	out, changed, err := e.executeFlatpak(context.Background(), &pb.FlatpakParams{
+		AppId:      "org.nonexistent.surely_does_not_exist_pmtest",
 		SystemWide: false,
 	}, pb.DesiredState_DESIRED_STATE_PRESENT)
 
-	got := buf.String()
-	if !strings.Contains(got, "level=WARN") {
-		t.Errorf("expected WARN-level coercion log when SystemWide=false, got:\n%s", got)
+	if err != nil {
+		t.Fatalf("expected no error on empty-session per-user install (no-op success), got: %v", err)
 	}
-	if !strings.Contains(got, "SystemWide=false coerced") {
-		t.Errorf("expected coercion warn body, got:\n%s", got)
+	if changed {
+		t.Errorf("expected changed=false on empty-session no-op, got changed=true")
 	}
-	if !strings.Contains(got, "org.nonexistent.surely_does_not_exist_12345") {
-		t.Errorf("expected app_id in the coercion warn so operators can locate the assignment, got:\n%s", got)
+	if out == nil || !strings.Contains(out.Stdout, "no signed-in desktop users") {
+		t.Errorf("expected stdout to explain the empty-set deferral, got: %#v", out)
+	}
+	if !strings.Contains(buf.String(), "level=WARN") {
+		t.Errorf("expected WARN log on per-user install with no signed-in users, got:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "deferred until a user signs in") {
+		t.Errorf("expected the warn body to explain the action will retry, got:\n%s", buf.String())
 	}
 }
 
-// TestExecuteFlatpak_SystemWideTrueDoesNotCoerce verifies the
-// happy-path stays silent — SystemWide=true is the supported config
-// and must not trigger the warn intended for the broken case.
-func TestExecuteFlatpak_SystemWideTrueDoesNotCoerce(t *testing.T) {
+// TestExecuteFlatpak_PerUserPresentDispatchesToLoop is the
+// complement to TestExecuteFlatpak_PerUserPresentNoSessions: when
+// graphical sessions are present, verify that the dispatch enters
+// the per-user fan-out path (rather than silently no-op'ing or
+// falling through to the system-wide branch). We don't assert on
+// the install succeeding — flatpak with a nonexistent app will
+// always fail, but the failure is per-user-shaped, which is what
+// pins the dispatch.
+func TestExecuteFlatpak_PerUserPresentDispatchesToLoop(t *testing.T) {
+	if _, err := exec.LookPath("flatpak"); err != nil {
+		t.Skip("flatpak is not available on this system")
+	}
+	sessions, err := desktop.ActiveSessions(context.Background())
+	if err != nil {
+		t.Skipf("loginctl probe failed (%v) — skipping rather than asserting against an unknown session state", err)
+	}
+	if len(sessions) == 0 {
+		t.Skip("no active desktop sessions — TestExecuteFlatpak_PerUserPresentNoSessions covers the empty-set path here")
+	}
+
+	e := NewExecutor(nil)
+	out, _, _ := e.executeFlatpak(context.Background(), &pb.FlatpakParams{
+		AppId:      "org.nonexistent.surely_does_not_exist_pmtest",
+		SystemWide: false,
+	}, pb.DesiredState_DESIRED_STATE_PRESENT)
+
+	// The per-user loop tags every line with `user=<name>: ...`. If
+	// we instead see the system-wide "is already installed" /
+	// "is already not installed" wording, the dispatch broke and
+	// SystemWide=false silently routed system-wide.
+	if out == nil || !strings.Contains(out.Stdout, "user=") {
+		t.Errorf("expected per-user fan-out output (lines tagged with user=<name>), got: %#v", out)
+	}
+}
+
+// TestExecuteFlatpak_PerUserAbsentNoUsers verifies the symmetric
+// empty-set path for ABSENT: if no /home/<user> on the box has the
+// app installed, the uninstall action is a success no-op (the
+// policy is already converged).
+func TestExecuteFlatpak_PerUserAbsentNoUsers(t *testing.T) {
 	if _, err := exec.LookPath("flatpak"); err != nil {
 		t.Skip("flatpak is not available on this system")
 	}
 
-	var buf bytes.Buffer
 	e := NewExecutor(nil)
-	e.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	out, changed, err := e.executeFlatpak(context.Background(), &pb.FlatpakParams{
+		AppId:      "org.nonexistent.surely_does_not_exist_pmtest",
+		SystemWide: false,
+	}, pb.DesiredState_DESIRED_STATE_ABSENT)
 
-	_, _, _ = e.executeFlatpak(context.Background(), &pb.FlatpakParams{
-		AppId:      "org.nonexistent.surely_does_not_exist_12345",
+	if err != nil {
+		t.Fatalf("expected no error on already-absent per-user uninstall, got: %v", err)
+	}
+	if changed {
+		t.Errorf("expected changed=false when nobody has the app installed, got changed=true")
+	}
+	if out == nil || !strings.Contains(out.Stdout, "already not installed") {
+		t.Errorf("expected stdout to confirm policy is already converged, got: %#v", out)
+	}
+}
+
+// TestExecuteFlatpak_SystemWideRoutesUnchanged sanity-checks that
+// SystemWide=true still flows through the original system path and
+// reports a real install error rather than no-op success — the
+// dispatch split (#79) must not silently swallow the system-wide
+// codepath.
+func TestExecuteFlatpak_SystemWideRoutesUnchanged(t *testing.T) {
+	if _, err := exec.LookPath("flatpak"); err != nil {
+		t.Skip("flatpak is not available on this system")
+	}
+
+	e := NewExecutor(nil)
+	out, _, err := e.executeFlatpak(context.Background(), &pb.FlatpakParams{
+		AppId:      "org.nonexistent.surely_does_not_exist_pmtest",
 		SystemWide: true,
 	}, pb.DesiredState_DESIRED_STATE_PRESENT)
 
-	if strings.Contains(buf.String(), "SystemWide=false coerced") {
-		t.Errorf("SystemWide=true must not trigger the coercion warn, got:\n%s", buf.String())
+	if out != nil && strings.Contains(out.Stdout, "no signed-in") {
+		t.Errorf("SystemWide=true must not enter the per-user empty-session branch; got %q", out.Stdout)
+	}
+	if err == nil {
+		t.Error("expected real install error for nonexistent app on SystemWide=true path, got nil")
 	}
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/manchtools/power-manage/agent/internal/store"
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/go/pkg"
+	"github.com/manchtools/power-manage/sdk/go/sys/desktop"
 	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
 	"github.com/manchtools/power-manage/sdk/go/verify"
 )
@@ -467,6 +468,17 @@ func (e *Executor) ExecuteWithStreaming(ctx context.Context, action *pb.Action, 
 // (sudo/doas + -n flag + absolute-path + backend-installed check)
 // so the agent stays consistent with the rest of the SDK's
 // privilege contract instead of hard-coding "sudo -n".
+//
+// RunAsRoot=false fans the script out to every active graphical
+// desktop session via desktop.ActiveSessions + runAsUserStreaming
+// (#79). Pre-fix this branch silently ran the script as the agent's
+// own UID (root in production) — exactly the bug profile that
+// SystemWide=false suffered for Flatpak. The new contract: an
+// admin who explicitly turns RunAsRoot off gets a per-user
+// execution, NOT a "still root, just without going through sudo"
+// fallback. Empty-set policy matches the Flatpak path: log Warn
+// and return success no-op so the next reconciliation tick retries
+// once a user signs in.
 func (e *Executor) runShellScript(ctx context.Context, params *pb.ShellParams, script string, callback OutputCallback) (*pb.CommandOutput, error) {
 	interpreter := params.Interpreter
 	if interpreter == "" {
@@ -506,7 +518,97 @@ func (e *Executor) runShellScript(ctx context.Context, params *pb.ShellParams, s
 		r, err := sysexec.PrivilegedStreaming(ctx, interpreter, args, envVars, params.WorkingDirectory, callback)
 		return toOutput(r), err
 	}
-	return runCmdStreaming(ctx, interpreter, args, envVars, params.WorkingDirectory, callback)
+	// RunAsRoot=false → per-user fan-out.
+	return e.runShellScriptPerUser(ctx, params, interpreter, args, envVars, callback)
+}
+
+// runShellScriptPerUser implements the RunAsRoot=false path: fans
+// the script over every active desktop session, prefixing each
+// streamed line with `[user=<name>] ` so the operator can attribute
+// output. Returns the merged output and the first per-user error
+// encountered (the loop continues on failure so one broken user
+// doesn't block the rest, matching the per-user Flatpak shape).
+//
+// The merged output's ExitCode is 0 if every user succeeded,
+// otherwise the first non-zero exit so the action result can still
+// drive the changed/failed bookkeeping in executeShellStreaming.
+func (e *Executor) runShellScriptPerUser(ctx context.Context, params *pb.ShellParams, interpreter string, args []string, envVars []string, callback OutputCallback) (*pb.CommandOutput, error) {
+	sessions, err := desktop.ActiveSessions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("enumerate active desktop sessions: %w", err)
+	}
+	if len(sessions) == 0 {
+		e.logger.Warn("shell RunAsRoot=false: no active desktop sessions; per-user run deferred until a user signs in")
+		return &pb.CommandOutput{
+			ExitCode: 0,
+			Stdout:   "skipped: no signed-in desktop users; will run again on next reconciliation",
+		}, nil
+	}
+
+	// Strip HOME / USER from the caller-supplied env baseline —
+	// desktop.EnvFor sets the per-user values inside
+	// runAsUserStreaming, and a duplicate from envVars would only
+	// confuse readers (Go's exec.Cmd takes the last occurrence,
+	// which is the per-user one, but the duplicates make the env
+	// list noisy in audit logs).
+	extraEnv := stripHomeAndUser(envVars)
+
+	merged := &pb.CommandOutput{}
+	var firstFailure error
+	for _, s := range sessions {
+		userPrefix := "[user=" + s.Username + "] "
+		var wrappedCB OutputCallback
+		if callback != nil {
+			wrappedCB = func(streamType sysexec.StreamType, line string, seq int64) {
+				callback(streamType, userPrefix+line, seq)
+			}
+		}
+		out, runErr := runAsUserStreaming(ctx, s, extraEnv, params.WorkingDirectory, interpreter, args, wrappedCB)
+		if out != nil {
+			if out.Stdout != "" {
+				merged.Stdout += userPrefix + out.Stdout
+				if !strings.HasSuffix(out.Stdout, "\n") {
+					merged.Stdout += "\n"
+				}
+			}
+			if out.Stderr != "" {
+				merged.Stderr += userPrefix + out.Stderr
+				if !strings.HasSuffix(out.Stderr, "\n") {
+					merged.Stderr += "\n"
+				}
+			}
+			if out.ExitCode != 0 && merged.ExitCode == 0 {
+				merged.ExitCode = out.ExitCode
+			}
+		}
+		if runErr != nil && firstFailure == nil {
+			firstFailure = fmt.Errorf("user %s: %w", s.Username, runErr)
+		}
+	}
+	return merged, firstFailure
+}
+
+// stripHomeAndUser drops HOME=/USER= entries from envVars. The
+// per-user runner sets these from the session, and leaving the
+// agent-derived defaults in extraEnv would only add noise (Go's
+// exec.Cmd uses last-write-wins so the per-user value still wins,
+// but the duplicates clutter audit logs and confuse reviewers).
+//
+// Allocates a fresh backing array rather than aliasing envVars
+// (envVars[:0:0]) — the [:0:0] form has zero capacity so an append
+// immediately reallocates and the aliasing is moot in practice,
+// but a future tweak toward [:0] or [:0:n] would silently start
+// mutating the caller's slice. Pin "no aliasing" explicitly so the
+// hazard can't creep back in.
+func stripHomeAndUser(envVars []string) []string {
+	out := make([]string, 0, len(envVars))
+	for _, kv := range envVars {
+		if strings.HasPrefix(kv, "HOME=") || strings.HasPrefix(kv, "USER=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
 }
 
 // executeShellStreaming executes a shell action with optional detection/execution/verification flow.

--- a/internal/executor/integration_test.go
+++ b/internal/executor/integration_test.go
@@ -449,9 +449,18 @@ func TestIntegration_Shell(t *testing.T) {
 	e := newTestExecutor()
 	ctx := context.Background()
 
+	// All integration tests below set RunAsRoot=true. Pre-#79
+	// RunAsRoot=false silently ran as the agent's UID (root in CI),
+	// which let these tests pass while exercising shell mechanics
+	// rather than the privilege model. Post-#79 RunAsRoot=false
+	// fans out per signed-in user — and CI containers without a
+	// graphical session no-op out of that path. Use RunAsRoot=true
+	// here so the tests still exercise the script execution they
+	// were written for; the privilege-routing tests are in their
+	// own files (action_flatpak_test.go, shell_per_user_test.go).
 	t.Run("BasicScript", func(t *testing.T) {
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT)
-		action.Params = &pb.Action_Shell{Shell: &pb.ShellParams{Script: "echo hello"}}
+		action.Params = &pb.Action_Shell{Shell: &pb.ShellParams{Script: "echo hello", RunAsRoot: true}}
 		result := e.Execute(ctx, action)
 		assertSuccess(t, result)
 		if !strings.Contains(safeStdout(result), "hello") {
@@ -461,7 +470,7 @@ func TestIntegration_Shell(t *testing.T) {
 
 	t.Run("NonZeroExit", func(t *testing.T) {
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT)
-		action.Params = &pb.Action_Shell{Shell: &pb.ShellParams{Script: "exit 42"}}
+		action.Params = &pb.Action_Shell{Shell: &pb.ShellParams{Script: "exit 42", RunAsRoot: true}}
 		result := e.Execute(ctx, action)
 		// Non-zero exit codes are treated as failures for shell actions.
 		// The exit code is captured in the output.
@@ -491,6 +500,7 @@ func TestIntegration_Shell(t *testing.T) {
 		action.Params = &pb.Action_Shell{Shell: &pb.ShellParams{
 			Script:      "echo $MY_TEST_VAR",
 			Environment: map[string]string{"MY_TEST_VAR": "test123"},
+			RunAsRoot:   true,
 		}}
 		result := e.Execute(ctx, action)
 		assertSuccess(t, result)
@@ -504,6 +514,7 @@ func TestIntegration_Shell(t *testing.T) {
 		action.Params = &pb.Action_Shell{Shell: &pb.ShellParams{
 			Script:           "pwd",
 			WorkingDirectory: "/tmp",
+			RunAsRoot:        true,
 		}}
 		result := e.Execute(ctx, action)
 		assertSuccess(t, result)
@@ -2938,7 +2949,8 @@ func TestIntegration_EdgeCase_ShellTimeout(t *testing.T) {
 
 	action := makeAction(t, pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT)
 	action.Params = &pb.Action_Shell{Shell: &pb.ShellParams{
-		Script: "sleep 30",
+		Script:    "sleep 30",
+		RunAsRoot: true,
 	}}
 	action.TimeoutSeconds = 2
 
@@ -3447,7 +3459,8 @@ func TestIntegration_EdgeCase_LargeShellOutput(t *testing.T) {
 		// Generate ~2MB of output
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT)
 		action.Params = &pb.Action_Shell{Shell: &pb.ShellParams{
-			Script: "dd if=/dev/zero bs=1024 count=2048 | tr '\\0' 'A'",
+			Script:    "dd if=/dev/zero bs=1024 count=2048 | tr '\\0' 'A'",
+			RunAsRoot: true,
 		}}
 		action.TimeoutSeconds = 30
 		result := e.Execute(ctx, action)
@@ -3458,7 +3471,8 @@ func TestIntegration_EdgeCase_LargeShellOutput(t *testing.T) {
 		// Generate ~1MB of stderr output
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT)
 		action.Params = &pb.Action_Shell{Shell: &pb.ShellParams{
-			Script: "dd if=/dev/zero bs=1024 count=1024 | tr '\\0' 'E' >&2",
+			Script:    "dd if=/dev/zero bs=1024 count=1024 | tr '\\0' 'E' >&2",
+			RunAsRoot: true,
 		}}
 		action.TimeoutSeconds = 30
 		result := e.Execute(ctx, action)
@@ -3469,7 +3483,8 @@ func TestIntegration_EdgeCase_LargeShellOutput(t *testing.T) {
 		// Rapidly alternate between stdout and stderr
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT)
 		action.Params = &pb.Action_Shell{Shell: &pb.ShellParams{
-			Script: `for i in $(seq 1 1000); do echo "stdout line $i"; echo "stderr line $i" >&2; done`,
+			Script:    `for i in $(seq 1 1000); do echo "stdout line $i"; echo "stderr line $i" >&2; done`,
+			RunAsRoot: true,
 		}}
 		action.TimeoutSeconds = 30
 		result := e.Execute(ctx, action)

--- a/internal/executor/per_user.go
+++ b/internal/executor/per_user.go
@@ -1,0 +1,108 @@
+// per_user.go — agent-side wrappers around sdk/go/sys/desktop's
+// per-user fan-out. The package-local helpers convert between the
+// SDK's *exec.Cmd shape and the agent's *pb.CommandOutput shape so
+// per-user execution paths match the existing runSudoCmd ergonomics
+// instead of forcing every caller to learn a parallel API.
+package executor
+
+import (
+	"bytes"
+	"context"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/sys/desktop"
+	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// runuserPath mirrors desktop.runuserPath. Pinned here as well so a
+// future move of the runuser invocation off the helper layer (e.g.
+// streaming variant below) doesn't have to import the SDK constant.
+const runuserPath = "/usr/sbin/runuser"
+
+// runAsUserCmd runs `name args...` as the user owning the given
+// session and returns the result as a *pb.CommandOutput, matching
+// runSudoCmd's signature so per-user call sites don't need a
+// different result-handling path.
+//
+// Caller-supplied extraEnv is merged on top of the desktop default
+// env (HOME / USER / LOGNAME / XDG_RUNTIME_DIR / DBUS_SESSION_BUS_ADDRESS);
+// duplicate keys win on the extraEnv side, matching Go's exec.Cmd
+// last-write-wins semantics. Pass nil for extraEnv when the
+// desktop defaults suffice.
+func runAsUserCmd(ctx context.Context, s desktop.Session, extraEnv []string, name string, args ...string) (*pb.CommandOutput, error) {
+	cmd, err := desktop.RunAsCommand(ctx, s, extraEnv, name, args...)
+	if err != nil {
+		return nil, err
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	out := &pb.CommandOutput{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}
+	if cmd.ProcessState != nil {
+		out.ExitCode = int32(cmd.ProcessState.ExitCode())
+	}
+	return out, runErr
+}
+
+// runAsUserCheck runs `name args...` as the given session's user
+// and reports whether the command exited 0. Mirrors checkCmdSuccess
+// for the per-user execution path — used for "is X installed for
+// this user" idempotency probes where stdout/stderr would be
+// discarded anyway.
+//
+// A failure to construct the command (zero-value session, etc.) is
+// reported as "false" rather than a separate error path because the
+// callers (idempotency checks) treat any inability-to-determine as
+// "not installed, attempt the install."
+func runAsUserCheck(ctx context.Context, s desktop.Session, name string, args ...string) bool {
+	cmd, err := desktop.RunAsCommand(ctx, s, nil, name, args...)
+	if err != nil {
+		return false
+	}
+	return cmd.Run() == nil
+}
+
+// runAsUserStreaming runs `name args...` as the given session's user
+// with real-time line-streaming via callback, mirroring
+// runCmdStreaming for the per-user execution path. The wrapper
+// builds `runuser -u <user> -- <name> <args...>` and hands the
+// resulting args + env (desktop defaults plus extraEnv) to the
+// SDK's RunStreaming so callers don't need a separate streaming
+// pipeline implementation.
+//
+// The callback receives lines tagged with the underlying child's
+// stream type (stdout/stderr); if the caller wants to multiplex
+// multiple users into one stream they should wrap the callback to
+// prepend a per-user prefix before forwarding.
+func runAsUserStreaming(ctx context.Context, s desktop.Session, extraEnv []string, dir string, name string, args []string, callback OutputCallback) (*pb.CommandOutput, error) {
+	if name == "" {
+		return nil, errEmptyName
+	}
+	if s.Username == "" {
+		return nil, errEmptyUsername
+	}
+	full := append([]string{"-u", s.Username, "--", name}, args...)
+	env := append(desktop.EnvFor(s), extraEnv...)
+	if dir == "" {
+		dir = s.Home
+	}
+	r, err := sysexec.RunStreaming(ctx, runuserPath, full, env, dir, callback)
+	return toOutput(r), err
+}
+
+// errEmptyName / errEmptyUsername are sentinel errors so the
+// callers can distinguish "caller bug" from "runuser execution
+// failure." Pinned as vars rather than fmt.Errorf'd inline so a
+// test can errors.Is() against them without string matching.
+var (
+	errEmptyName     = errPerUser("name is required")
+	errEmptyUsername = errPerUser("session has empty Username")
+)
+
+type errPerUser string
+
+func (e errPerUser) Error() string { return "executor.runAsUserStreaming: " + string(e) }

--- a/internal/executor/shell_per_user_test.go
+++ b/internal/executor/shell_per_user_test.go
@@ -1,0 +1,137 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/sys/desktop"
+)
+
+// TestRunShellScript_RunAsRootFalseNoSessions pins the empty-set
+// policy for #79's shell fan-out: when RunAsRoot=false and nobody
+// is signed in, the action returns success no-op + a Warn rather
+// than the pre-fix "silently runs as the agent's UID (root)"
+// behavior. Without this guard an admin who turned off RunAsRoot
+// would still see effectively-root behavior with no diagnostic.
+func TestRunShellScript_RunAsRootFalseNoSessions(t *testing.T) {
+	sessions, err := desktop.ActiveSessions(context.Background())
+	if err != nil {
+		t.Skipf("loginctl probe failed (%v) — skipping rather than asserting against an unknown session state", err)
+	}
+	if len(sessions) > 0 {
+		t.Skipf("host has %d active desktop session(s) — empty-set branch not reachable here", len(sessions))
+	}
+
+	var buf bytes.Buffer
+	e := NewExecutor(nil)
+	e.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	out, err := e.runShellScript(context.Background(), &pb.ShellParams{
+		Script:    "echo hello",
+		RunAsRoot: false,
+	}, "echo hello", nil)
+
+	if err != nil {
+		t.Fatalf("expected no error on empty-session per-user shell (no-op success), got: %v", err)
+	}
+	if out == nil || !strings.Contains(out.Stdout, "no signed-in desktop users") {
+		t.Errorf("expected stdout to explain the empty-set deferral, got: %#v", out)
+	}
+	if !strings.Contains(buf.String(), "level=WARN") {
+		t.Errorf("expected WARN log on per-user shell with no signed-in users, got:\n%s", buf.String())
+	}
+}
+
+// TestRunShellScript_RunAsRootFalseDispatchesToLoop is the
+// complement when sessions ARE present: verify the script actually
+// runs per-user and the streamed output is tagged with a
+// `[user=<name>] ` prefix so downstream log consumers can attribute
+// lines back to the right account. We don't pin the script's
+// stdout content — the goal is to pin the prefix shape and confirm
+// the dispatch reached the per-user runner at all.
+func TestRunShellScript_RunAsRootFalseDispatchesToLoop(t *testing.T) {
+	if os.Geteuid() != 0 {
+		// runuser requires root to switch users — without it the
+		// per-user fan-out fails before any script output reaches
+		// us. The agent runs as root in production so this test
+		// exercises real behavior in privileged CI; locally a
+		// developer sees a skip rather than a meaningless failure.
+		t.Skip("runuser requires root to switch users; run this test under privileged CI")
+	}
+	sessions, err := desktop.ActiveSessions(context.Background())
+	if err != nil {
+		t.Skipf("loginctl probe failed (%v)", err)
+	}
+	if len(sessions) == 0 {
+		t.Skip("no active desktop sessions — TestRunShellScript_RunAsRootFalseNoSessions covers the empty-set path here")
+	}
+
+	e := NewExecutor(nil)
+	out, err := e.runShellScript(context.Background(), &pb.ShellParams{
+		// `id -un` prints the username; if the per-user fan-out
+		// works, the merged stdout will contain the desktop user's
+		// name, NOT root. That difference is the load-bearing
+		// behavioral pin for #79 — exactly the bug the fix
+		// addresses.
+		Script:    "id -un",
+		RunAsRoot: false,
+	}, "id -un", nil)
+
+	if err != nil {
+		// Per-user execution can fail if runuser isn't available
+		// (extremely unusual) or if PAM rejects the impersonation —
+		// but the dispatch path is what we're pinning here, not the
+		// happy-path end-to-end execution. Surface the failure but
+		// don't abort the assertion below.
+		t.Logf("per-user shell execution returned error (still asserting dispatch shape): %v", err)
+	}
+	if out == nil {
+		t.Fatal("expected non-nil output from per-user dispatch")
+	}
+	if !strings.Contains(out.Stdout, "[user=") {
+		t.Errorf("expected per-user prefix `[user=<name>] ` in merged stdout, got: %q", out.Stdout)
+	}
+	if strings.Contains(out.Stdout, "[user=root]") {
+		t.Errorf("RunAsRoot=false must NOT impersonate root via the per-user fan-out path; output was: %q", out.Stdout)
+	}
+}
+
+// TestStripHomeAndUser pins the env-cleanup helper that runs before
+// per-user fan-out: HOME/USER from the agent's env baseline are
+// dropped because runAsUserStreaming sets per-user values via
+// desktop.EnvFor. Pin the absence so a future refactor doesn't
+// regress and start sending mismatched HOME/USER pairs (the
+// per-user one wins via Go's last-write-wins, but the duplicate is
+// noise in audit logs and confuses reviewers).
+func TestStripHomeAndUser(t *testing.T) {
+	in := []string{
+		"PATH=/usr/bin:/bin",
+		"HOME=/root",
+		"LANG=en_US.UTF-8",
+		"USER=root",
+		"FLATPAK_USER_DIR=/foo",
+	}
+	got := stripHomeAndUser(in)
+	for _, e := range got {
+		if strings.HasPrefix(e, "HOME=") {
+			t.Errorf("HOME entry survived strip: %q (full: %v)", e, got)
+		}
+		if strings.HasPrefix(e, "USER=") {
+			t.Errorf("USER entry survived strip: %q (full: %v)", e, got)
+		}
+	}
+	want := []string{"PATH=/usr/bin:/bin", "LANG=en_US.UTF-8", "FLATPAK_USER_DIR=/foo"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries after strip, want %d (got=%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the placeholder coercion-to-system-wide path that shipped with the v2026.06 polish bundle (#87). Both Flatpak \`SystemWide=false\` and shell \`RunAsRoot=false\` now fan out to actual desktop users via the new \`sdk/go/sys/desktop\` primitives — exactly the bug profile that surfaced as #79.

The proto contract is unchanged; this is a pure agent-runtime fix that finally makes those booleans behave the way operators have always assumed.

## Behavior

### Flatpak (\`action_flatpak.go\`)

| Scope | Behavior |
| --- | --- |
| \`SystemWide=true\` | Original system-wide install path — unchanged. |
| \`SystemWide=false\` PRESENT | \`desktop.ActiveSessions\` → loop \`flatpak --user info\`+\`install\` per signed-in user. Pin (mask) fans out the same way. |
| \`SystemWide=false\` ABSENT | \`desktop.UsersWithFlatpakInstall(appID)\` → loop \`flatpak --user uninstall\` per real user with the app installed under \`~/.local/share/flatpak/\`. |
| Empty session set on PRESENT | success no-op + Warn ("deferred until a user signs in"). |
| Empty install set on ABSENT | success no-op (policy already converged). |

The asymmetry is deliberate: install needs a live session (the user wants to see the new app immediately), uninstall must reach dormant accounts to converge the policy.

### Shell / Script (\`executor.go\`)

| Scope | Behavior |
| --- | --- |
| \`RunAsRoot=true\` | Existing privileged path — unchanged. |
| \`RunAsRoot=false\` | \`desktop.ActiveSessions\` → loop \`runuser -u <user> -- <interpreter> -c <script>\` per session. Each streamed line is tagged with \`[user=<name>] \` for log attribution. Merged exit code = first non-zero. First per-user error is returned but the loop continues — one broken user shouldn't block the rest. |
| Empty session set | success no-op + Warn (same shape as Flatpak). |

Pre-fix \`RunAsRoot=false\` silently ran the script as the agent's own UID (root in production) — which is exactly the same class of bug as Flatpak's \`SystemWide=false\` writing to \`/root/.local/share/flatpak\`.

## Helpers (\`per_user.go\`)

- \`runAsUserCmd\` / \`runAsUserCheck\` — per-user equivalents of \`runSudoCmd\` / \`checkCmdSuccess\` so call sites don't have to learn a parallel API.
- \`runAsUserStreaming\` — agent-side assembly of the SDK's \`RunStreaming\` with \`desktop.EnvFor\` and \`runuser\`, used by the shell fan-out for line-by-line streaming.
- \`stripHomeAndUser\` — drops the agent-baseline \`HOME\`/\`USER\` from shell extraEnv so per-user values from \`desktop.EnvFor\` aren't shadowed by stale duplicates.

## SDK pin

Bumped to \`e2168be4d3c5\` (SDK PR #67 — adds \`sdk/go/sys/desktop\`).

## Test plan

- [x] \`go test -count=1 -short ./internal/executor/\` — green (4 new test cases for the dispatch + empty-set policy + helper)
  - \`TestExecuteFlatpak_PerUserPresentNoSessions\` (skip when sessions present)
  - \`TestExecuteFlatpak_PerUserPresentDispatchesToLoop\` (skip when no sessions)
  - \`TestExecuteFlatpak_PerUserAbsentNoUsers\`
  - \`TestExecuteFlatpak_SystemWideRoutesUnchanged\`
  - \`TestRunShellScript_RunAsRootFalseNoSessions\`
  - \`TestRunShellScript_RunAsRootFalseDispatchesToLoop\` (skip when not root — runuser can't impersonate without it)
  - \`TestStripHomeAndUser\`
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l .\` clean
- [x] \`cr review --plain --base main\` — 1 finding (slice-init clarity in \`stripHomeAndUser\`) addressed in this PR; one false positive (path traversal on \`WorkingDirectory\`) skipped because the field doesn't sandbox an arbitrary admin script anyway

## Out of scope

- File action user-scoping — same pattern would apply (\`runuser -u <user> -- tee /home/.../foo.conf\`) but the file action's design (path-based, not user-context-based) needs a small UX decision first. Tracked separately.
- Per-user detection-script semantics for the shell action (run detection per-user, only remediate users where it failed). The current change runs everyone through the same detection/remediation loop matching the existing shape; a smarter per-user detection split is follow-up work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-user Flatpak install/uninstall with system-wide vs per-user routing.
  * Per-user execution of shell scripts when not running as root, with per-session output aggregation.
  * Automatic detection of active desktop sessions to target per-user actions.

* **Chores**
  * Updated SDK module version pinning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-agent/pull/88)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->