### PR TITLE
test(arch): architectural fitness functions + clock seam

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -38,6 +38,27 @@ See `CLAUDE.md` for the full build command reference.
 - Follow existing patterns in the codebase.
 - Always handle errors -- never silently ignore them.
 
+## Guardrails (architectural fitness functions)
+
+`internal/archtest/` holds build-failing invariant tests that run in the
+normal `go test ./...` path:
+
+- **`TestNoDynamicSQL`** — the hand-written sqlite queries (`s.db`/`tx`) must
+  use string-literal SQL with `?` placeholders; never `fmt.Sprintf`/
+  concatenate SQL.
+- **`TestSecretComparesAreConstantTime`** — compare secrets/tokens/MACs/
+  signatures with `subtle.ConstantTimeCompare`/`hmac.Equal`, never
+  `==`/`bytes.Equal`.
+- **`TestNoUnabstractedTimeNow`** — no direct `time.Now()` calls in runtime
+  code. Read the clock through an injected `now func() time.Time` seam
+  (defaulting to `time.Now`) and call `t.now()`, so time-dependent logic (the
+  offline scheduler's maintenance-window gate, expiry, rotation cutoffs) is
+  testable with a fixed clock.
+
+Each guard ships a documented, no-stale-guarded allowlist for genuine
+exceptions. **Prefer fixing the code over adding an allowlist entry.** The
+rationale lives in the server repo's `docs/adr/0002-architectural-fitness-functions.md`.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the AGPL-3.0 license.

--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -111,7 +111,7 @@ func main() {
 	}
 
 	// Clean up stale update state from a previous cycle (if any).
-	executor.CheckStartupUpdateState(cfg.DataDir, logger)
+	executor.CheckStartupUpdateState(cfg.DataDir, logger, time.Now)
 
 	// Get hostname
 	hostname, err := os.Hostname()
@@ -291,7 +291,7 @@ func main() {
 		"version", version,
 	)
 
-	runAgent(ctx, credStore, creds, hostname, h, sched, syncTrigger, cfg.pendingSecurityAlert, logger)
+	runAgent(ctx, credStore, creds, hostname, h, sched, syncTrigger, cfg.pendingSecurityAlert, logger, time.Now)
 
 	// Stop background goroutines started during runAgent. The
 	// terminal sweeper would otherwise outlive the agent process in

--- a/cmd/power-manage-agent/runtime.go
+++ b/cmd/power-manage-agent/runtime.go
@@ -35,7 +35,7 @@ func reloadCredsForReconnect(credStore *credentials.Store, current *credentials.
 	return reloaded
 }
 
-func runAgent(ctx context.Context, credStore *credentials.Store, creds *credentials.Credentials, hostname string, h *handler.Handler, sched *scheduler.Scheduler, syncTrigger <-chan struct{}, securityAlert *pendingSecurityAlert, logger *slog.Logger) {
+func runAgent(ctx context.Context, credStore *credentials.Store, creds *credentials.Credentials, hostname string, h *handler.Handler, sched *scheduler.Scheduler, syncTrigger <-chan struct{}, securityAlert *pendingSecurityAlert, logger *slog.Logger, now func() time.Time) {
 	// Current sync interval (can be updated by server). Owned by
 	// runAgent — periodicSync receives its initial value as a
 	// stack-local copy and any subsequent updates over a channel.
@@ -145,7 +145,7 @@ func runAgent(ctx context.Context, credStore *credentials.Store, creds *credenti
 		// child reports during the session so the parent's
 		// `syncInterval` carries the latest value into the next
 		// reconnect attempt.
-		connStart := time.Now()
+		connStart := now()
 		streamErr := waitForStreamEnd(streamDone, intervalUpdatesOut, &syncInterval)
 		err = streamErr
 
@@ -169,7 +169,7 @@ func runAgent(ctx context.Context, credStore *credentials.Store, creds *credenti
 		}
 
 		// Reset backoff if the connection was stable (lasted longer than the backoff interval)
-		if time.Since(connStart) > currentBackoff {
+		if now().Sub(connStart) > currentBackoff {
 			currentBackoff = randomBackoff()
 		}
 

--- a/internal/archtest/archtest.go
+++ b/internal/archtest/archtest.go
@@ -1,0 +1,179 @@
+// Package archtest holds architectural fitness functions for the
+// agent module: self-discovering, repo-wide invariant tests that fail
+// the build when a known code smell is reintroduced or an established
+// good pattern is broken.
+//
+// # Why these exist
+//
+// The 2026-06 security + architecture sweeps fixed a set of smells
+// (raw/concatenated SQL, non-constant-time secret comparisons) and
+// pinned a set of good patterns (parameterized queries,
+// subtle.ConstantTimeCompare/hmac.Equal, an injected clock seam). A
+// one-off fix does not stop the next contributor from reintroducing the
+// smell. These tests turn each invariant into a permanent, build-failing
+// guard.
+//
+// # Design constraints
+//
+//   - Standard library only (go/parser, go/ast, go/token, go/printer).
+//     No golang.org/x/tools dependency, so the guards stay hermetic,
+//     fast, and identical in shape across the sdk/agent/server archtest
+//     packages. Syntactic invariants do not need full type resolution;
+//     where a guard relies on a naming/structure heuristic it documents
+//     the heuristic and ships a guarded allowlist for true exceptions.
+//   - Self-discovering: every guard walks the module tree and asserts it
+//     inspected a non-empty set, so it can never pass vacuously (the
+//     classic stale-allowlist failure that fails open).
+//   - Every allowlist is itself guarded: a no-stale-entry check fails the
+//     build if an allowlisted exception no longer exists, so the
+//     allowlist cannot rot into a silent escape hatch.
+//
+// # Coverage map (what lives where)
+//
+//   - TestNoDynamicSQL .................... no_dynamic_sql_test.go
+//   - TestSecretComparesAreConstantTime ... secret_compare_test.go
+//   - TestNoUnabstractedTimeNow ........... time_now_test.go
+package archtest
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// goFile is a parsed Go source file with its module-relative path.
+type goFile struct {
+	abs  string
+	rel  string // slash-separated, relative to the module root
+	fset *token.FileSet
+	ast  *ast.File
+}
+
+// moduleRoot walks up from the test's working directory until it finds
+// the directory containing go.mod. go test sets the working directory to
+// the package under test, so this reliably locates the agent module
+// root regardless of where the archtest package sits.
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not locate go.mod above %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// walkGoFiles parses every .go file under root whose module-relative,
+// slash-separated path satisfies keep. Test files, the archtest package
+// itself, and anything under a vendor/ directory are never returned —
+// keep only narrows further. Parsing is syntactic (no type checking) and
+// skips object resolution for speed.
+func walkGoFiles(t *testing.T, root string, keep func(rel string) bool) []*goFile {
+	t.Helper()
+	var out []*goFile
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if name == "vendor" || name == "testdata" || name == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if strings.HasSuffix(rel, "_test.go") {
+			return nil
+		}
+		if strings.HasPrefix(rel, "internal/archtest/") {
+			return nil
+		}
+		if !keep(rel) {
+			return nil
+		}
+		fset := token.NewFileSet()
+		f, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", rel, perr)
+		}
+		out = append(out, &goFile{abs: path, rel: rel, fset: fset, ast: f})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return out
+}
+
+// render returns the gofmt-style source text of an AST node. Used to
+// build stable, line-independent allowlist keys and human-readable
+// failure messages.
+func render(fset *token.FileSet, n ast.Node) string {
+	var b strings.Builder
+	if err := printer.Fprint(&b, fset, n); err != nil {
+		return "<unprintable node>"
+	}
+	// Collapse internal newlines so multi-line call expressions render as
+	// a single stable key.
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+// line returns the 1-based source line of a node within its file.
+func (gf *goFile) line(n ast.Node) int {
+	return gf.fset.Position(n.Pos()).Line
+}
+
+// allowlist couples a set of intentionally-exempt sites with their
+// documented justifications and tracks which entries were actually hit,
+// so a stale entry (an exemption whose site no longer exists) fails the
+// build instead of silently widening the guard.
+type allowlist struct {
+	reason map[string]string // key -> why it is exempt
+	used   map[string]bool
+}
+
+func newAllowlist(reasons map[string]string) *allowlist {
+	return &allowlist{reason: reasons, used: make(map[string]bool)}
+}
+
+// exempt reports whether key is allowlisted, marking it used.
+func (a *allowlist) exempt(key string) bool {
+	if _, ok := a.reason[key]; ok {
+		a.used[key] = true
+		return true
+	}
+	return false
+}
+
+// assertNoStale fails the test for every allowlist entry that was never
+// matched during the scan — a stale exemption is itself a finding,
+// because it means the guard's surface drifted out from under it.
+func (a *allowlist) assertNoStale(t *testing.T) {
+	t.Helper()
+	for key := range a.reason {
+		if !a.used[key] {
+			t.Errorf("stale allowlist entry never matched any site (remove it or fix the key): %q", key)
+		}
+	}
+}

--- a/internal/archtest/astutil.go
+++ b/internal/archtest/astutil.go
@@ -1,0 +1,166 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// identName returns the most specific name an expression is known by:
+// the identifier for a bare ident, or the trailing selector field
+// (foo.Bar -> "Bar"). Anything else yields "".
+func identName(e ast.Expr) string {
+	switch x := e.(type) {
+	case *ast.Ident:
+		return x.Name
+	case *ast.SelectorExpr:
+		return x.Sel.Name
+	case *ast.StarExpr:
+		return identName(x.X)
+	case *ast.ParenExpr:
+		return identName(x.X)
+	}
+	return ""
+}
+
+// isContextArg reports whether an argument is (very likely) a
+// context.Context, so SQL-method scanning can locate the SQL string at
+// the correct argument index for both the database/sql shape
+// (sql first) and the pgx shape (ctx first).
+func isContextArg(e ast.Expr) bool {
+	switch x := e.(type) {
+	case *ast.Ident:
+		return x.Name == "ctx"
+	case *ast.SelectorExpr:
+		return x.Sel.Name == "ctx" || x.Sel.Name == "Ctx" || x.Sel.Name == "Context"
+	case *ast.CallExpr:
+		if sel, ok := x.Fun.(*ast.SelectorExpr); ok {
+			if sel.Sel.Name == "Context" || sel.Sel.Name == "Background" || sel.Sel.Name == "TODO" {
+				return true
+			}
+			if id, ok := sel.X.(*ast.Ident); ok && id.Name == "context" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isPresenceComparand reports whether an operand is a nil / empty-string
+// / zero literal — i.e. the comparison is a presence/absence check, not a
+// secret-value comparison. Constant-time compares only matter when both
+// sides carry real secret material.
+func isPresenceComparand(e ast.Expr) bool {
+	switch x := e.(type) {
+	case *ast.Ident:
+		return x.Name == "nil"
+	case *ast.BasicLit:
+		switch x.Kind {
+		case token.STRING:
+			// `""` (or `` `` ``) — empty string literal.
+			if s, err := strconv.Unquote(x.Value); err == nil {
+				return s == ""
+			}
+		case token.INT, token.FLOAT:
+			return x.Value == "0" || x.Value == "0.0"
+		}
+	case *ast.CallExpr:
+		// []byte(nil), []byte("") — presence checks on byte slices.
+		if len(x.Args) == 1 {
+			return isPresenceComparand(x.Args[0])
+		}
+	}
+	return false
+}
+
+// stringConstNames returns the set of every package-level identifier in
+// the module bound to a string-literal constant. A query whose SQL
+// argument is one of these names is a literal query (e.g. an
+// sqlc-generated query const), not dynamically-built SQL.
+func stringConstNames(t *testing.T, root string) map[string]bool {
+	t.Helper()
+	out := make(map[string]bool)
+	files := walkGoFiles(t, root, func(string) bool { return true })
+	for _, gf := range files {
+		for _, decl := range gf.ast.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range vs.Names {
+					if i < len(vs.Values) && isStringLiteralExpr(vs.Values[i]) {
+						out[name.Name] = true
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+// isStringLiteralExpr reports whether e is a string literal or a
+// concatenation of string literals (`"a" + "b"`).
+func isStringLiteralExpr(e ast.Expr) bool {
+	switch x := e.(type) {
+	case *ast.BasicLit:
+		return x.Kind == token.STRING
+	case *ast.BinaryExpr:
+		return x.Op == token.ADD && isStringLiteralExpr(x.X) && isStringLiteralExpr(x.Y)
+	case *ast.ParenExpr:
+		return isStringLiteralExpr(x.X)
+	}
+	return false
+}
+
+// unquoteLit returns the string value of a STRING BasicLit, or "".
+func unquoteLit(lit *ast.BasicLit) string {
+	if lit == nil || lit.Kind != token.STRING {
+		return ""
+	}
+	if s, err := strconv.Unquote(lit.Value); err == nil {
+		return s
+	}
+	return ""
+}
+
+// secretNameRe matches identifiers that hold secret material. Bare "sig"
+// and "mac" from the original sweep regex are intentionally dropped:
+// "sig" collides with "assign", and "mac" is too short to be specific;
+// the full "signature" / "hmac" forms are kept instead. A match is only a
+// violation when it is NOT metadata about the secret (see
+// secretMetaSuffixes) and NOT a presence check.
+var secretNameRe = regexp.MustCompile(`(?i)(token|secret|hmac|signature|fingerprint|password|passwd|digest|apikey)`)
+
+// secretMetaSuffixes name fields that describe a secret rather than carry
+// its bytes (TokenType, SessionVersion, KeyID, ...). Comparing these with
+// == is fine — they are not timing-sensitive secret material.
+var secretMetaSuffixes = []string{
+	"type", "kind", "id", "name", "len", "length", "count", "version",
+	"expiry", "expiresat", "at", "format", "algorithm", "algo", "method",
+	"status", "enabled", "disabled", "index", "idx", "field", "size",
+}
+
+// looksLikeSecretOperand reports whether an operand names secret material
+// that must be compared in constant time (matches the secret regex and is
+// not a metadata field).
+func looksLikeSecretOperand(e ast.Expr) bool {
+	name := identName(e)
+	if name == "" || !secretNameRe.MatchString(name) {
+		return false
+	}
+	lower := strings.ToLower(name)
+	for _, suf := range secretMetaSuffixes {
+		if strings.HasSuffix(lower, suf) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/archtest/no_dynamic_sql_test.go
+++ b/internal/archtest/no_dynamic_sql_test.go
@@ -1,0 +1,145 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"testing"
+)
+
+// sqlMethodNames are the database driver methods (database/sql and pgx)
+// whose query/statement argument MUST be a string literal or named
+// string constant. A non-literal argument means the SQL text was built
+// at runtime — the raw/concatenated-SQL smell this guard forbids.
+var sqlMethodNames = map[string]bool{
+	"Exec": true, "ExecContext": true,
+	"Query": true, "QueryContext": true,
+	"QueryRow": true, "QueryRowContext": true,
+	"Prepare": true, "PrepareContext": true,
+}
+
+// sqlHandleReceivers are the identifiers the agent binds its
+// database/sql handles to: the store's `db *sql.DB` field (accessed as
+// `s.db` or copied to a local `db`) and the `tx` locals from
+// `s.db.Begin()`. The method-name set above is necessary but not
+// sufficient in this module: `Query` collides with the osquery client
+// (`oq.Query`, `registry.Query` — a *pb.OSQuery proto arg), the system
+// command runner (`sysexec.Query(name, ...)` — a binary name), and
+// `*url.URL.Query()`. None of those touch SQL. Gating on the receiver
+// being a real sql handle keeps the guard pointed only at hand-written
+// sqlite, which must stay parameterized. SkipObjectResolution parsing
+// cannot resolve receiver *types*, so this matches by the conventional
+// handle name; isSQLHandleReceiver is the single point that decides, and
+// the matches-zero guard fails the build if it ever stops matching the
+// real DB calls (e.g. the handle gets renamed without updating this set).
+var sqlHandleReceivers = map[string]bool{
+	"db": true,
+	"tx": true,
+}
+
+// dynamicSQLAllowlist lists the only sites permitted to pass a
+// non-literal SQL string to a database method, each with the reason it is
+// safe. Keyed by "<module-rel path> :: <rendered call>" so it survives
+// line moves. assertNoStale fails the build if any entry stops matching.
+//
+// The agent's SQL is entirely hand-written, literal, parameterized
+// sqlite — there are no exceptions, so this allowlist is empty.
+var dynamicSQLAllowlist = map[string]string{}
+
+// TestNoDynamicSQL pins the parameterized-SQL discipline: every call to a
+// database query/exec method must receive a string-literal or
+// named-string-const SQL argument. This makes "build a query string with
+// fmt.Sprintf / string concatenation" fail the build — the canonical
+// SQL-injection footgun — and locks the good state for the agent's
+// hand-written sqlite queries (all literal/parameterized today).
+func TestNoDynamicSQL(t *testing.T) {
+	root := moduleRoot(t)
+
+	// A query whose SQL arg is a named string const (e.g. a query const)
+	// is still a literal query.
+	consts := stringConstNames(t, root)
+
+	// Scan all production Go. The agent has no generated SQL package.
+	files := walkGoFiles(t, root, func(rel string) bool { return true })
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero production Go files — detector is mis-scoped")
+	}
+
+	allow := newAllowlist(dynamicSQLAllowlist)
+	candidates := 0
+	for _, gf := range files {
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || !sqlMethodNames[sel.Sel.Name] {
+				return true
+			}
+			if !isSQLHandleReceiver(sel.X) {
+				return true
+			}
+			sqlArg, ok := sqlArgOf(call)
+			if !ok {
+				return true
+			}
+			candidates++
+			if isLiteralSQL(sqlArg, consts) {
+				return true
+			}
+			key := gf.rel + " :: " + render(gf.fset, call)
+			if allow.exempt(key) {
+				return true
+			}
+			t.Errorf("dynamic SQL at %s:%d — %s\n  passes a non-literal SQL string. Use a parameterized literal; never build SQL with fmt.Sprintf/concatenation. If genuinely unavoidable, add a justified, guarded entry to dynamicSQLAllowlist.",
+				gf.rel, gf.line(call), render(gf.fset, call))
+			return true
+		})
+	}
+	if candidates == 0 {
+		t.Fatal("matches-zero guard: found no database query/exec call sites at all — the SQL-method set is mis-scoped, the guard would pass vacuously")
+	}
+	allow.assertNoStale(t)
+}
+
+// isSQLHandleReceiver reports whether the receiver expression of a
+// method call is one of the database/sql handles (sqlHandleReceivers).
+// It matches both a bare local (`tx.Exec(...)`, `db.Exec(...)`) and a
+// field access (`s.db.Exec(...)`), taking the most specific name via
+// identName so `s.db` resolves to "db".
+func isSQLHandleReceiver(recv ast.Expr) bool {
+	return sqlHandleReceivers[identName(recv)]
+}
+
+// sqlArgOf returns the SQL-text argument of a database method call,
+// accounting for the pgx shape (ctx, sql, args...) vs the database/sql
+// shape (sql, args...).
+func sqlArgOf(call *ast.CallExpr) (ast.Expr, bool) {
+	if len(call.Args) == 0 {
+		return nil, false
+	}
+	idx := 0
+	if isContextArg(call.Args[0]) {
+		idx = 1
+	}
+	if idx >= len(call.Args) {
+		return nil, false
+	}
+	return call.Args[idx], true
+}
+
+// isLiteralSQL reports whether the SQL argument is a string literal or a
+// named string constant (both safe), as opposed to a runtime-built value.
+func isLiteralSQL(e ast.Expr, consts map[string]bool) bool {
+	switch x := e.(type) {
+	case *ast.BasicLit:
+		return x.Kind == token.STRING
+	case *ast.Ident:
+		return consts[x.Name]
+	case *ast.SelectorExpr:
+		return consts[x.Sel.Name]
+	case *ast.ParenExpr:
+		return isLiteralSQL(x.X, consts)
+	}
+	return false
+}

--- a/internal/archtest/secret_compare_test.go
+++ b/internal/archtest/secret_compare_test.go
@@ -1,0 +1,89 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"testing"
+)
+
+// secretCompareAllowlist lists comparisons that match the secret-name
+// heuristic but are NOT timing-sensitive secret-value compares (typically
+// enum/metadata fields the suffix filter didn't catch). Each entry is
+// justified; assertNoStale fails the build if one stops matching.
+// Keyed by "<module-rel path> :: <rendered expression>".
+var secretCompareAllowlist = map[string]string{
+	`internal/executor/lps.go :: params.Complexity == pb.LpsPasswordComplexity_LPS_PASSWORD_COMPLEXITY_UNSPECIFIED`: "Enum-mode compare, not secret bytes. The secret-name regex matches because the LPS (Local Password Solution) complexity enum's constant name contains \"PASSWORD\"; params.Complexity is a policy-complexity mode (UNSPECIFIED/COMPLEX/ALPHANUMERIC), carrying no secret material and no timing oracle. The generated password itself is never compared with ==/!=.",
+	`internal/executor/lps.go :: params.Complexity == pb.LpsPasswordComplexity_LPS_PASSWORD_COMPLEXITY_COMPLEX`:     "Enum-mode compare, not secret bytes. Same as above: selects whether the rotated password includes special characters. params.Complexity is a configuration enum, not timing-sensitive secret material.",
+}
+
+// TestSecretComparesAreConstantTime forbids comparing secret material
+// (tokens, MACs, signatures, fingerprints, password/digest bytes) with
+// == / != / bytes.Equal — all of which short-circuit and leak length and
+// content through timing. The correct primitives are
+// subtle.ConstantTimeCompare and hmac.Equal. Presence checks (`tok == ""`,
+// `sig == nil`) and metadata fields (TokenType, KeyID, SessionVersion)
+// are excluded; everything else that names secret material and is
+// compared with a non-constant-time operator is a finding.
+func TestSecretComparesAreConstantTime(t *testing.T) {
+	root := moduleRoot(t)
+	files := walkGoFiles(t, root, func(string) bool { return true })
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero production Go files — detector is mis-scoped")
+	}
+
+	allow := newAllowlist(secretCompareAllowlist)
+	sawComparison := false
+	sawSecretName := false
+
+	for _, gf := range files {
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			switch x := n.(type) {
+			case *ast.BinaryExpr:
+				if x.Op == token.EQL || x.Op == token.NEQ {
+					sawComparison = true
+					checkSecretCompare(t, gf, x, x.X, x.Y, allow, &sawSecretName)
+				}
+			case *ast.CallExpr:
+				// bytes.Equal(a, b) is non-constant-time for secrets.
+				if sel, ok := x.Fun.(*ast.SelectorExpr); ok {
+					if id, ok := sel.X.(*ast.Ident); ok && id.Name == "bytes" && sel.Sel.Name == "Equal" && len(x.Args) == 2 {
+						sawComparison = true
+						checkSecretCompare(t, gf, x, x.Args[0], x.Args[1], allow, &sawSecretName)
+					}
+				}
+			}
+			return true
+		})
+	}
+
+	if !sawComparison {
+		t.Fatal("matches-zero guard: found no equality comparisons in the module — the AST walk is not reaching real code")
+	}
+	if !sawSecretName {
+		t.Fatal("matches-zero guard: the secret-name detector matched no identifier anywhere in the module — the regex/scoping is dead, the guard would pass vacuously")
+	}
+	allow.assertNoStale(t)
+}
+
+// checkSecretCompare flags node if either operand names secret material
+// and neither operand is a presence comparand (nil/empty/zero).
+func checkSecretCompare(t *testing.T, gf *goFile, node ast.Node, lhs, rhs ast.Expr, allow *allowlist, sawSecretName *bool) {
+	t.Helper()
+	lSecret := looksLikeSecretOperand(lhs)
+	rSecret := looksLikeSecretOperand(rhs)
+	if lSecret || rSecret {
+		*sawSecretName = true
+	}
+	if !lSecret && !rSecret {
+		return
+	}
+	if isPresenceComparand(lhs) || isPresenceComparand(rhs) {
+		return // presence/absence check, not a secret-value compare
+	}
+	key := gf.rel + " :: " + render(gf.fset, node)
+	if allow.exempt(key) {
+		return
+	}
+	t.Errorf("non-constant-time secret compare at %s:%d — %s\n  compares secret material with ==/!=/bytes.Equal, which leaks length and content via timing. Use subtle.ConstantTimeCompare or hmac.Equal. If this is metadata (not secret bytes), add a justified, guarded entry to secretCompareAllowlist.",
+		gf.rel, gf.line(node), render(gf.fset, node))
+}

--- a/internal/archtest/time_now_test.go
+++ b/internal/archtest/time_now_test.go
@@ -1,0 +1,128 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// TestNoUnabstractedTimeNow enforces that production runtime code never
+// CALLS time.Now() directly. Time-dependent logic (token/cert/session
+// expiry, rate-limit windows, timestamps, even latency measurement) must
+// read the current time through an injected `now func() time.Time` seam
+// (defaulting to the bare time.Now value), so every time-dependent path
+// is deterministically testable with a fixed clock. This extends the
+// existing seam already used by internal/crl, internal/terminal,
+// internal/compliance and internal/gateway/registry to the whole module.
+//
+// The bare `time.Now` *value* (the injection default, e.g. `now: time.Now`)
+// is not a call and is therefore allowed — it is the single sanctioned
+// reference to the wall clock.
+//
+// One structural exception: time.Now() passed as the timestamp argument to
+// ulid.Timestamp(...) is ID generation, where the wall clock seeds the
+// ULID's time component rather than driving a decision; injecting a clock
+// there buys no testability and threads a parameter through every ID
+// helper. This is a category rule, not a per-site blessing — any ULID
+// generator is covered, and nothing else is.
+//
+// Scope: production runtime only. _test.go, the generated sqlc package,
+// the archtest package itself, and internal/testutil (test scaffolding,
+// imported only by tests) are out of scope.
+func TestNoUnabstractedTimeNow(t *testing.T) {
+	root := moduleRoot(t)
+	files := walkGoFiles(t, root, func(rel string) bool {
+		if strings.HasPrefix(rel, "internal/store/generated/") {
+			return false
+		}
+		if strings.HasPrefix(rel, "internal/testutil/") {
+			return false
+		}
+		return true
+	})
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero production Go files — detector is mis-scoped")
+	}
+
+	// sawTimeNowRef counts every reference to the `time.Now` selector,
+	// whether a call (`time.Now()`) or the bare injection-default value
+	// (`now: time.Now`). It is the detector's liveness signal: the agent
+	// has already been fully migrated to the clock seam, so in steady
+	// state there are ZERO direct `time.Now()` CALLS — the matches-zero
+	// guard therefore cannot key off call count (that would fail-closed
+	// on a clean module and pressure someone to keep a violation alive
+	// just to satisfy the detector). It keys off the `time.Now` selector
+	// instead, which every seam default still carries, so the guard stays
+	// non-vacuous (it fails if zero files are scanned or the `time.Now`
+	// recognition machinery dies) without demanding a violation exist.
+	// The server's copy keys off call count because its ULID path keeps
+	// at least one allowed `time.Now()` call present; the agent has no
+	// ULID generator, hence this divergence.
+	sawTimeNowRef := 0
+	for _, gf := range files {
+		exempt := map[token.Pos]bool{}
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			if isTimeNowSelector(n) {
+				sawTimeNowRef++
+			}
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			// Mark a time.Now() that seeds ulid.Timestamp(...) as exempt.
+			// Inspect is top-down, so the ulid.Timestamp parent is seen
+			// before its time.Now child and the exemption is in place by
+			// the time the child is visited.
+			if isULIDTimestampCall(call) {
+				if inner, ok := call.Args[0].(*ast.CallExpr); ok && isTimeNowCall(inner) {
+					exempt[inner.Pos()] = true
+				}
+			}
+			if isTimeNowCall(call) {
+				if exempt[call.Pos()] {
+					return true
+				}
+				t.Errorf("unabstracted time.Now() at %s:%d — read the clock through an injected `now func() time.Time` seam (default `time.Now`) and call it, e.g. s.now(); never call time.Now() directly in runtime code.",
+					gf.rel, gf.line(call))
+			}
+			return true
+		})
+	}
+	if sawTimeNowRef == 0 {
+		t.Fatal("matches-zero guard: found no reference to the time.Now selector anywhere (not even a seam default) — the detector is dead, the guard would pass vacuously")
+	}
+}
+
+// isTimeNowSelector reports whether n is the selector expression
+// `time.Now` itself — matching both the call `time.Now()` (whose Fun is
+// this selector) and the bare value `time.Now` used as an injection
+// default. It is the liveness probe for the matches-zero guard.
+func isTimeNowSelector(n ast.Node) bool {
+	sel, ok := n.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Now" {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	return ok && id.Name == "time"
+}
+
+// isTimeNowCall reports whether call is exactly time.Now().
+func isTimeNowCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Now" || len(call.Args) != 0 {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	return ok && id.Name == "time"
+}
+
+// isULIDTimestampCall reports whether call is ulid.Timestamp(<one arg>).
+func isULIDTimestampCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Timestamp" || len(call.Args) != 1 {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	return ok && id.Name == "ulid"
+}

--- a/internal/deviceauth/enroll.go
+++ b/internal/deviceauth/enroll.go
@@ -54,6 +54,8 @@ type EnrollHandler struct {
 	statusMu       sync.Mutex
 	cachedDeviceID string
 	statusCached   bool
+
+	now func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // NewEnrollHandler creates a handler for enrollment RPCs.
@@ -65,6 +67,7 @@ func NewEnrollHandler(hostname, version string, credStore *credentials.Store, lo
 		credStore:  credStore,
 		logger:     logger,
 		onEnrolled: onEnrolled,
+		now:        time.Now,
 	}
 }
 
@@ -72,7 +75,7 @@ func NewEnrollHandler(hostname, version string, credStore *credentials.Store, lo
 func (h *EnrollHandler) Enroll(ctx context.Context, req *connect.Request[pm.EnrollRequest]) (*connect.Response[pm.EnrollResponse], error) {
 	// Rate limiting: max 5 attempts per minute
 	h.rateMu.Lock()
-	now := time.Now()
+	now := h.now()
 	cutoff := now.Add(-1 * time.Minute)
 	var recent []time.Time
 	for _, t := range h.lastAttempts {

--- a/internal/deviceauth/status_cache_test.go
+++ b/internal/deviceauth/status_cache_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
@@ -30,7 +31,7 @@ func (c *countingStore) Load() (*credentials.Credentials, error) {
 func (c *countingStore) Save(*credentials.Credentials) error { return nil }
 
 func newStatusHandler(store credentialStore) *EnrollHandler {
-	return &EnrollHandler{credStore: store, logger: slog.Default()}
+	return &EnrollHandler{credStore: store, logger: slog.Default(), now: time.Now}
 }
 
 // GetEnrollmentStatus must not run credStore.Load() (a 64 MiB Argon2id

--- a/internal/executor/action_user.go
+++ b/internal/executor/action_user.go
@@ -259,7 +259,7 @@ func (e *Executor) createUser(ctx context.Context, params *pb.UserParams, output
 				rotations := []lpsRotationEntry{{
 					Username:  params.Username,
 					Password:  tempPassword,
-					RotatedAt: time.Now().UTC().Format(time.RFC3339),
+					RotatedAt: e.now().UTC().Format(time.RFC3339),
 					Reason:    "user_created",
 				}}
 				rotationsJSON, err := json.Marshal(rotations)

--- a/internal/executor/agent_update.go
+++ b/internal/executor/agent_update.go
@@ -432,10 +432,12 @@ func clearUpdateState(dataDir string) {
 // Parameters:
 //   - dataDir: agent data directory containing update/state.json + update/
 //   - logger: structured logger
+//   - now: clock seam (pass time.Now in production); injected so the
+//     24h stale-tmp cutoff is deterministically testable.
 func CheckStartupUpdateState(dataDir string, logger interface {
 	Info(string, ...any)
 	Warn(string, ...any)
-}) {
+}, now func() time.Time) {
 	phase, _, err := readUpdateState(dataDir)
 	if err != nil {
 		logger.Warn("failed to read update state", "error", err)
@@ -466,7 +468,7 @@ func CheckStartupUpdateState(dataDir string, logger interface {
 		}
 		return
 	}
-	cutoff := time.Now().Add(-24 * time.Hour)
+	cutoff := now().Add(-24 * time.Hour)
 	for _, entry := range entries {
 		name := entry.Name()
 		if !strings.HasPrefix(name, "agent-update-") || !strings.HasSuffix(name, ".tmp") {
@@ -481,6 +483,6 @@ func CheckStartupUpdateState(dataDir string, logger interface {
 			logger.Warn("failed to remove stale update tmp file", "path", path, "error", err)
 			continue
 		}
-		logger.Info("removed stale update tmp file", "path", path, "age", time.Since(info.ModTime()).Round(time.Second))
+		logger.Info("removed stale update tmp file", "path", path, "age", now().Sub(info.ModTime()).Round(time.Second))
 	}
 }

--- a/internal/executor/agent_update_test.go
+++ b/internal/executor/agent_update_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 )
@@ -177,7 +178,7 @@ func TestMarkAgentUpdateExecuted(t *testing.T) {
 	// F042 + F048). Construct a fresh Executor for the test and
 	// exercise the methods directly instead of the deprecated
 	// package-level globals.
-	e := &Executor{}
+	e := &Executor{now: time.Now}
 
 	// First call should succeed
 	if !e.markAgentUpdateExecuted() {
@@ -201,7 +202,7 @@ func TestCheckStartupUpdateState_CleansStaleState(t *testing.T) {
 	writeStateForTest(t, dir, "staged", "2026.04.01")
 
 	logger := &testLogger{}
-	CheckStartupUpdateState(dir, logger)
+	CheckStartupUpdateState(dir, logger, time.Now)
 
 	// State should be cleared
 	phase, _, _ := readUpdateState(dir)
@@ -218,7 +219,7 @@ func TestCheckStartupUpdateState_NoState(t *testing.T) {
 	dir := t.TempDir()
 
 	logger := &testLogger{}
-	CheckStartupUpdateState(dir, logger)
+	CheckStartupUpdateState(dir, logger, time.Now)
 
 	// No logs expected
 	if len(logger.infos) > 0 || len(logger.warns) > 0 {

--- a/internal/executor/download_test.go
+++ b/internal/executor/download_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,7 +29,7 @@ func TestDownloadFile(t *testing.T) {
 		_, _ = w.Write(content)
 	}))
 	defer srv.Close()
-	e := &Executor{httpClient: srv.Client()}
+	e := &Executor{httpClient: srv.Client(), now: time.Now}
 	ctx := context.Background()
 
 	// Operators paste uppercase / whitespace-padded sha256 hashes; a
@@ -90,7 +91,7 @@ func TestDownloadFile_OversizeRejectedAndLeavesDestIntact(t *testing.T) {
 	maxDownloadSize = 16
 	t.Cleanup(func() { maxDownloadSize = orig })
 
-	e := &Executor{httpClient: srv.Client()}
+	e := &Executor{httpClient: srv.Client(), now: time.Now}
 	dest := filepath.Join(t.TempDir(), "app")
 	require.NoError(t, os.WriteFile(dest, []byte("WORKING"), 0o755))
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -187,6 +187,8 @@ type Executor struct {
 	// to miss when buried in journald Warn-level lines.
 	luksTimestampFailMu    sync.Mutex
 	luksTimestampFailCount map[string]int
+
+	now func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // NewExecutor creates a new action executor.
@@ -225,6 +227,7 @@ func NewExecutor(verifier *verify.ActionVerifier) *Executor {
 		pkgManager: pm,
 		verifier:   verifier,
 		logger:     logger,
+		now:        time.Now,
 	}
 }
 
@@ -307,7 +310,7 @@ func (e *Executor) VerifyAction(action *pb.Action) error {
 // ExecuteWithStreaming runs an action with optional output streaming.
 // The callback is called for each line of output as it's produced (for shell actions).
 func (e *Executor) ExecuteWithStreaming(ctx context.Context, action *pb.Action, callback OutputCallback) *pb.ActionResult {
-	start := time.Now()
+	start := e.now()
 
 	result := &pb.ActionResult{
 		ActionId: action.Id,
@@ -341,7 +344,7 @@ func (e *Executor) ExecuteWithStreaming(ctx context.Context, action *pb.Action, 
 		result.Status = pb.ExecutionStatus_EXECUTION_STATUS_FAILED
 		result.Error = fmt.Sprintf("refusing to execute unsigned/tampered action: %v", verifyErr)
 		result.CompletedAt = timestamppb.Now()
-		result.DurationMs = time.Since(start).Milliseconds()
+		result.DurationMs = e.now().Sub(start).Milliseconds()
 		return result
 	}
 
@@ -454,7 +457,7 @@ func (e *Executor) ExecuteWithStreaming(ctx context.Context, action *pb.Action, 
 
 	result.Output = output
 	result.CompletedAt = timestamppb.Now()
-	result.DurationMs = time.Since(start).Milliseconds()
+	result.DurationMs = e.now().Sub(start).Milliseconds()
 
 	// Check context errors first - distinguish between timeout and cancellation
 	switch {

--- a/internal/executor/integration_test.go
+++ b/internal/executor/integration_test.go
@@ -379,6 +379,7 @@ func TestIntegration_Package(t *testing.T) {
 			httpClient: e.httpClient,
 			pkgManager: nil,
 			logger:     e.logger,
+			now:        e.now,
 		}
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_PACKAGE, pb.DesiredState_DESIRED_STATE_PRESENT)
 		action.Params = &pb.Action_Package{Package: &pb.PackageParams{Name: "sl"}}

--- a/internal/executor/lps.go
+++ b/internal/executor/lps.go
@@ -94,7 +94,7 @@ func (e *Executor) setupLpsPasswords(ctx context.Context, params *pb.LpsParams, 
 		storedState := userStates[username]
 
 		// Determine if rotation is needed
-		rotate, reason := shouldRotateLps(storedState, params, username)
+		rotate, reason := shouldRotateLps(storedState, params, username, e.now().UTC())
 		if !rotate {
 			output.WriteString(fmt.Sprintf("LPS: %s — password up to date\n", username))
 			continue
@@ -132,7 +132,7 @@ func (e *Executor) setupLpsPasswords(ctx context.Context, params *pb.LpsParams, 
 
 		rotatedUsers = append(rotatedUsers, username)
 
-		now := time.Now().UTC()
+		now := e.now().UTC()
 		output.WriteString(fmt.Sprintf("LPS: %s — rotated password (reason: %s)\n", username, reason))
 
 		// Update per-user state in SQLite
@@ -237,8 +237,9 @@ func (e *Executor) removeLpsManagement(_ context.Context, actionID string) (*pb.
 }
 
 // shouldRotateLps determines if a password rotation is needed for a user and returns the reason.
-func shouldRotateLps(state *store.LpsUserState, params *pb.LpsParams, username string) (bool, string) {
-	now := time.Now().UTC()
+// now is the caller's clock reading (UTC); injecting it keeps rotation decisions
+// deterministically testable with a fixed clock.
+func shouldRotateLps(state *store.LpsUserState, params *pb.LpsParams, username string, now time.Time) (bool, string) {
 
 	// No state = first run
 	if state == nil {

--- a/internal/executor/luks.go
+++ b/internal/executor/luks.go
@@ -350,7 +350,7 @@ func (e *Executor) checkAndRotate(ctx context.Context, params *pb.EncryptionPara
 	if params.RotationIntervalDays > 0 {
 		// No previous rotation recorded — set the timestamp and skip.
 		if localState.LastRotatedAt.IsZero() {
-			if err := st.SetLuksLastRotatedAt(actionID, time.Now()); err != nil {
+			if err := st.SetLuksLastRotatedAt(actionID, e.now().UTC()); err != nil {
 				// First-rotation timestamp persistence failed.
 				// Subsequent ticks re-enter this branch and re-skip
 				// rotation, so rotation never starts. Track
@@ -363,7 +363,7 @@ func (e *Executor) checkAndRotate(ctx context.Context, params *pb.EncryptionPara
 			return false, nil
 		}
 		intervalDuration := time.Duration(params.RotationIntervalDays) * 24 * time.Hour
-		if time.Since(localState.LastRotatedAt) < intervalDuration {
+		if e.now().Sub(localState.LastRotatedAt) < intervalDuration {
 			return false, nil
 		}
 	}
@@ -415,7 +415,7 @@ func (e *Executor) checkAndRotate(ctx context.Context, params *pb.EncryptionPara
 	// next tick believes nothing rotated and re-rotates — a hot loop
 	// that churns LUKS slots. Track consecutive failures so the
 	// buried-Warn case escalates to Error after the threshold (#80).
-	if err := st.SetLuksLastRotatedAt(actionID, time.Now().UTC()); err != nil {
+	if err := st.SetLuksLastRotatedAt(actionID, e.now().UTC()); err != nil {
 		e.recordLuksTimestampFailure(actionID, "post_rotation", err)
 	} else {
 		e.clearLuksTimestampFailures(actionID)

--- a/internal/executor/luks_rotation_failures_test.go
+++ b/internal/executor/luks_rotation_failures_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestRecordLuksTimestampFailure_EscalatesAtThreshold pins the
@@ -17,7 +18,7 @@ import (
 // stuck-rotation hazard.
 func TestRecordLuksTimestampFailure_EscalatesAtThreshold(t *testing.T) {
 	var buf bytes.Buffer
-	e := &Executor{logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))}
+	e := &Executor{logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})), now: time.Now}
 
 	const actionID = "01HXTEST0000000000000ABCDE"
 	for i := 1; i <= luksTimestampFailureThreshold+1; i++ {
@@ -64,7 +65,7 @@ func TestRecordLuksTimestampFailure_EscalatesAtThreshold(t *testing.T) {
 // doesn't leave the next genuine failure already at Error level.
 func TestClearLuksTimestampFailures_ResetsCounter(t *testing.T) {
 	var buf bytes.Buffer
-	e := &Executor{logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))}
+	e := &Executor{logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})), now: time.Now}
 
 	const actionID = "01HXTEST0000000000000ABCDE"
 
@@ -95,7 +96,7 @@ func TestClearLuksTimestampFailures_ResetsCounter(t *testing.T) {
 // cross-contaminate each other's escalation state.
 func TestRecordLuksTimestampFailure_PerActionIsolation(t *testing.T) {
 	var buf bytes.Buffer
-	e := &Executor{logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))}
+	e := &Executor{logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})), now: time.Now}
 
 	// Action A fails (threshold-1) times — still at Warn.
 	for i := 1; i < luksTimestampFailureThreshold; i++ {

--- a/internal/executor/luks_user_passphrase_test.go
+++ b/internal/executor/luks_user_passphrase_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,7 +28,7 @@ func TestReconcileDeviceKey_UserPassphrasePersistsModeAndConverges(t *testing.T)
 	const devicePath = "/dev/mapper/test"
 	require.NoError(t, st.SetLuksOwnershipTaken(actionID, devicePath))
 
-	e := &Executor{logger: slog.Default()}
+	e := &Executor{logger: slog.Default(), now: time.Now}
 	e.SetStore(st)
 
 	params := &pb.EncryptionParams{

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -46,6 +46,8 @@ type Handler struct {
 	terminalIdleTimeout    time.Duration
 	terminalSweeperStarted bool
 	terminalSweeperStop    chan struct{} // closed by StopTerminalSweeper to stop the sweep loop
+
+	now func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // NewHandler creates a new stream handler.
@@ -57,6 +59,7 @@ func NewHandler(logger *slog.Logger, exec *executor.Executor, sched *scheduler.S
 		store:       st,
 		syncTrigger: syncTrigger,
 		connectedCh: make(chan struct{}),
+		now:         time.Now,
 	}
 }
 

--- a/internal/handler/terminal.go
+++ b/internal/handler/terminal.go
@@ -90,11 +90,13 @@ type terminalSession struct {
 	tempHome     string             // "" during sessionStateStarting
 	cancel       context.CancelFunc // bound to a sessionCtx that gates both start prep and the I/O loop
 	lastActivity time.Time
+
+	now func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 func (ts *terminalSession) touch() {
 	ts.mu.Lock()
-	ts.lastActivity = time.Now()
+	ts.lastActivity = ts.now()
 	ts.mu.Unlock()
 }
 
@@ -265,6 +267,7 @@ func (h *Handler) OnTerminalStart(ctx context.Context, req *pb.TerminalStart) er
 		sender:  sender,
 		state:   sessionStateStarting,
 		cancel:  cancel,
+		now:     time.Now,
 	}
 	ts.touch()
 
@@ -437,7 +440,7 @@ func (h *Handler) OnTerminalStart(ctx context.Context, req *pb.TerminalStart) er
 // touchLocked is the lock-free variant of touch, used when the caller
 // already holds ts.mu (e.g. inside the activation transition).
 func (ts *terminalSession) touchLocked() {
-	ts.lastActivity = time.Now()
+	ts.lastActivity = ts.now()
 }
 
 // OnTerminalInput writes the bytes to the named session's PTY. Unknown
@@ -743,7 +746,7 @@ func (h *Handler) sweepIdleTerminals() {
 	if timeout == 0 {
 		timeout = defaultTerminalIdleTimeout
 	}
-	cutoff := time.Now().Add(-timeout)
+	cutoff := h.now().Add(-timeout)
 	var idle []string
 	for id, ts := range h.terminals {
 		if ts == nil {

--- a/internal/handler/terminal_test.go
+++ b/internal/handler/terminal_test.go
@@ -65,6 +65,7 @@ func newTestHandlerWithTTY(t *testing.T, ttyEnabled bool) (*Handler, *fakeSender
 		logger:      slog.Default(),
 		connectedCh: make(chan struct{}),
 		store:       st,
+		now:         time.Now,
 	}
 	sender := &fakeSender{}
 	h.SetTerminalSender(sender)
@@ -83,6 +84,7 @@ func addTestSession(h *Handler, id, ttyUser string, lastActivity time.Time) *ter
 		ttyUser:      ttyUser,
 		state:        sessionStateActive,
 		lastActivity: lastActivity,
+		now:          time.Now,
 	}
 	h.mu.Lock()
 	h.terminals[id] = ts
@@ -202,6 +204,7 @@ func TestTerminal_SetTerminalSender_AppliesDefaults(t *testing.T) {
 	h := &Handler{
 		logger:      slog.Default(),
 		connectedCh: make(chan struct{}),
+		now:         time.Now,
 	}
 	h.SetTerminalSender(&fakeSender{})
 
@@ -225,6 +228,7 @@ func TestTerminal_SetTerminalSender_DoesNotResetExistingValues(t *testing.T) {
 		connectedCh:         make(chan struct{}),
 		terminalLimit:       7,
 		terminalIdleTimeout: 5 * time.Minute,
+		now:                 time.Now,
 	}
 	h.SetTerminalSender(&fakeSender{})
 
@@ -328,6 +332,7 @@ func TestTerminal_Start_RejectsWhenStoreMissing(t *testing.T) {
 	h := &Handler{
 		logger:      slog.Default(),
 		connectedCh: make(chan struct{}),
+		now:         time.Now,
 		// intentionally no store
 	}
 	sender := &fakeSender{}
@@ -375,6 +380,7 @@ func TestTerminal_CloseDuringStart_MarksStoppingButLeavesRegistryEntry(t *testin
 		ttyUser: "pm-tty-test",
 		state:   sessionStateStarting,
 		cancel:  wrappedCancel,
+		now:     time.Now,
 	}
 	h.mu.Lock()
 	h.terminals["01ABC"] = ts
@@ -422,6 +428,7 @@ func TestTerminal_SnapshotTerminalSender_ReturnsLatest(t *testing.T) {
 	h := &Handler{
 		logger:      slog.Default(),
 		connectedCh: make(chan struct{}),
+		now:         time.Now,
 	}
 	if got := h.snapshotTerminalSender(); got != nil {
 		t.Errorf("snapshot before SetTerminalSender = %v, want nil", got)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -47,6 +47,8 @@ type Scheduler struct {
 	executor ActionExecutor
 	logger   *slog.Logger
 
+	now func() time.Time // clock seam; defaults to time.Now, overridden in tests
+
 	// mu guards Start/Stop transitions only. resultsCh is set once
 	// at construction in New() and is read on the receiver side
 	// without the lock — the lock here exists purely to make the
@@ -86,6 +88,7 @@ func New(store *store.Store, executor ActionExecutor, logger *slog.Logger) *Sche
 		store:    store,
 		executor: executor,
 		logger:   logger,
+		now:      time.Now,
 		// resultsCh buffer is sized for typical tick volume (one
 		// channel write per scheduled action result). When full,
 		// executeAction logs a Warn and continues — the result is
@@ -310,7 +313,7 @@ func (s *Scheduler) runDueActions(ctx context.Context) {
 	// the spec — admins hitting "reboot now" expect immediate
 	// execution.
 	window := s.activeWindow()
-	if !maintenance.IsAllowed(window, time.Now().Local()) {
+	if !maintenance.IsAllowed(window, s.now().Local()) {
 		s.logger.Info("maintenance window closed; deferring due dispatches",
 			"standalone", len(actions),
 			"groups", len(groups),
@@ -393,7 +396,7 @@ func (s *Scheduler) executeGroup(ctx context.Context, g store.StoredActionGroup)
 	}
 
 	// Mark the group as fired so its next_execute_at advances.
-	if err := s.store.MarkGroupExecuted(g.ID, time.Now()); err != nil {
+	if err := s.store.MarkGroupExecuted(g.ID, s.now()); err != nil {
 		s.logger.Error("failed to mark group executed",
 			"group_id", g.ID, "error", err)
 	}
@@ -461,7 +464,7 @@ func (s *Scheduler) executeAction(ctx context.Context, stored *store.StoredActio
 		ActionID:   action.Id.Value,
 		Result:     result,
 		HasChanges: hasChanges,
-		ExecutedAt: time.Now(),
+		ExecutedAt: s.now(),
 	}:
 	default:
 		s.logger.Warn("result channel full, dropping result",

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -479,6 +479,52 @@ func TestRunDueActions_GroupRunOnAssign_OrdersMembers(t *testing.T) {
 	}
 }
 
+// TestRunDueActions_MaintenanceWindowGatedByInjectedClock pins that the
+// offline scheduler's maintenance-window gate is evaluated against the
+// INJECTED clock, not the wall clock: the same due action defers when the
+// injected time is outside the window and fires when it is inside. This
+// is the security-relevant property of the clock seam — an agent that
+// ignored its maintenance window (or read the wrong clock) could run
+// disruptive actions at a forbidden time.
+func TestRunDueActions_MaintenanceWindowGatedByInjectedClock(t *testing.T) {
+	sched, mock := newTestScheduler(t)
+	ctx := context.Background()
+
+	// A RunOnAssign group is due on the next tick (see
+	// TestRunDueActions_GroupRunOnAssign_OrdersMembers).
+	a := makeTestAction("mw-a", pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT)
+	group := &pb.ActionGroup{
+		SourceLabel: "action_set:mw",
+		Schedule:    &pb.ActionSchedule{RunOnAssign: true, IntervalHours: 8},
+		Actions:     []*pb.Action{a},
+	}
+	if err := sched.SyncActions(ctx, nil, []*pb.ActionGroup{group}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Allow only Monday 02:00–03:00 (device-local).
+	sched.SetMaintenanceWindow(&pb.MaintenanceWindow{
+		Schedule: []*pb.MaintenanceWindowEntry{{Days: []string{"mon"}, Allow: "02:00-03:00"}},
+	})
+
+	// 2024-01-01 is a Monday. Clock at 12:00 local is OUTSIDE the window:
+	// the due dispatch must defer (next_execute_at is not advanced), so
+	// the executor is never called.
+	sched.now = func() time.Time { return time.Date(2024, 1, 1, 12, 0, 0, 0, time.Local) }
+	sched.runDueActions(ctx)
+	if got := len(mock.getCalls()); got != 0 {
+		t.Fatalf("window closed per injected clock: expected 0 executions, got %d", got)
+	}
+
+	// Move the injected clock INSIDE the window (Monday 02:30 local).
+	// The still-due action now fires exactly once.
+	sched.now = func() time.Time { return time.Date(2024, 1, 1, 2, 30, 0, 0, time.Local) }
+	sched.runDueActions(ctx)
+	if got := len(mock.getCalls()); got != 1 {
+		t.Fatalf("window open per injected clock: expected 1 execution, got %d", got)
+	}
+}
+
 // Same action id can appear at multiple positions within a group (e.g.
 // AAA in two sets that compose the same definition). Each occurrence
 // dispatches the executor — idempotent action contracts absorb the cost.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -37,8 +37,9 @@ var cronParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month 
 
 // Store manages persistent storage for actions and execution results.
 type Store struct {
-	db *sql.DB
-	mu sync.RWMutex
+	db  *sql.DB
+	mu  sync.RWMutex
+	now func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // StoredAction represents an action stored locally on the agent.
@@ -128,7 +129,7 @@ func New(dataDir string) (*Store, error) {
 		return nil, fmt.Errorf("run migrations: %w", err)
 	}
 
-	return &Store{db: db}, nil
+	return &Store{db: db, now: time.Now}, nil
 }
 
 // Close closes the database connection.
@@ -188,7 +189,7 @@ func (s *Store) SaveAction(action *pb.Action) error {
 	// Cursor for the NEXT scheduled run, computed as if the action just
 	// executed now (the caller runs it inline). Passing &now — rather
 	// than nil — is what keeps it in the future for every schedule shape.
-	now := time.Now().UTC()
+	now := s.now().UTC()
 	nextExecute := s.calculateNextExecute(action, &now, false)
 
 	_, err = s.db.Exec(`
@@ -275,7 +276,7 @@ func (s *Store) GetDueActions(ctx context.Context) ([]*StoredAction, error) {
 		FROM actions
 		WHERE next_execute_at <= ? AND is_grouped = 0
 		ORDER BY next_execute_at ASC
-	`, time.Now().UTC())
+	`, s.now().UTC())
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +379,7 @@ func (s *Store) RecordExecution(actionID string, result *pb.ActionResult, hasCha
 		return "", fmt.Errorf("unmarshal action: %w", err)
 	}
 
-	now := time.Now().UTC()
+	now := s.now().UTC()
 	nextExecute := s.calculateNextExecute(action, &now, false)
 
 	// Calculate result hash for change detection (must match scheduler.detectChanges format)
@@ -538,7 +539,7 @@ func (s *Store) CleanupOldResults(retention time.Duration) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	cutoff := time.Now().Add(-retention)
+	cutoff := s.now().Add(-retention)
 	_, err := s.db.Exec("DELETE FROM results WHERE synced = 1 AND executed_at < ?", cutoff)
 	return err
 }
@@ -637,7 +638,7 @@ func (s *Store) SyncActions(actions []*pb.Action) (*SyncResult, error) {
 		// executes new/changed actions immediately via ID lists, not via next_execute_at.
 		// Setting next_execute_at to "now" caused the scheduler's runDueActions ticker
 		// to double-execute actions while the sync execution was still running.
-		now := time.Now().UTC()
+		now := s.now().UTC()
 		nextExecute := s.calculateNextExecute(action, &now, false)
 
 		// Upsert: insert new or update existing (but preserve execution history)
@@ -767,7 +768,7 @@ func (s *Store) SyncStandaloneAndGrouped(standalone []*pb.Action, groups []*pb.A
 	}
 
 	// Standalone upserts.
-	now := time.Now().UTC()
+	now := s.now().UTC()
 	for _, action := range standalone {
 		if action.Id == nil {
 			continue
@@ -912,7 +913,7 @@ func (s *Store) SyncStandaloneAndGrouped(standalone []*pb.Action, groups []*pb.A
 				lastExec = &t
 				lastExecutedAt = prior.lastExecutedAt
 			}
-			nextExecute = calculateNextExecuteFromSchedule(g.Schedule, lastExec, false)
+			nextExecute = calculateNextExecuteFromSchedule(g.Schedule, lastExec, false, s.now())
 		}
 
 		if _, err := tx.Exec(`
@@ -955,7 +956,7 @@ func (s *Store) GetDueGroups(ctx context.Context) ([]StoredActionGroup, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	now := time.Now().UTC()
+	now := s.now().UTC()
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, source_label, schedule_json, last_executed_at, next_execute_at
 		FROM action_groups
@@ -1073,7 +1074,7 @@ func (s *Store) MarkGroupExecuted(groupID string, executedAt time.Time) error {
 		return fmt.Errorf("unmarshal group schedule: %w", err)
 	}
 	executedUTC := executedAt.UTC()
-	next := calculateNextExecuteFromSchedule(&sched, &executedUTC, false)
+	next := calculateNextExecuteFromSchedule(&sched, &executedUTC, false, s.now())
 
 	_, err := s.db.Exec(`
 		UPDATE action_groups SET last_executed_at = ?, next_execute_at = ?
@@ -1085,8 +1086,10 @@ func (s *Store) MarkGroupExecuted(groupID string, executedAt time.Time) error {
 // calculateNextExecuteFromSchedule mirrors calculateNextExecute but
 // works directly on an ActionSchedule pointer so groups can use it
 // without faking a pb.Action.
-func calculateNextExecuteFromSchedule(schedule *pb.ActionSchedule, lastExecuted *time.Time, runImmediately bool) time.Time {
-	now := time.Now().UTC()
+// now is the caller's clock reading; it is normalised to UTC here so callers
+// can pass a bare reading and the schedule math stays deterministically testable.
+func calculateNextExecuteFromSchedule(schedule *pb.ActionSchedule, lastExecuted *time.Time, runImmediately bool, now time.Time) time.Time {
+	now = now.UTC()
 	if runImmediately && lastExecuted == nil {
 		return now
 	}
@@ -1142,7 +1145,7 @@ func (s *Store) GetAllActionIDs() ([]string, error) {
 // calculateNextExecute determines when an action should next be executed.
 // All returned times are in UTC to ensure correct SQLite comparisons.
 func (s *Store) calculateNextExecute(action *pb.Action, lastExecuted *time.Time, runImmediately bool) time.Time {
-	now := time.Now().UTC()
+	now := s.now().UTC()
 
 	// Run immediately if requested and never executed
 	if runImmediately && lastExecuted == nil {
@@ -1232,7 +1235,7 @@ func (s *Store) SetLuksOwnershipTaken(actionID, devicePath string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := s.now().UTC().Format(time.RFC3339)
 	_, err := s.db.Exec(`
 		INSERT INTO luks_state (action_id, device_path, ownership_taken, device_key_type, last_rotated_at)
 		VALUES (?, ?, TRUE, 'none', ?)


### PR DESCRIPTION
## Summary
Adds self-discovering, build-failing architectural fitness functions in `internal/archtest` and extends the injected-clock seam module-wide. Part of WS0 of the security hardening workplan; green against current `main`.

## Guards
- **TestNoDynamicSQL** — the hand-written sqlite queries (`db`/`tx` receivers) must use string-literal SQL with placeholders; never `fmt.Sprintf`/concatenation. (Receiver-narrowed to the real `*sql.DB`/tx handles so it doesn't false-match osquery/url.URL `.Query()`.)
- **TestSecretComparesAreConstantTime** — secret/token/MAC/signature compares use `subtle.ConstantTimeCompare`/`hmac.Equal`, never `==`/`bytes.Equal`.
- **TestNoUnabstractedTimeNow** — no direct `time.Now()` in runtime code; read the clock through an injected `now func() time.Time` seam (default `time.Now`).

## Clock seam
24 sites converted across Executor/Store/Scheduler/terminal/EnrollHandler plus two free functions. A fixed-clock test pins the offline scheduler's **maintenance-window gate** — a due action defers when the injected clock is outside the window and fires inside it. Duration and the LUKS rotation-interval check use the same seam for deterministic testing.

## Design
Pure-stdlib AST (no `golang.org/x/tools`). Every guard is matches-zero guarded and ships a no-stale-entry-guarded allowlist. Rationale: server repo `docs/adr/0002-architectural-fitness-functions.md`.

Closes #98