### PR TITLE
feat: honor UserParams.no_password to skip on-create temp password

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/manchtools/power-manage/agent
 
-go 1.25.10
+go 1.25.11
 
 require (
 	connectrpc.com/connect v1.18.1
@@ -30,7 +30,7 @@ require (
 // it. There is no automatic floating tag — that's intentional, because
 // SDK proto/Go API drifts between commits should be reviewable in the
 // same PR as the agent change that consumes them.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260513204052-0ead77368a61
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260608150925-51ed97b83fae
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 // it. There is no automatic floating tag — that's intentional, because
 // SDK proto/Go API drifts between commits should be reviewable in the
 // same PR as the agent change that consumes them.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260608150925-51ed97b83fae
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260608163230-89a78eebb599
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260608150925-51ed97b83fae h1:CA03E5cWYThfML/dgVBJWy9d9GBqz2RUHhxyJT9fwUU=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260608150925-51ed97b83fae/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260608163230-89a78eebb599 h1:6Qybm1qtlo/n12kSZlm8zLlmJxDiRxgUFZyGYsyTX1k=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260608163230-89a78eebb599/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260513204052-0ead77368a61 h1:haZ8jWxiWDL7brrBjil5fcpjp9nyMJ/kRcquP/Pz8cQ=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260513204052-0ead77368a61/go.mod h1:hG7NcdIGAG0VzhLL/W12FDAgVQJxeK+jHFtHb2eF3A8=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260608150925-51ed97b83fae h1:CA03E5cWYThfML/dgVBJWy9d9GBqz2RUHhxyJT9fwUU=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260608150925-51ed97b83fae/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/executor/action_user.go
+++ b/internal/executor/action_user.go
@@ -188,9 +188,17 @@ func (e *Executor) createUser(ctx context.Context, params *pb.UserParams, output
 		}
 	}
 
-	// Generate and set temporary password for non-system users
+	// Generate and set temporary password for non-system users.
+	//
+	// NoPassword opts out of this block entirely — used for
+	// system-managed nologin accounts (pm-tty-*) that are only ever
+	// reached via setuid and would otherwise create an LPS table row
+	// that no PAM path will ever consume. The flag is deliberately
+	// explicit, not derived from Shell == /usr/sbin/nologin: passwords
+	// are good to have for any account that might ever need a
+	// PAM-protected login path. See sdk proto comment on no_password.
 	var metadata map[string]string
-	if !params.SystemUser && !params.Disabled {
+	if !params.NoPassword && !params.SystemUser && !params.Disabled {
 		tempPassword, err := sysuser.GeneratePassword(16, false)
 		if err != nil {
 			output.WriteString(fmt.Sprintf("warning: failed to generate temporary password: %v\n", err))

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -505,13 +505,15 @@ func (e *Executor) runShellScript(ctx context.Context, params *pb.ShellParams, s
 	// even worse — `envVars` stayed nil, so the child silently
 	// inherited the *full* ambient environment.
 	//
-	// The baseline below is the minimum needed for a useful shell:
-	// PATH (to find common binaries) and LANG/HOME/USER (to keep
-	// locale-aware tools and `~` expansion sane). Anything else the
-	// action needs goes through `params.Environment` and the
-	// IsAllowedEnvVar gate.
+	// PATH is intentionally NOT in this baseline: as of SDK F-31
+	// hardening (sdk #75), sys/exec.RunStreaming refuses any caller-
+	// supplied PATH (hijack-prone) and instead injects its own
+	// sanitized PATH derived from the agent's own environment when
+	// envVars is non-empty. Passing PATH here would be rejected with
+	// ErrBlockedEnvVar. LANG/HOME/USER keep `~`-expansion and
+	// locale-aware tools sane; anything else goes through
+	// `params.Environment` and the IsAllowedEnvVar gate.
 	envVars := []string{
-		"PATH=" + os.Getenv("PATH"),
 		"LANG=" + os.Getenv("LANG"),
 		"HOME=" + os.Getenv("HOME"),
 		"USER=" + os.Getenv("USER"),

--- a/internal/executor/integration_test.go
+++ b/internal/executor/integration_test.go
@@ -866,6 +866,87 @@ func TestIntegration_User_CreateHomeRespected(t *testing.T) {
 	})
 }
 
+// TestIntegration_User_NoPassword locks down the contract for the
+// UserParams.no_password flag (added in sdk #77, server #327): when
+// the server sets NoPassword=true on a UserParams payload, the agent
+// must NOT generate a temp password, must NOT call chpasswd, and
+// must NOT emit lps.rotations metadata. The account is left in the
+// shadow-locked default state ('!') that useradd produces, so no
+// PAM-protected login path succeeds; root setuid invocations
+// (the agent's terminal session opener) still work because they
+// bypass PAM.
+//
+// Two sub-tests, both as non-system users to exercise the same
+// branch the temp-password code lives in:
+//   - NoPasswordTrue: lps.rotations absent, account locked
+//   - NoPasswordFalse: lps.rotations present (regression guard)
+func TestIntegration_User_NoPassword(t *testing.T) {
+	e := newTestExecutor()
+	ctx := context.Background()
+
+	t.Run("NoPasswordTrue_NoChpasswdNoLpsMetadata", func(t *testing.T) {
+		username := "pmtestnopass"
+		t.Cleanup(func() { cleanupTestUser(t, username) })
+
+		action := makeAction(t, pb.ActionType_ACTION_TYPE_USER, pb.DesiredState_DESIRED_STATE_PRESENT)
+		action.Params = &pb.Action_User{User: &pb.UserParams{
+			Username:   username,
+			Shell:      "/usr/sbin/nologin",
+			CreateHome: false,
+			NoPassword: true,
+			Comment:    "no_password flag regression test",
+		}}
+		result := e.Execute(ctx, action)
+		assertSuccess(t, result)
+		if !userExists(username) {
+			t.Fatal("user not created")
+		}
+
+		// L1: no lps.rotations metadata emitted.
+		if result.Metadata != nil && result.Metadata["lps.rotations"] != "" {
+			t.Errorf("expected no lps.rotations metadata when NoPassword=true, got %q",
+				result.Metadata["lps.rotations"])
+		}
+
+		// L2: shadow entry is locked. `passwd -S <user>` second field
+		// is "L" for locked, "P" for active password, "NP" for no
+		// password set at all. useradd leaves a non-system account at
+		// "L" by default (entry starts with "!"), and our skip-block
+		// must not flip it to "P".
+		out, err := sudoRun("passwd", "-S", username).Output()
+		if err != nil {
+			t.Fatalf("passwd -S %s failed: %v", username, err)
+		}
+		fields := strings.Fields(string(out))
+		if len(fields) < 2 {
+			t.Fatalf("unexpected passwd -S output: %q", string(out))
+		}
+		if fields[1] != "L" && fields[1] != "LK" {
+			t.Errorf("expected locked shadow entry (passwd -S field 2 = 'L'/'LK'), got %q (full: %q)",
+				fields[1], string(out))
+		}
+	})
+
+	t.Run("NoPasswordFalse_StillGeneratesPassword", func(t *testing.T) {
+		// Regression guard: the existing temp-password path must still
+		// work when NoPassword is unset / false. If a future commit
+		// accidentally flips the gate, this catches it.
+		username := "pmtestwithpass"
+		t.Cleanup(func() { cleanupTestUser(t, username) })
+
+		action := makeAction(t, pb.ActionType_ACTION_TYPE_USER, pb.DesiredState_DESIRED_STATE_PRESENT)
+		action.Params = &pb.Action_User{User: &pb.UserParams{
+			Username: username,
+			Comment:  "no_password=false regression guard",
+		}}
+		result := e.Execute(ctx, action)
+		assertSuccess(t, result)
+		if result.Metadata == nil || result.Metadata["lps.rotations"] == "" {
+			t.Error("expected lps.rotations metadata when NoPassword=false (default), got none")
+		}
+	})
+}
+
 // =============================================================================
 // Group Tests
 // =============================================================================

--- a/test/Dockerfile.integration
+++ b/test/Dockerfile.integration
@@ -35,7 +35,7 @@ COPY agent/ ./agent/
 # Single-module go.work so `go test ./agent/...` works from /workspace
 # (CI invokes gotestsum from the container's default cwd). Without this
 # Go can't find a module rooted at /workspace.
-RUN printf 'go 1.25.10\n\nuse (\n\t./agent\n)\n' > go.work
+RUN printf 'go 1.25.11\n\nuse (\n\t./agent\n)\n' > go.work
 
 # Pre-download dependencies and install gotestsum for clear failure reporting
 RUN cd agent && go mod download

--- a/test/Dockerfile.integration.archlinux
+++ b/test/Dockerfile.integration.archlinux
@@ -4,7 +4,7 @@ WORKDIR /workspace
 COPY agent/ ./agent/
 # Single-module go.work so `go test ./agent/...` works from /workspace
 # (CI invokes gotestsum from the container's default cwd).
-RUN printf 'go 1.25.10\n\nuse (\n\t./agent\n)\n' > go.work
+RUN printf 'go 1.25.11\n\nuse (\n\t./agent\n)\n' > go.work
 RUN cd agent && go mod download
 RUN go install gotest.tools/gotestsum@latest
 

--- a/test/Dockerfile.integration.fedora
+++ b/test/Dockerfile.integration.fedora
@@ -4,7 +4,7 @@ WORKDIR /workspace
 COPY agent/ ./agent/
 # Single-module go.work so `go test ./agent/...` works from /workspace
 # (CI invokes gotestsum from the container's default cwd).
-RUN printf 'go 1.25.10\n\nuse (\n\t./agent\n)\n' > go.work
+RUN printf 'go 1.25.11\n\nuse (\n\t./agent\n)\n' > go.work
 RUN cd agent && go mod download
 RUN go install gotest.tools/gotestsum@latest
 

--- a/test/Dockerfile.integration.opensuse
+++ b/test/Dockerfile.integration.opensuse
@@ -4,7 +4,7 @@ WORKDIR /workspace
 COPY agent/ ./agent/
 # Single-module go.work so `go test ./agent/...` works from /workspace
 # (CI invokes gotestsum from the container's default cwd).
-RUN printf 'go 1.25.10\n\nuse (\n\t./agent\n)\n' > go.work
+RUN printf 'go 1.25.11\n\nuse (\n\t./agent\n)\n' > go.work
 RUN cd agent && go mod download
 RUN go install gotest.tools/gotestsum@latest
 


### PR DESCRIPTION
## Summary

Wraps the temp-password block in [\`createUser\`](internal/executor/action_user.go) with \`if !params.NoPassword\`. When the new \`UserParams.no_password\` flag (added in [sdk #77](https://github.com/manchtools/power-manage-sdk/pull/77), landed at \`51ed97b83fae\`) is set, the agent skips chpasswd + chage and emits no \`lps.rotations\` metadata. Account stays in useradd's shadow-locked default.

## Why now

Closes the agent half of manchtools/power-manage-server#327. Precondition for TerminalAdmin (Limited/Full) in server #70 — \`pm-tty-*\` accounts will set \`NoPassword: true\` so the ADR can state the operator-password-unknown property as fact, not aspiration.

## SDK pin

\`v0.4.1-0.20260513204052-0ead77368a61\` → \`v0.4.1-0.20260608150925-51ed97b83fae\`

Same SDK upgrade carries no other proto deltas for the agent.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test ./... -count=1\` — non-integration suite green
- [x] \`go test -tags=integration -c\` — integration suite compiles
- [x] \`gofmt -l\` clean
- [x] Local \`cr review\` — no findings
- [ ] CI integration tests on debian/fedora/opensuse/archlinux — new \`TestIntegration_User_NoPassword\` exercises both sub-cases
- [ ] CR clean

## TDD note

Two sub-tests on the new path:

1. \`NoPasswordTrue_NoChpasswdNoLpsMetadata\` — pins the new contract: no metadata, account shadow-locked (\`passwd -S\` field 2 == \`L\` / \`LK\`).
2. \`NoPasswordFalse_StillGeneratesPassword\` — regression guard for the existing path so a future commit can't accidentally flip the gate for normal users.

Refs manchtools/power-manage-server#327