### PR TITLE
sec: F-31 verify CA signature on instant actions (REBOOT/SYNC)

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -306,8 +306,18 @@ func (e *Executor) ExecuteWithStreaming(ctx context.Context, action *pb.Action, 
 		defer cancel()
 	}
 
-	// Verify action signature before execution (skip for instant actions — they have no params to sign)
-	if e.verifier != nil && !IsInstantAction(action.Type) {
+	// Verify action signature before execution (audit F-31). Every
+	// action — including instant actions REBOOT and SYNC — must
+	// carry a CA-signature. Pre-fix, instant actions skipped this
+	// check entirely, which made the F-02 Asynq exploit chain
+	// (compromised Valkey → forged ActionDispatchPayload with type=
+	// REBOOT) survive even after task envelopes were HMAC'd: a
+	// compromised gateway would still pass an unsigned REBOOT
+	// through. The control server now signs instant actions with
+	// canonical paramsJSON `{}` so the agent's verifier uses the
+	// same (id, type, paramsCanonical) tuple as for regular
+	// actions — no protocol change, just no special-casing.
+	if e.verifier != nil {
 		actionID := getActionID(action)
 		if verifyErr := e.verifier.Verify(actionID, int32(action.Type), action.ParamsCanonical, action.Signature); verifyErr != nil {
 			result.Status = pb.ExecutionStatus_EXECUTION_STATUS_FAILED


### PR DESCRIPTION
## Summary

Agent half of the F-31 fix from `SECURITY_AUDIT.md`. Removes the `!IsInstantAction(...)` carve-out in the action-signature verifier so REBOOT and SYNC now go through the same CA-signed check as every other action type.

## Threat closed

Pre-fix, the executor skipped signature verification for REBOOT and SYNC. Combined with the F-02 Asynq exploit chain (compromised Valkey or gateway → forged `ActionDispatchPayload` with `type=REBOOT`), this left a "reboot any agent at will" primitive even after the F-02 task-envelope HMAC closed the queue boundary — a gateway compromise would still pass an unsigned REBOOT through.

The matching server PR signs instant actions with canonical paramsJSON `{}`, so the agent's verifier reuses the existing `(id, type, paramsCanonical, sig)` tuple. No proto change, no new helper — just removing the skip.

## ⚠️ Merge order

**This PR MUST merge AFTER the matching server PR (manchtools/power-manage-server PR #313).** Otherwise agents will reject all REBOOT/SYNC dispatches from the not-yet-updated control instance.

For deployments that can't coordinate precisely: server-side signing is a strict superset of the prior wire shape, so older agents keep working unchanged — the agent rollout can lag by one release window.

`IsInstantAction` is kept (still used by scheduler paths that distinguish parameterless actions for non-signature concerns); only the verifier skip is gone.

## Test plan

- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/executor/...` green
- [ ] CI: full Unit + Integration + CodeRabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced action signature verification to apply consistently across all action types, strengthening validation reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-agent/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->