### PR TITLE
feat(executor): TerminalAdmin Limited/Full passwordless sudoers templates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 // it. There is no automatic floating tag — that's intentional, because
 // SDK proto/Go API drifts between commits should be reviewable in the
 // same PR as the agent change that consumes them.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260608163230-89a78eebb599
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260608193749-8a7b13b95072
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260608163230-89a78eebb599 h1:6Qybm1qtlo/n12kSZlm8zLlmJxDiRxgUFZyGYsyTX1k=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260608163230-89a78eebb599/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260608193749-8a7b13b95072 h1:/DIvYZjrZTtGgxI7Ny6j4eRxgGCeyFQ0U9+CFOazXpU=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260608193749-8a7b13b95072/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/executor/sudo.go
+++ b/internal/executor/sudo.go
@@ -54,20 +54,13 @@ func (e *Executor) setupSudoPolicy(ctx context.Context, params *pb.AdminPolicyPa
 		}
 	}
 
-	// Generate sudoers content
-	var content string
-	switch params.AccessLevel {
-	case pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_FULL:
-		content = generateFullSudoConfig(groupName)
-	case pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_LIMITED:
-		content = generateLimitedSudoConfig(groupName)
-	case pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_CUSTOM:
-		if params.CustomConfig == "" {
-			return nil, false, fmt.Errorf("custom_config is required when access_level is CUSTOM")
-		}
-		content = generateCustomSudoConfig(groupName, params.CustomConfig)
-	default:
-		return nil, false, fmt.Errorf("unsupported access level: %v", params.AccessLevel)
+	// Generate sudoers content. The switch is extracted into
+	// sudoConfigForParams so unit tests can pin the enum → template
+	// mapping without touching the filesystem / group-membership
+	// work this function does next.
+	content, err := sudoConfigForParams(params, groupName)
+	if err != nil {
+		return nil, false, err
 	}
 
 	// Check idempotency: file content + group membership
@@ -143,6 +136,142 @@ func (e *Executor) removeSudoPolicy(ctx context.Context, groupName, sudoersPath 
 // =============================================================================
 // Sudoers config generators
 // =============================================================================
+
+// sudoConfigForParams maps an AdminPolicyParams to the sudoers content
+// that setupSudoPolicy will write to disk. Extracted from
+// setupSudoPolicy so unit tests can pin the enum → template mapping
+// without standing up the surrounding filesystem / group-membership
+// work.
+//
+// The two TERMINAL_ADMIN_* arms route to passwordless templates
+// designed for pm-tty-* accounts (see manchtools/power-manage-server#70).
+// The pre-existing FULL/LIMITED/CUSTOM arms are unchanged — operator-
+// authored AdminPolicy actions continue to behave exactly as they did
+// before this PR.
+func sudoConfigForParams(params *pb.AdminPolicyParams, groupName string) (string, error) {
+	switch params.AccessLevel {
+	case pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_FULL:
+		return generateFullSudoConfig(groupName), nil
+	case pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_LIMITED:
+		return generateLimitedSudoConfig(groupName), nil
+	case pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_CUSTOM:
+		if params.CustomConfig == "" {
+			return "", fmt.Errorf("custom_config is required when access_level is CUSTOM")
+		}
+		return generateCustomSudoConfig(groupName, params.CustomConfig), nil
+	case pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_LIMITED:
+		return generateTerminalAdminLimitedSudoConfig(groupName), nil
+	case pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_FULL:
+		return generateTerminalAdminFullSudoConfig(groupName), nil
+	default:
+		return "", fmt.Errorf("unsupported access level: %v", params.AccessLevel)
+	}
+}
+
+// terminalAdminDefaultsBlock is the Defaults block both TERMINAL_ADMIN
+// templates emit at the top of their sudoers fragment. Per the ADR's
+// T4: requiretty pins TTY-stream input audit; env_reset stops
+// LD_PRELOAD / BASH_ENV / PATH propagation; !lecture skips the
+// operator-confusing first-time prompt; timestamp_timeout=0 forces
+// sudoers re-evaluation on every sudo call so a fresh revocation lands
+// immediately under NOPASSWD.
+const terminalAdminDefaultsBlock = `Defaults requiretty
+Defaults env_reset
+Defaults !lecture
+Defaults timestamp_timeout=0`
+
+// terminalAdminLimitedDenyBlocks are the !-deny rules the LIMITED
+// template emits to close ADR T2 (editor escapes), T3 (shell spawns),
+// and T5 (persistence vectors). Under NOPASSWD an escape vector in
+// the allowlist is unprompted root, so the deny rules are mandatory,
+// not advisory.
+func terminalAdminLimitedDenyBlocks(groupName string) []string {
+	return []string{
+		"",
+		"# Deny editor escapes (vim :!bash, less !sh, etc.) — ADR T2",
+		fmt.Sprintf("%%%s ALL=(ALL) !/usr/bin/vim, !/usr/bin/vi, !/usr/bin/vimdiff, !/usr/bin/view, !/usr/bin/nvim", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) !/usr/bin/emacs, !/usr/bin/emacsclient", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) !/usr/bin/nano, !/bin/nano", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) !/usr/bin/less, !/usr/bin/more, !/usr/bin/most", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) !/usr/bin/ed, !/usr/bin/ex", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) !/usr/bin/mc, !/usr/bin/joe, !/usr/bin/jed", groupName),
+		"",
+		"# Deny shell spawns — ADR T3",
+		fmt.Sprintf("%%%s ALL=(ALL) !/bin/sh, !/bin/bash, !/bin/dash, !/bin/zsh, !/bin/ksh, !/bin/csh, !/bin/tcsh, !/bin/fish", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) !/usr/bin/sh, !/usr/bin/bash, !/usr/bin/dash, !/usr/bin/zsh, !/usr/bin/ksh, !/usr/bin/csh, !/usr/bin/tcsh, !/usr/bin/fish", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) !/usr/bin/env", groupName),
+		"",
+		"# Deny persistence vectors — ADR T5",
+		fmt.Sprintf("%%%s ALL=(ALL) !/usr/bin/at, !/usr/bin/atq, !/usr/bin/atrm, !/usr/bin/batch", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) !/usr/bin/crontab", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) !/usr/sbin/dpkg-divert, !/usr/bin/dpkg-divert", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) !/usr/bin/update-alternatives, !/usr/sbin/update-alternatives", groupName),
+	}
+}
+
+// generateTerminalAdminLimitedSudoConfig is the LIMITED template for
+// the server's TerminalAdmin reconciler (#70). The allowlist mirrors
+// the existing generateLimitedSudoConfig content (package management,
+// systemd, network, disk, containers, diagnostics, agent-protection
+// denies) but every rule carries NOPASSWD: and the editor/shell/
+// persistence deny blocks land on top.
+func generateTerminalAdminLimitedSudoConfig(groupName string) string {
+	lines := []string{
+		"# Managed by Power Manage — do not edit manually",
+		fmt.Sprintf("# Passwordless LIMITED sudo for group %s (TerminalAdmin, server #70)", groupName),
+		"",
+		terminalAdminDefaultsBlock,
+		"",
+		"# Package management",
+		fmt.Sprintf("%%%s ALL=(ALL) NOPASSWD: /usr/bin/apt, /usr/bin/apt-get, /usr/bin/apt-cache, /usr/bin/dpkg", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) NOPASSWD: /usr/bin/dnf, /usr/bin/yum, /usr/bin/rpm", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) NOPASSWD: /usr/bin/pacman", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) NOPASSWD: /usr/bin/zypper", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) NOPASSWD: /usr/bin/flatpak, /usr/bin/snap", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) NOPASSWD: /usr/bin/nix, /usr/bin/nix-env, /usr/bin/nix-store, /usr/bin/nix-channel", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) NOPASSWD: /sbin/apk", groupName),
+		"",
+		"# Service and system management",
+		fmt.Sprintf("%%%s ALL=(ALL) NOPASSWD: /usr/bin/systemctl, /usr/bin/journalctl", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) NOPASSWD: /usr/sbin/reboot, /usr/sbin/shutdown", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) NOPASSWD: /usr/bin/timedatectl, /usr/bin/hostnamectl", groupName),
+		"",
+		"# Network management",
+		fmt.Sprintf("%%%s ALL=(ALL) NOPASSWD: /usr/bin/ip, /usr/bin/nmcli, /usr/bin/networkctl", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) NOPASSWD: /usr/sbin/ufw, /usr/bin/firewall-cmd", groupName),
+		"",
+		"# Disk and storage",
+		fmt.Sprintf("%%%s ALL=(ALL) NOPASSWD: /usr/bin/mount, /usr/bin/umount, /usr/sbin/blkid", groupName),
+		"",
+		"# Containers",
+		fmt.Sprintf("%%%s ALL=(ALL) NOPASSWD: /usr/bin/docker, /usr/bin/podman", groupName),
+		"",
+		"# Diagnostics",
+		fmt.Sprintf("%%%s ALL=(ALL) NOPASSWD: /usr/bin/dmesg", groupName),
+		"",
+		"# Deny modifications to power-manage-agent and sudoers",
+		fmt.Sprintf("%%%s ALL=(ALL) !!/usr/bin/systemctl * power-manage-agent*", groupName),
+		fmt.Sprintf("%%%s ALL=(ALL) !!/usr/bin/visudo, !!/usr/sbin/visudo", groupName),
+	}
+	lines = append(lines, terminalAdminLimitedDenyBlocks(groupName)...)
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// generateTerminalAdminFullSudoConfig is the FULL template for
+// TerminalAdmin (#70). Single ALL=(ALL:ALL) NOPASSWD: ALL grant
+// preceded by the same Defaults block as the Limited template — the
+// Defaults block applies regardless of access level.
+func generateTerminalAdminFullSudoConfig(groupName string) string {
+	lines := []string{
+		"# Managed by Power Manage — do not edit manually",
+		fmt.Sprintf("# Passwordless FULL sudo for group %s (TerminalAdmin, server #70)", groupName),
+		"",
+		terminalAdminDefaultsBlock,
+		"",
+		fmt.Sprintf("%%%s ALL=(ALL:ALL) NOPASSWD: ALL", groupName),
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
 
 func generateFullSudoConfig(groupName string) string {
 	lines := []string{

--- a/internal/executor/sudo_test.go
+++ b/internal/executor/sudo_test.go
@@ -1,0 +1,253 @@
+package executor
+
+// TerminalAdmin sudoers template coverage —
+// manchtools/power-manage-server#70.
+//
+// This file covers ONLY the two new server-managed templates added
+// alongside the new AdminAccessLevel enum values. The existing
+// generateLimitedSudoConfig / generateFullSudoConfig / generateCustomSudoConfig
+// generators are deliberately untouched by #70 and stay untested in
+// this PR — that's separate test-coverage work.
+//
+// The two new templates exist because the operator-authored
+// FULL/LIMITED templates assume a password-bearing account; pm-tty-*
+// accounts (#327) are passwordless, so the server's TerminalAdmin
+// reconciler points the two global AdminPolicy actions at these new
+// templates instead. The ADR (server/docs/adr/0000-terminal-admin-
+// threat-model.md) is the authoritative contract for what they must
+// reject.
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+const testTerminalAdminGroup = "pm-sudo-test"
+
+// =============================================================================
+// generateTerminalAdminLimitedSudoConfig — passwordless LIMITED.
+// =============================================================================
+
+func TestGenerateTerminalAdminLimitedSudoConfig_GroupInterpolation(t *testing.T) {
+	out := generateTerminalAdminLimitedSudoConfig(testTerminalAdminGroup)
+	assert.Contains(t, out, "%"+testTerminalAdminGroup+" ALL=",
+		"the passed group name must appear in every rule")
+}
+
+// ADR T1: every command rule must carry NOPASSWD so the passwordless
+// pm-tty-* account can use the allowlist at all. Without it the
+// template is unusable — the operator has no password to type.
+func TestGenerateTerminalAdminLimitedSudoConfig_NOPASSWD(t *testing.T) {
+	out := generateTerminalAdminLimitedSudoConfig(testTerminalAdminGroup)
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		// Defaults lines and deny rules don't need NOPASSWD; only
+		// affirmative command grants do.
+		if !strings.HasPrefix(trimmed, "%"+testTerminalAdminGroup) {
+			continue
+		}
+		// A grant line is of the form `%group ALL=(ALL) <stuff>`. If
+		// the <stuff> starts with `!` it's a deny block and doesn't
+		// need NOPASSWD. Otherwise NOPASSWD: must appear before the
+		// command list.
+		runspec := strings.SplitN(trimmed, "ALL=(ALL)", 2)
+		if len(runspec) != 2 {
+			t.Fatalf("unexpected rule shape: %q", line)
+		}
+		body := strings.TrimSpace(runspec[1])
+		if strings.HasPrefix(body, "!") {
+			continue // deny rule
+		}
+		assert.True(t, strings.HasPrefix(body, "NOPASSWD:"),
+			"affirmative grant must start with NOPASSWD: — %q", line)
+	}
+}
+
+// ADR T4: Defaults block must pin requiretty, env_reset, !lecture,
+// and timestamp_timeout=0. The last forces sudoers re-evaluation on
+// every sudo call so a fresh revocation lands immediately under
+// NOPASSWD.
+func TestGenerateTerminalAdminLimitedSudoConfig_DefaultsBlock(t *testing.T) {
+	out := generateTerminalAdminLimitedSudoConfig(testTerminalAdminGroup)
+	for _, want := range []string{
+		"Defaults requiretty",
+		"Defaults env_reset",
+		"Defaults !lecture",
+		"Defaults timestamp_timeout=0",
+	} {
+		assert.Contains(t, out, want,
+			"ADR T4: Defaults block must include %q", want)
+	}
+}
+
+// ADR T2: editor escapes (vim → :!bash etc.) MUST be denied — under
+// NOPASSWD a missed editor in the allowlist is unprompted root.
+func TestGenerateTerminalAdminLimitedSudoConfig_DeniesEditors(t *testing.T) {
+	out := generateTerminalAdminLimitedSudoConfig(testTerminalAdminGroup)
+	// Per ADR T2: vim, vi, vimdiff, view, nvim, emacs, emacsclient,
+	// nano, less, more, most, ed, ex, mc, joe, jed.
+	editors := []string{
+		"/usr/bin/vim", "/usr/bin/vi", "/usr/bin/vimdiff", "/usr/bin/view", "/usr/bin/nvim",
+		"/usr/bin/emacs", "/usr/bin/emacsclient",
+		"/usr/bin/nano", "/bin/nano",
+		"/usr/bin/less", "/usr/bin/more", "/usr/bin/most",
+		"/usr/bin/ed", "/usr/bin/ex",
+		"/usr/bin/mc", "/usr/bin/joe", "/usr/bin/jed",
+	}
+	for _, editor := range editors {
+		assert.Contains(t, out, "!"+editor,
+			"ADR T2: editor %s must appear in the deny block", editor)
+	}
+}
+
+// ADR T3: shell spawns must be denied.
+func TestGenerateTerminalAdminLimitedSudoConfig_DeniesShells(t *testing.T) {
+	out := generateTerminalAdminLimitedSudoConfig(testTerminalAdminGroup)
+	shells := []string{
+		"/bin/sh", "/bin/bash", "/bin/dash", "/bin/zsh", "/bin/ksh", "/bin/csh", "/bin/tcsh", "/bin/fish",
+		"/usr/bin/sh", "/usr/bin/bash", "/usr/bin/dash", "/usr/bin/zsh", "/usr/bin/ksh", "/usr/bin/csh", "/usr/bin/tcsh", "/usr/bin/fish",
+		"/usr/bin/env",
+	}
+	for _, shell := range shells {
+		assert.Contains(t, out, "!"+shell,
+			"ADR T3: shell %s must appear in the deny block", shell)
+	}
+}
+
+// ADR T5: persistence vectors (at, crontab, dpkg-divert,
+// update-alternatives) must be denied.
+func TestGenerateTerminalAdminLimitedSudoConfig_DeniesPersistenceVectors(t *testing.T) {
+	out := generateTerminalAdminLimitedSudoConfig(testTerminalAdminGroup)
+	vectors := []string{
+		"/usr/bin/at", "/usr/bin/atq", "/usr/bin/atrm", "/usr/bin/batch",
+		"/usr/bin/crontab",
+		"/usr/sbin/dpkg-divert", "/usr/bin/dpkg-divert",
+		"/usr/bin/update-alternatives", "/usr/sbin/update-alternatives",
+	}
+	for _, vector := range vectors {
+		assert.Contains(t, out, "!"+vector,
+			"ADR T5: persistence vector %s must appear in the deny block", vector)
+	}
+}
+
+// =============================================================================
+// generateTerminalAdminFullSudoConfig — passwordless FULL.
+// =============================================================================
+
+func TestGenerateTerminalAdminFullSudoConfig_GroupInterpolation(t *testing.T) {
+	out := generateTerminalAdminFullSudoConfig(testTerminalAdminGroup)
+	assert.Contains(t, out, "%"+testTerminalAdminGroup,
+		"the passed group name must appear in the rule")
+}
+
+// ADR: Full template grants ALL=(ALL:ALL) NOPASSWD: ALL.
+func TestGenerateTerminalAdminFullSudoConfig_NOPASSWD_ALL(t *testing.T) {
+	out := generateTerminalAdminFullSudoConfig(testTerminalAdminGroup)
+	assert.Contains(t, out, "%"+testTerminalAdminGroup+" ALL=(ALL:ALL) NOPASSWD: ALL",
+		"FULL template must grant ALL=(ALL:ALL) NOPASSWD: ALL")
+}
+
+// The Defaults block applies to FULL too — audit and TTY constraints
+// are the same regardless of access level.
+func TestGenerateTerminalAdminFullSudoConfig_DefaultsBlock(t *testing.T) {
+	out := generateTerminalAdminFullSudoConfig(testTerminalAdminGroup)
+	for _, want := range []string{
+		"Defaults requiretty",
+		"Defaults env_reset",
+		"Defaults !lecture",
+		"Defaults timestamp_timeout=0",
+	} {
+		assert.Contains(t, out, want,
+			"ADR T4: Defaults block must apply to FULL as well — missing %q", want)
+	}
+}
+
+// =============================================================================
+// Switch wiring: the two new enum values route to the new generators.
+// =============================================================================
+
+// TestSetupSudoPolicy_RoutesTerminalAdminLimitedEnumToNewGenerator pins
+// the switch arm in setupSudoPolicy: the new enum value must select
+// the new generator, NOT the existing LIMITED template (which requires
+// a password and is unusable through pm-tty-* accounts).
+func TestSetupSudoPolicy_RoutesTerminalAdminLimitedEnumToNewGenerator(t *testing.T) {
+	out := contentForAccessLevel(t, pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_LIMITED)
+	want := generateTerminalAdminLimitedSudoConfig(testTerminalAdminGroup)
+	assert.Equal(t, want, out,
+		"AccessLevel=TERMINAL_ADMIN_LIMITED must select the new passwordless generator, not the existing LIMITED template")
+}
+
+func TestSetupSudoPolicy_RoutesTerminalAdminFullEnumToNewGenerator(t *testing.T) {
+	out := contentForAccessLevel(t, pb.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_FULL)
+	want := generateTerminalAdminFullSudoConfig(testTerminalAdminGroup)
+	assert.Equal(t, want, out,
+		"AccessLevel=TERMINAL_ADMIN_FULL must select the new passwordless generator, not the existing FULL template")
+}
+
+// contentForAccessLevel exercises sudoConfigForParams (the dispatch
+// function the switch in setupSudoPolicy now uses) directly so the
+// test isn't entangled with the filesystem / group-membership work
+// the surrounding setupSudoPolicy does.
+func contentForAccessLevel(t *testing.T, level pb.AdminAccessLevel) string {
+	t.Helper()
+	params := &pb.AdminPolicyParams{
+		AccessLevel: level,
+		Users:       []string{"pm-tty-alice"},
+	}
+	content, err := sudoConfigForParams(params, testTerminalAdminGroup)
+	if err != nil {
+		t.Fatalf("sudoConfigForParams: %v", err)
+	}
+	return content
+}
+
+// =============================================================================
+// Integration: visudo -c -f accepts the generated content.
+//
+// Skipped when visudo isn't on PATH (CI containers may not install
+// the sudo package). When present, this catches any syntax error the
+// unit tests above wouldn't surface — a malformed Defaults line, an
+// unterminated rule, etc.
+// =============================================================================
+
+func TestSudoConfig_PassesVisudoCheck_TerminalAdminLimited(t *testing.T) {
+	requireVisudo(t)
+	out := generateTerminalAdminLimitedSudoConfig(testTerminalAdminGroup)
+	requireVisudoAccepts(t, out)
+}
+
+func TestSudoConfig_PassesVisudoCheck_TerminalAdminFull(t *testing.T) {
+	requireVisudo(t)
+	out := generateTerminalAdminFullSudoConfig(testTerminalAdminGroup)
+	requireVisudoAccepts(t, out)
+}
+
+func requireVisudo(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("visudo"); err != nil {
+		t.Skipf("visudo not on PATH; skipping syntax-check integration: %v", err)
+	}
+}
+
+func requireVisudoAccepts(t *testing.T, content string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "sudoers.d.pm-test")
+	if err := os.WriteFile(path, []byte(content), 0o440); err != nil {
+		t.Fatalf("write tempfile: %v", err)
+	}
+	out, err := exec.CommandContext(context.Background(), "visudo", "-c", "-f", path).CombinedOutput()
+	if err != nil {
+		t.Fatalf("visudo -c -f rejected the generated content:\n%s\n---\n%s", err, out)
+	}
+}


### PR DESCRIPTION
## Summary

Agent-side implementation of [manchtools/power-manage-server#70](https://github.com/manchtools/power-manage-server/issues/70) (TerminalAdmin Limited/Full).

Adds two new sudoers generators routed by the new `AdminAccessLevel` enum values from [sdk #80](https://github.com/manchtools/power-manage-sdk/pull/80) (merged):

- `generateTerminalAdminLimitedSudoConfig` — passwordless variant of LIMITED with the ADR's mandatory hardening:
  - NOPASSWD on every allowlist rule
  - Defaults block: `requiretty`, `env_reset`, `!lecture`, `timestamp_timeout=0`
  - `!`-deny blocks for editor escapes (ADR T2), shell spawns (ADR T3), persistence vectors (ADR T5)
- `generateTerminalAdminFullSudoConfig` — passwordless `ALL=(ALL:ALL) NOPASSWD: ALL` with the same Defaults block.

`setupSudoPolicy` gains two new switch arms pointing at the new generators. The existing FULL/LIMITED/CUSTOM templates are 100% untouched, so operator-authored AdminPolicy actions are unchanged.

The dispatch switch is extracted into `sudoConfigForParams` so unit tests can pin the enum → template mapping without filesystem / group-membership work.

Paired with the server PR for #70 — neither merges alone (the server emits actions the agent rejects without these arms; the agent without the server has nothing to apply them to).

## Test plan

NEW `agent/internal/executor/sudo_test.go` — first test file for the sudoers generators:

- [x] `TestGenerateTerminalAdminLimitedSudoConfig_*` — 6 tests: group interpolation, NOPASSWD, Defaults block, editor deny, shell deny, persistence-vector deny (ADR T1-T5 regression matrix)
- [x] `TestGenerateTerminalAdminFullSudoConfig_*` — 3 tests: group interpolation, NOPASSWD ALL grant, Defaults block applies
- [x] `TestSetupSudoPolicy_Routes*` — 2 tests pin the switch arms
- [x] `TestSudoConfig_PassesVisudoCheck_*` — 2 integration tests run `visudo -c -f` on the generated content (skipped when visudo isn't on PATH)
- [x] `gofmt`, `go vet`, full executor test suite green
- [x] Local `cr review` — no findings