### PR TITLE
fix(executor): validate login shell, GECOS comment, and primary group

### DIFF
--- a/internal/executor/action_user.go
+++ b/internal/executor/action_user.go
@@ -43,6 +43,37 @@ func (e *Executor) executeUser(ctx context.Context, params *pb.UserParams, state
 		}
 	}
 
+	// Validate the login shell when explicitly set. usermod -s does NOT
+	// restrict the value to /etc/shells, so an arbitrary binary here would
+	// be a persistence/escalation primitive for an operator who can drive a
+	// user action. Reject anything not on the system allowlist before it
+	// reaches useradd/usermod argv. The empty-shell case falls through to
+	// the SDK-trusted defaults (/bin/bash, /usr/sbin/nologin) chosen below.
+	if params.Shell != "" {
+		if err := sysuser.ValidateLoginShell(params.Shell); err != nil {
+			return nil, false, nil, fmt.Errorf("invalid login shell: %w", err)
+		}
+	}
+
+	// Validate the GECOS/comment: it becomes a colon-delimited field in
+	// /etc/passwd, so ':' or a newline would corrupt or forge a record.
+	if params.Comment != "" {
+		if err := sysuser.ValidateComment(params.Comment); err != nil {
+			return nil, false, nil, fmt.Errorf("invalid comment: %w", err)
+		}
+	}
+
+	// Validate a named primary group before it reaches `useradd/usermod -g`.
+	// GroupEnsureExists validates internally, but its failure is only
+	// logged — without this an invalid or flag-shaped group name would
+	// still be appended to argv. (Numeric Gid takes precedence and is not
+	// affected.)
+	if params.PrimaryGroup != "" {
+		if !sysuser.IsValidName(params.PrimaryGroup) {
+			return nil, false, nil, fmt.Errorf("invalid primary group %q: must start with a lowercase letter and contain only [a-z0-9_-], max 32 chars", params.PrimaryGroup)
+		}
+	}
+
 	// Repair filesystem if mounted read-only
 	if out, err := e.requireWritableFS(ctx); err != nil {
 		return out, false, nil, err

--- a/internal/executor/action_user_shell_test.go
+++ b/internal/executor/action_user_shell_test.go
@@ -1,0 +1,72 @@
+package executor
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// An operator who can drive a USER action must not be able to set an
+// account's login shell to an arbitrary binary: usermod -s does not
+// enforce /etc/shells, so /tmp/evil would otherwise become a persistence
+// primitive. executeUser must reject an explicit, non-allowlisted shell
+// before it reaches useradd/usermod argv. The rejection runs ahead of any
+// filesystem/exec side effect, so a minimal Executor exercises it.
+func TestExecuteUser_RejectsArbitraryLoginShell(t *testing.T) {
+	e := &Executor{logger: slog.Default()}
+	params := &pb.UserParams{
+		Username: "alice",
+		Shell:    "/tmp/evil", // clean absolute path, but not a system shell
+	}
+	_, _, _, err := e.executeUser(context.Background(), params, pb.DesiredState_DESIRED_STATE_PRESENT)
+	if err == nil {
+		t.Fatal("executeUser accepted login shell /tmp/evil; want rejection")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "shell") {
+		t.Errorf("error = %v, want it to name the login shell", err)
+	}
+}
+
+// A flag-shaped shell must also be refused (defense against argv injection
+// even though it would land as the operand of -s).
+func TestExecuteUser_RejectsFlagShapedLoginShell(t *testing.T) {
+	e := &Executor{logger: slog.Default()}
+	params := &pb.UserParams{
+		Username: "bob",
+		Shell:    "--login",
+	}
+	if _, _, _, err := e.executeUser(context.Background(), params, pb.DesiredState_DESIRED_STATE_PRESENT); err == nil {
+		t.Fatal("executeUser accepted flag-shaped shell --login; want rejection")
+	}
+}
+
+// A GECOS/comment containing ':' or a newline would corrupt the
+// /etc/passwd record (extra fields / forged record). executeUser must
+// reject it with a comment-specific error BEFORE it reaches useradd/usermod
+// -c. We assert the error names the comment so a generic useradd failure
+// (e.g. "not root") can't make this pass for the wrong reason.
+func TestExecuteUser_RejectsCommentInjection(t *testing.T) {
+	e := &Executor{logger: slog.Default()}
+	for _, bad := range []string{"root:x:0:0:", "name\nroot:x:0:0"} {
+		params := &pb.UserParams{Username: "carol", Comment: bad}
+		_, _, _, err := e.executeUser(context.Background(), params, pb.DesiredState_DESIRED_STATE_PRESENT)
+		if err == nil || !strings.Contains(strings.ToLower(err.Error()), "comment") {
+			t.Errorf("executeUser(comment=%q) err = %v; want a comment-validation error", bad, err)
+		}
+	}
+}
+
+// A malformed PrimaryGroup (flag-shaped or otherwise invalid) must be
+// rejected with a group-specific error before reaching `-g`, not silently
+// appended after a logged GroupEnsureExists failure.
+func TestExecuteUser_RejectsInvalidPrimaryGroup(t *testing.T) {
+	e := &Executor{logger: slog.Default()}
+	params := &pb.UserParams{Username: "dave", PrimaryGroup: "-G"}
+	_, _, _, err := e.executeUser(context.Background(), params, pb.DesiredState_DESIRED_STATE_PRESENT)
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "group") {
+		t.Fatalf("executeUser(PrimaryGroup=-G) err = %v; want a primary-group-validation error", err)
+	}
+}


### PR DESCRIPTION
Consumer side of the SDK command-invocation hardening — pairs with **manchtools/power-manage-sdk#89** (issue manchtools/power-manage-sdk#88). This branch shares the SDK branch name, so agent integration-test CI builds against that SDK branch automatically.

`executeUser` now rejects, **before any `useradd`/`usermod` shell-out**:

- An explicit **login shell** not on the system allowlist (`sysuser.ValidateLoginShell`). `usermod -s` does not enforce `/etc/shells`, so an operator who can drive a user action could otherwise point any account's login shell at an arbitrary binary — a persistence/escalation primitive.
- A **GECOS/comment** containing `:` or a newline (`sysuser.ValidateComment`), which would corrupt or forge an `/etc/passwd` record.
- A malformed / flag-shaped **PrimaryGroup**, which was previously appended to `-g` after a merely-*logged* `GroupEnsureExists` failure.

Tests are intent-asserting and pin the *specific* validation error (so a generic non-root `useradd` failure can't pass them for the wrong reason).

> Merge order: SDK #89 first, then bump the agent `go.mod` SDK replace and merge this. CI here resolves the SDK via the matching branch name in the meantime.