### PR TITLE
feat(executor): CA-bound self-update hash, https-only downloads, anti-rollback (WS7)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -27,8 +27,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     systemd \
     && rm -rf /var/lib/apt/lists/*
 
-# Create data directory for agent credentials
-RUN mkdir -p /var/lib/power-manage
+# Create data directory for agent credentials. chmod 700 to match
+# install.sh (WS7 #10): the dir holds action secrets and the agent store,
+# so it must not be group/world-readable.
+RUN mkdir -p /var/lib/power-manage && chmod 700 /var/lib/power-manage
 
 COPY --from=builder /power-manage-agent /usr/local/bin/power-manage-agent
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ The install script:
 2. Creates `/var/lib/power-manage` as a root-owned, mode 0700 data directory
 3. Removes any leftover `/etc/sudoers.d/power-manage`, `/etc/sudoers.d/power-manage-luks`, or `/etc/doas.d/power-manage.conf` from a previous (pre-root-mode) install
 4. Installs the systemd unit with `User=root` and the documented capability bounding set, then enables and starts the service
-5. Installs the desktop URI handler for browser-launched enrollment
-6. Enrolls via the enrollment socket if `--server` and `--token` were provided
+5. Enrolls via the enrollment socket if `--server` and `--token` were provided
+
+The `power-manage://` desktop URI handler is **opt-in** (`--enable-uri-handler` or `POWER_MANAGE_ENABLE_URI_HANDLER=true`) and **off by default** — an unconditional handler exposes the root-capable binary to drive-by browser links (WS7 #4). When enabled, the `.desktop` entry sets `Terminal=false` so a link cannot auto-spawn a terminal.
 
 There is **no LUKS sudoers rule** — `power-manage-agent luks set-passphrase` is an unprivileged client to the root agent's LUKS daemon socket (see [LUKS passphrase daemon](#luks-passphrase-daemon)).
 
@@ -158,6 +159,8 @@ power-manage-agent enroll -server=https://control.example.com:8081 -token=YOUR_T
 
 The agent supports a `power-manage://` URI scheme for easy enrollment from the web UI.
 When clicked, the desktop handler launches the agent which tries socket enrollment first (no sudo), falling back to direct registration.
+
+> The desktop handler that registers this scheme is **opt-in** (`--enable-uri-handler`, off by default — WS7 #4). The CLI invocation below works regardless; only the clickable browser-link registration requires the handler.
 
 ```bash
 power-manage-agent 'power-manage://control.example.com:8081?token=abc123'
@@ -401,13 +404,15 @@ Download and install standalone application binaries.
 
 | Field | Description |
 |-------|-------------|
-| `url` | Download URL |
-| `checksum_sha256` | Optional SHA256 checksum for verification |
+| `url` | Download URL — **HTTPS only** |
+| `checksum_sha256` | **Mandatory** SHA256 checksum (64 lowercase hex) — the download is rejected without it |
 | `install_path` | Installation path |
 
 **Desired State:**
 - `PRESENT`: Download and install the application
 - `ABSENT`: Remove the installed file
+
+> **Mandatory integrity (WS7):** `url` must be HTTPS and `checksum_sha256` is required for all download-and-install actions (`APP_IMAGE`/`DEB`/`RPM`). Without a checksum the only authenticity would be TLS to a possibly-compromised origin, so the agent fails closed.
 
 ### DEB Package (`DEB`)
 
@@ -415,7 +420,8 @@ Install or remove Debian packages directly from URLs.
 
 | Field | Description |
 |-------|-------------|
-| `url` | Download URL for the .deb file |
+| `url` | Download URL for the .deb file — **HTTPS only** |
+| `checksum_sha256` | **Mandatory** SHA256 checksum (64 lowercase hex) |
 
 **Desired State:**
 - `PRESENT`: Download and install with `dpkg`
@@ -427,7 +433,8 @@ Install or remove RPM packages directly from URLs.
 
 | Field | Description |
 |-------|-------------|
-| `url` | Download URL for the .rpm file |
+| `url` | Download URL for the .rpm file — **HTTPS only** |
+| `checksum_sha256` | **Mandatory** SHA256 checksum (64 lowercase hex) |
 
 **Desired State:**
 - `PRESENT`: Download and install with `rpm`
@@ -683,25 +690,34 @@ journalctl -u power-manage-agent -f
 
 ## Auto-Update
 
-The agent self-updates via the `ACTION_TYPE_AGENT_UPDATE` action. Admins schedule this action on their managed devices; the action payload contains architecture-specific binary URLs and SHA256SUMS URLs.
+The agent self-updates via the `ACTION_TYPE_AGENT_UPDATE` action. Admins schedule this action on their managed devices; the action payload carries, per architecture, an HTTPS `binary_url` and the **CA-signed `expected_sha256`** of that binary.
+
+### Authenticity: CA-signed hash, not a same-origin checksum (WS7)
+
+The integrity gate is `expected_sha256`, which travels **inside the CA-signed action**. The agent verifies the downloaded binary against that hash — a value bound to the control server's signature — **not** against a checksum file fetched from the binary's own (untrusted) download origin. A compromised mirror or a man-in-the-middle on the download cannot vouch for a tampered binary: it cannot forge the CA signature over `expected_sha256`. `binary_url` must be HTTPS.
+
+> Binary code-signing is a future enhancement; this interim model binds the hash to the existing enrolled-CA trust root. Any future signing key must be operator-pinnable, never a hardcoded project key. Signing of the *release* `SHA256SUMS` (the initial-install integrity, separate from self-update) is tracked separately.
+
+### Anti-rollback
+
+The agent refuses a candidate **older** than the running version (`vYYYY.MM.PP` comparison); an unparseable version fails closed (never treated as newer). A downgrade requires the signed action to set `allow_downgrade` — the bypass is an explicit, authenticated operator decision, also inside the CA-signed payload.
 
 ### Update Process
 
-1. Download SHA256SUMS file, extract checksum for this binary's filename
-2. Download binary to `/var/lib/power-manage/update/agent-update-*.tmp`, verify SHA256
-3. Run `<tmpPath> version` on the staged binary to extract the new version string, compare with running — skip if same
-4. Run `<tmpPath> self-test` as a subprocess (60s timeout). The self-test:
+1. Download binary to `/var/lib/power-manage/update/agent-update-*.tmp` and verify its SHA256 against the CA-signed `expected_sha256` (no checksum file is fetched or trusted)
+2. Run `<tmpPath> version`, compare with running — skip if same; refuse a downgrade unless `allow_downgrade`
+3. Run `<tmpPath> self-test` as a subprocess (60s timeout). The self-test:
    - Loads stored credentials
    - Establishes an mTLS connection to the gateway
    - Sends `Hello`, waits for `Welcome` (proves bidirectional stream)
    - Calls `SyncActions` (proves unary RPC works)
    - Exits 0 on success, 1 on any failure
-5. If the self-test exits 0: atomically swap the live binary (`cp → chmod → mv`) and trigger graceful shutdown. Systemd restarts with the new binary.
-6. If the self-test fails: report the action as `EXECUTION_STATUS_FAILED` and leave the live binary untouched.
+4. If the self-test exits 0: swap the live binary via `SafeBackupAndReplace` (O_NOFOLLOW + renameat2; the previous binary is copied to `<BinaryPath>.bak` first) and trigger graceful shutdown. Systemd restarts with the new binary.
+5. If the self-test fails: report the action as `EXECUTION_STATUS_FAILED` and leave the live binary untouched.
 
 ### Validate-before-swap
 
-The old binary is **never replaced** until the new binary proves it can connect, sync, and handle the protocol. There is no backup/rollback mechanism — there's nothing to roll back because the swap only happens after validation.
+The old binary is **never replaced** until the new binary proves it can connect, sync, and handle the protocol. The previous binary is kept at `<BinaryPath>.bak` for manual rollback if the new one fails to start after restart (a case the self-test cannot catch).
 
 ### Retry behavior
 

--- a/cmd/power-manage-agent/install_lint_test.go
+++ b/cmd/power-manage-agent/install_lint_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// readRepoFile reads a file at the agent repo root (two levels up from
+// this package: agent/cmd/power-manage-agent → agent/).
+func readRepoFile(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("..", "..", name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}
+
+// WS7 #4: the power-manage:// URI handler must be OPT-IN (off by default),
+// and the desktop entry must not auto-launch a terminal. An unconditional
+// handler exposes the root-capable binary to drive-by links.
+func TestInstall_DesktopHandlerOptIn(t *testing.T) {
+	sh := readRepoFile(t, "install.sh")
+
+	if !strings.Contains(sh, "--enable-uri-handler") {
+		t.Error("install.sh must expose an --enable-uri-handler opt-in flag")
+	}
+	if !strings.Contains(sh, `if [[ "$ENABLE_URI_HANDLER" == "true" ]]`) {
+		t.Error("install_desktop_handler must be gated behind ENABLE_URI_HANDLER (opt-in)")
+	}
+	// Default off: the env default must not be true.
+	if strings.Contains(sh, `ENABLE_URI_HANDLER="${POWER_MANAGE_ENABLE_URI_HANDLER:-true}`) {
+		t.Error("the URI handler must default to OFF")
+	}
+	// No auto-launching terminal entry.
+	if strings.Contains(sh, "Terminal=true") {
+		t.Error("the desktop entry must not set Terminal=true (drive-by auto-launch)")
+	}
+}
+
+// WS7 #9: every capability in the systemd unit's CapabilityBoundingSet
+// must carry a justification comment. Self-discovering: a cap added
+// without a comment fails this test.
+func TestInstall_CapsDocumented(t *testing.T) {
+	sh := readRepoFile(t, "install.sh")
+
+	var capLine string
+	commentCaps := map[string]bool{}
+	for _, l := range strings.Split(sh, "\n") {
+		trimmed := strings.TrimSpace(l)
+		if strings.HasPrefix(trimmed, "CapabilityBoundingSet=") {
+			capLine = strings.TrimPrefix(trimmed, "CapabilityBoundingSet=")
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") {
+			for _, tok := range strings.Fields(trimmed) {
+				tok = strings.Trim(tok, "/,.—-")
+				if strings.HasPrefix(tok, "CAP_") {
+					commentCaps[tok] = true
+				}
+			}
+		}
+	}
+
+	if capLine == "" {
+		t.Fatal("no CapabilityBoundingSet= line found in install.sh")
+	}
+	caps := strings.Fields(capLine)
+	if len(caps) == 0 {
+		t.Fatal("CapabilityBoundingSet is empty")
+	}
+	for _, c := range caps {
+		if !commentCaps[c] {
+			t.Errorf("capability %s in CapabilityBoundingSet has no justification comment", c)
+		}
+	}
+}
+
+// WS7 #10: the Containerfile must chmod the data dir 700, matching
+// install.sh (it holds action secrets + the agent store).
+func TestContainerfile_DataDirPerms(t *testing.T) {
+	cf := readRepoFile(t, "Containerfile")
+	if !strings.Contains(cf, "chmod 700 /var/lib/power-manage") {
+		t.Error("Containerfile must `chmod 700 /var/lib/power-manage` after creating it")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 // it. There is no automatic floating tag — that's intentional, because
 // SDK proto/Go API drifts between commits should be reviewable in the
 // same PR as the agent change that consumes them.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260613220456-3fe7f61ef851
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260614074439-f08e3153fa4b
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260613220456-3fe7f61ef851 h1:wYMA0KgMwNMg8Ene1+uuz/M9IU2HW3106Cy+ImzCMx8=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260613220456-3fe7f61ef851/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260614074439-f08e3153fa4b h1:pbMiax9QoJNlKqcV7FxoIliFijWxrGPRkwAUKtkbrsI=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260614074439-f08e3153fa4b/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,11 @@ SERVER_URL=""
 SKIP_DOWNLOAD=""
 PRE_RELEASE=""
 VERSION="latest"
+# WS7 #4: the power-manage:// desktop URI handler is OPT-IN and OFF by
+# default — an unconditional handler exposes the root-capable binary to
+# drive-by browser links. Enable with --enable-uri-handler or
+# POWER_MANAGE_ENABLE_URI_HANDLER=true.
+ENABLE_URI_HANDLER="${POWER_MANAGE_ENABLE_URI_HANDLER:-false}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -126,6 +131,10 @@ parse_args() {
                 ;;
             --skip-download)
                 SKIP_DOWNLOAD="true"
+                shift
+                ;;
+            --enable-uri-handler)
+                ENABLE_URI_HANDLER="true"
                 shift
                 ;;
             --uninstall)
@@ -562,17 +571,24 @@ uninstall() {
     log_info "Uninstall complete"
 }
 
+# install_desktop_handler registers the power-manage:// URI scheme so a
+# browser link can launch `power-manage-agent luks set-passphrase`. It is
+# OPT-IN (--enable-uri-handler / POWER_MANAGE_ENABLE_URI_HANDLER=true) and
+# OFF by default: an unconditional handler exposes the root-capable binary
+# to drive-by links (WS7 #4). The entry sets Terminal=false so a malicious
+# link cannot silently auto-spawn a terminal; operators who enable the
+# handler get a non-auto-launching entry.
 install_desktop_handler() {
     local desktop_file="/usr/share/applications/power-manage-agent.desktop"
 
-    log_info "Installing desktop URI handler..."
+    log_info "Installing desktop URI handler (opt-in)..."
 
     cat > "$desktop_file" << EOF
 [Desktop Entry]
 Name=Power Manage Agent
 Comment=Power Manage device agent
 Exec=$BINARY_PATH %u
-Terminal=true
+Terminal=false
 Type=Application
 MimeType=x-scheme-handler/power-manage;
 NoDisplay=true
@@ -657,7 +673,13 @@ main() {
 
     create_directories
     install_systemd_service
-    install_desktop_handler
+    # WS7 #4: opt-in only — the URI handler exposes the root-capable binary
+    # to drive-by power-manage:// links, so it is not installed by default.
+    if [[ "$ENABLE_URI_HANDLER" == "true" ]]; then
+        install_desktop_handler
+    else
+        log_info "Skipping power-manage:// URI handler (enable with --enable-uri-handler)"
+    fi
 
     enable_and_start_service
 

--- a/internal/executor/action_appimage.go
+++ b/internal/executor/action_appimage.go
@@ -50,15 +50,16 @@ func (e *Executor) executeAppImage(ctx context.Context, params *pb.AppInstallPar
 	// directly, so a URL like "https://evil.example/../../etc/" or
 	// a malformed input could produce a path-meaningful filename
 	// and either escape installPath or land on an unexpected name.
-	// Require a parseable https/http URL with a non-empty host;
-	// derive the filename from a path segment that has no slashes
-	// or other directory components.
+	// Require a parseable HTTPS URL with a non-empty host (WS7 #2:
+	// https-only — the previous code also allowed http://); derive the
+	// filename from a path segment that has no slashes or other directory
+	// components.
 	parsedURL, err := url.Parse(strings.TrimSpace(params.Url))
 	if err != nil ||
-		(parsedURL.Scheme != "https" && parsedURL.Scheme != "http") ||
+		parsedURL.Scheme != "https" ||
 		parsedURL.Opaque != "" ||
 		parsedURL.Host == "" {
-		return nil, false, fmt.Errorf("invalid appimage URL: %q", params.Url)
+		return nil, false, fmt.Errorf("invalid appimage URL (must be https): %q", params.Url)
 	}
 	filename := filepath.Base(parsedURL.Path)
 	// Reject ".." too — filepath.Base of e.g. https://x.example/.. returns

--- a/internal/executor/agent_update.go
+++ b/internal/executor/agent_update.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"bufio"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -13,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -63,16 +63,18 @@ func (e *Executor) markAgentUpdateExecuted() bool {
 //  1. Check if another AGENT_UPDATE already ran this cycle → skip
 //  2. Look up AgentUpdateArch for own architecture
 //  3. If no entry → skip (success, no changes)
-//  4. Validate URLs are HTTPS
-//  5. Download checksum file, extract checksum for binary filename
-//  6. Download binary to temp file, verify SHA256
-//  7. Run ./agent-new version → extract version string
-//  8. Compare with running version → skip if same
-//  9. Run ./agent-new self-test → subprocess validates connectivity
+//  4. Validate the binary URL is HTTPS
+//  5. Download binary to temp file, verify SHA256 against the CA-signed
+//     expected_sha256 (WS7 #1 — NOT a same-origin checksum file)
+//  6. Run ./agent-new version → extract version string
+//  7. Compare with running version → skip if same; refuse a downgrade
+//     unless allow_downgrade is set on the signed action (anti-rollback)
+//  8. Run ./agent-new self-test → subprocess validates connectivity
 //     (credentials load, mTLS, stream, SyncActions). If it fails,
 //     the old binary stays untouched.
-//  10. Atomically swap binary (cp → chmod → mv)
-//  11. Signal graceful shutdown (systemd restarts with new binary)
+//  9. Atomically swap binary via SafeBackupAndReplace (O_NOFOLLOW +
+//     renameat2; copies the old binary to .bak first)
+//  10. Signal graceful shutdown (systemd restarts with new binary)
 //
 // Retry behavior: if the self-test fails, the update is reported as
 // EXECUTION_STATUS_FAILED and the old binary continues running. There is no
@@ -100,20 +102,26 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 		return &pb.CommandOutput{Stdout: fmt.Sprintf("No update entry for architecture %s", runtime.GOARCH)}, false, nil
 	}
 
-	// Step 3: Validate HTTPS
+	// Step 3: Validate the binary URL is HTTPS (fail-closed before any
+	// network).
 	if err := validateHTTPS(arch.BinaryUrl); err != nil {
 		return nil, false, fmt.Errorf("binary URL validation: %w", err)
 	}
-	if err := validateHTTPS(arch.ChecksumUrl); err != nil {
-		return nil, false, fmt.Errorf("checksum URL validation: %w", err)
-	}
 
-	// Step 4: Download checksum file and extract checksum for our binary.
-	// Use url.Parse to strip query parameters (e.g. S3 presigned URLs).
-	binaryFilename := extractFilename(arch.BinaryUrl)
-	expectedChecksum, err := downloadAndExtractChecksum(ctx, e.httpClient, arch.ChecksumUrl, binaryFilename)
-	if err != nil {
-		return nil, false, fmt.Errorf("download checksum: %w", err)
+	// Step 4: The AUTHORITATIVE integrity gate is the CA-signed
+	// expected_sha256 (WS7 #1). It rides inside the signed action, so a
+	// compromised download origin — or a checksum file fetched from that
+	// same origin — cannot vouch for a tampered binary. We deliberately do
+	// NOT download or trust a same-origin checksum file; checksum_url is
+	// retained on the action only as operator-facing metadata.
+	expectedChecksum := strings.ToLower(arch.ExpectedSha256)
+	// Defense-in-depth: the server + proto require expected_sha256, but
+	// fail closed here too rather than downloading and reporting a
+	// confusing "expected , got <hash>" mismatch. (This path uses
+	// downloadToFile, not the downloadFile chokepoint, so the guard must
+	// live here.)
+	if expectedChecksum == "" {
+		return nil, false, fmt.Errorf("agent update rejected: expected_sha256 is empty in the signed action")
 	}
 
 	// Step 5: Download binary to temp file in DataDir (agent-owned).
@@ -139,8 +147,8 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 	}
 	tmpFile.Close()
 
-	if actualChecksum != expectedChecksum {
-		return nil, false, fmt.Errorf("checksum mismatch: expected %s, got %s", expectedChecksum, actualChecksum)
+	if !strings.EqualFold(actualChecksum, expectedChecksum) {
+		return nil, false, fmt.Errorf("checksum mismatch: binary does not match CA-signed expected_sha256 (expected %s, got %s)", expectedChecksum, actualChecksum)
 	}
 
 	// Make executable
@@ -154,10 +162,30 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 		return nil, false, fmt.Errorf("version check on downloaded binary: %w", err)
 	}
 
-	// Step 7: Compare versions — skip if same
+	// Step 7: Compare versions — skip if same (fast exact-string path).
 	if newVersion == cfg.Version {
 		e.logger.Info("agent is already at the latest version", "version", cfg.Version)
 		return &pb.CommandOutput{Stdout: fmt.Sprintf("Already at version %s", cfg.Version)}, false, nil
+	}
+
+	// Anti-rollback (WS7 #7): refuse a candidate that is older than the
+	// running version unless the signed action explicitly allows a
+	// downgrade. An unparseable version fails CLOSED — never treated as
+	// newer. allow_downgrade rides inside the CA-signed action, so a
+	// downgrade is an explicit, authenticated operator decision.
+	if !params.AllowDowngrade {
+		cmp, cmpErr := compareAgentVersion(cfg.Version, newVersion)
+		if cmpErr != nil {
+			return nil, false, fmt.Errorf("refusing update: cannot compare versions (running %q, candidate %q): %w", cfg.Version, newVersion, cmpErr)
+		}
+		if cmp > 0 {
+			return nil, false, fmt.Errorf("refusing downgrade: candidate %s is older than running %s (set allow_downgrade on the action to override)", newVersion, cfg.Version)
+		}
+		if cmp == 0 {
+			// Semantically equal despite differing strings — nothing to do.
+			e.logger.Info("agent is already at an equivalent version", "running", cfg.Version, "candidate", newVersion)
+			return &pb.CommandOutput{Stdout: fmt.Sprintf("Already at version %s", cfg.Version)}, false, nil
+		}
 	}
 
 	e.logger.Info("updating agent", "from", cfg.Version, "to", newVersion)
@@ -191,9 +219,11 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 	e.logger.Info("self-test passed", "output", selfTestResult.Stdout)
 
 	// Step 9: Self-test passed — swap the binary. The old binary is
-	// still running in memory, so this is safe. Use atomic
-	// cp → chmod → mv so the live path is only updated after the
-	// new file is fully written and executable.
+	// still running in memory, so this is safe. The swap goes through the
+	// SDK's SafeBackupAndReplace (O_NOFOLLOW + renameat2), so the live
+	// path is only updated after the new file is fully written, and a
+	// symlink-replacement race on the live path or the .bak cannot
+	// redirect the write.
 	//
 	// Before the swap, save the currently-installed binary to a
 	// `.bak` sibling so an operator can roll back manually with
@@ -246,13 +276,48 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 	return &pb.CommandOutput{Stdout: stdout}, true, nil
 }
 
-// extractFilename returns the filename from a URL, stripping query parameters.
-func extractFilename(rawURL string) string {
-	u, err := url.Parse(rawURL)
+// compareAgentVersion compares two vYYYY.MM.PP version strings and returns
+// -1 if a < b, 0 if equal, +1 if a > b. The leading "v" is optional. A
+// version that does not parse to exactly three numeric components is an
+// error — callers MUST treat that as fail-closed (never "newer"), so a
+// malformed candidate cannot bypass anti-rollback (WS7 #7).
+func compareAgentVersion(a, b string) (int, error) {
+	pa, err := parseAgentVersion(a)
 	if err != nil {
-		return filepath.Base(rawURL)
+		return 0, err
 	}
-	return filepath.Base(u.Path)
+	pb, err := parseAgentVersion(b)
+	if err != nil {
+		return 0, err
+	}
+	for i := 0; i < len(pa); i++ {
+		if pa[i] != pb[i] {
+			if pa[i] < pb[i] {
+				return -1, nil
+			}
+			return 1, nil
+		}
+	}
+	return 0, nil
+}
+
+// parseAgentVersion parses "vYYYY.MM.PP" (leading v optional) into its
+// three numeric components.
+func parseAgentVersion(v string) ([3]int, error) {
+	var out [3]int
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	parts := strings.Split(v, ".")
+	if len(parts) != 3 {
+		return out, fmt.Errorf("invalid version %q: want vYYYY.MM.PP", v)
+	}
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return out, fmt.Errorf("invalid version component %q in %q: %w", p, v, err)
+		}
+		out[i] = n
+	}
+	return out, nil
 }
 
 // getArchEntry returns the AgentUpdateArch for the current runtime architecture.
@@ -277,61 +342,6 @@ func validateHTTPS(rawURL string) error {
 		return fmt.Errorf("URL must use HTTPS, got %q", u.Scheme)
 	}
 	return nil
-}
-
-// downloadAndExtractChecksum downloads a SHA256SUMS-style file and extracts
-// the checksum for the given filename. Format: "<hex>  <filename>" or "<hex> <filename>".
-func downloadAndExtractChecksum(ctx context.Context, client *http.Client, checksumURL, filename string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, checksumURL, nil)
-	if err != nil {
-		return "", fmt.Errorf("create request: %w", err)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("download: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected status %d", resp.StatusCode)
-	}
-
-	// Parse SHA256SUMS format: each line is "<hex>  <filename>" or "<hex> <filename>"
-	scanner := bufio.NewScanner(resp.Body)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
-
-		// Split on whitespace (double-space or single-space)
-		parts := strings.Fields(line)
-		if len(parts) != 2 {
-			continue
-		}
-
-		checksumHex := parts[0]
-		name := parts[1]
-
-		// Strip leading "./" or "*" prefix from filename (common in SHA256SUMS)
-		name = strings.TrimPrefix(name, "./")
-		name = strings.TrimPrefix(name, "*")
-
-		if name == filename {
-			// Validate it looks like a hex SHA256
-			if len(checksumHex) != 64 {
-				return "", fmt.Errorf("invalid checksum length for %s: %d", filename, len(checksumHex))
-			}
-			return strings.ToLower(checksumHex), nil
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("read checksum file: %w", err)
-	}
-
-	return "", fmt.Errorf("checksum for %q not found in checksum file", filename)
 }
 
 // downloadToFile downloads a URL to a file and returns the SHA256 hex checksum.

--- a/internal/executor/agent_update_orchestration_test.go
+++ b/internal/executor/agent_update_orchestration_test.go
@@ -1,0 +1,253 @@
+package executor
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// agentScript builds a staged "agent binary" as a shell script that
+// answers `version` and `self-test`, so executeAgentUpdate can be driven
+// end-to-end without a real binary.
+func agentScript(version string, selfTestExit int) []byte {
+	return []byte(fmt.Sprintf(`#!/bin/sh
+case "$1" in
+  version) echo %q ;;
+  self-test) exit %d ;;
+  *) exit 0 ;;
+esac
+`, version, selfTestExit))
+}
+
+func sha256hex(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+// updateHarness wires an executor with an AgentUpdateConfig pointed at a
+// tmp "installed" binary, an httptest TLS server serving the staged
+// binary + a SHA256SUMS document, and a Shutdown spy.
+type updateHarness struct {
+	e            *Executor
+	binaryPath   string
+	oldBytes     []byte
+	srv          *httptest.Server
+	shutdownCh   chan struct{}
+	shutdownOnce sync.Once
+}
+
+// newUpdateHarness serves `serveBody` at /agent and `sumsBody` at /sums.
+func newUpdateHarness(t *testing.T, runningVersion string, serveBody, sumsBody []byte) *updateHarness {
+	t.Helper()
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "power-manage-agent")
+	oldBytes := []byte("#!/bin/sh\necho OLD\n")
+	if err := os.WriteFile(binaryPath, oldBytes, 0o755); err != nil {
+		t.Fatalf("seed binary: %v", err)
+	}
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/agent":
+			w.Write(serveBody)
+		case "/sums":
+			w.Write(sumsBody)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	h := &updateHarness{binaryPath: binaryPath, oldBytes: oldBytes, srv: srv, shutdownCh: make(chan struct{})}
+	e := &Executor{logger: slog.Default(), now: time.Now}
+	e.httpClient = srv.Client()
+	e.SetUpdateConfig(&AgentUpdateConfig{
+		Version:    runningVersion,
+		DataDir:    t.TempDir(),
+		BinaryPath: binaryPath,
+		Shutdown:   func() { h.shutdownOnce.Do(func() { close(h.shutdownCh) }) },
+	})
+	h.e = e
+	return h
+}
+
+func (h *updateHarness) params(expectedSha string) *pb.AgentUpdateParams {
+	return &pb.AgentUpdateParams{
+		Amd64: &pb.AgentUpdateArch{
+			BinaryUrl:      h.srv.URL + "/agent",
+			ChecksumUrl:    h.srv.URL + "/sums",
+			ExpectedSha256: expectedSha,
+		},
+		Arm64: &pb.AgentUpdateArch{
+			BinaryUrl:      h.srv.URL + "/agent",
+			ChecksumUrl:    h.srv.URL + "/sums",
+			ExpectedSha256: expectedSha,
+		},
+	}
+}
+
+func (h *updateHarness) shutdownCalled() bool {
+	select {
+	case <-h.shutdownCh:
+		return true
+	case <-time.After(4 * time.Second):
+		return false
+	}
+}
+
+func (h *updateHarness) currentBinary(t *testing.T) []byte {
+	t.Helper()
+	b, err := os.ReadFile(h.binaryPath)
+	if err != nil {
+		t.Fatalf("read binary: %v", err)
+	}
+	return b
+}
+
+// WS7 #6: a binary whose bytes do not hash to the action's
+// expected_sha256 is rejected; the swap is aborted, the live binary is
+// byte-identical, no .bak is created, Shutdown is not called.
+func TestExecuteAgentUpdate_ChecksumMismatchAbortsSwap(t *testing.T) {
+	genuine := agentScript("v2026.06.05", 0)
+	tampered := append([]byte{}, genuine...)
+	tampered[len(tampered)-2] ^= 0xff // flip a non-terminal byte
+
+	// expected_sha256 is the hash of the GENUINE bytes; the server serves
+	// TAMPERED bytes → mismatch (intent: hash binds content).
+	h := newUpdateHarness(t, "v2026.06.01", tampered, nil)
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params(sha256hex(genuine)))
+
+	if err == nil {
+		t.Fatal("checksum mismatch must abort the update")
+	}
+	if changed {
+		t.Error("changed must be false on checksum mismatch")
+	}
+	if got := h.currentBinary(t); string(got) != string(h.oldBytes) {
+		t.Error("live binary must be unchanged on checksum mismatch")
+	}
+	if _, statErr := os.Stat(h.binaryPath + ".bak"); statErr == nil {
+		t.Error(".bak must not be created when the swap aborts")
+	}
+}
+
+// WS7 #1 (core): when expected_sha256 is present, the swap is gated on it
+// and a malicious same-origin checksum document is NOT trusted. Serve a
+// SHA256SUMS that advertises a MATCHING hash for the tampered bytes while
+// expected_sha256 holds the genuine hash → tampered binary rejected.
+func TestExecuteAgentUpdate_HashBoundToSignedAction_NotChecksumFile(t *testing.T) {
+	genuine := agentScript("v2026.06.05", 0)
+	tampered := append([]byte{}, genuine...)
+	tampered[len(tampered)-2] ^= 0xff
+
+	// The lying checksum file vouches for the tampered bytes.
+	sums := []byte(sha256hex(tampered) + "  agent\n")
+	h := newUpdateHarness(t, "v2026.06.01", tampered, sums)
+
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params(sha256hex(genuine)))
+	if err == nil {
+		t.Fatal("tampered binary must be rejected even when a same-origin checksum file vouches for it")
+	}
+	if changed {
+		t.Error("changed must be false")
+	}
+	if got := h.currentBinary(t); string(got) != string(h.oldBytes) {
+		t.Error("live binary must be unchanged")
+	}
+}
+
+// WS7 #6: a staged binary whose self-test fails keeps the current binary.
+func TestExecuteAgentUpdate_SelfTestFailKeepsBinary(t *testing.T) {
+	staged := agentScript("v2026.06.05", 1) // self-test exits non-zero
+	h := newUpdateHarness(t, "v2026.06.01", staged, nil)
+
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params(sha256hex(staged)))
+	if err == nil {
+		t.Fatal("self-test failure must abort the update")
+	}
+	if changed {
+		t.Error("changed must be false on self-test failure")
+	}
+	if got := h.currentBinary(t); string(got) != string(h.oldBytes) {
+		t.Error("live binary must be unchanged on self-test failure")
+	}
+}
+
+// WS7 #6 happy path: correct sha + passing self-test + newer version →
+// binary swapped, .bak holds old bytes, Shutdown invoked.
+func TestExecuteAgentUpdate_HappyPathSwapsAndShutsDown(t *testing.T) {
+	staged := agentScript("v2026.06.05", 0)
+	h := newUpdateHarness(t, "v2026.06.01", staged, nil)
+
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params(sha256hex(staged)))
+	if err != nil {
+		t.Fatalf("happy-path update failed: %v", err)
+	}
+	if !changed {
+		t.Error("changed must be true on a successful update")
+	}
+	if got := h.currentBinary(t); string(got) != string(staged) {
+		t.Error("live binary must be the staged bytes after swap")
+	}
+	bak, err := os.ReadFile(h.binaryPath + ".bak")
+	if err != nil {
+		t.Fatalf("read .bak: %v", err)
+	}
+	if string(bak) != string(h.oldBytes) {
+		t.Error(".bak must hold the previous binary")
+	}
+	if !h.shutdownCalled() {
+		t.Error("Shutdown must be invoked after a successful update")
+	}
+}
+
+// WS7 #1 defense-in-depth: an empty expected_sha256 in the (signed)
+// action is refused fail-closed before any download — the agent-update
+// path uses downloadToFile, which has no checksum chokepoint of its own.
+func TestExecuteAgentUpdate_RefusesEmptyExpectedSha256(t *testing.T) {
+	staged := agentScript("v2026.06.05", 0)
+	h := newUpdateHarness(t, "v2026.06.01", staged, nil)
+
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params("")) // empty expected_sha256
+	if err == nil {
+		t.Fatal("an empty expected_sha256 must be refused")
+	}
+	if changed {
+		t.Error("changed must be false")
+	}
+	if got := h.currentBinary(t); string(got) != string(h.oldBytes) {
+		t.Error("live binary must be unchanged")
+	}
+}
+
+// WS7 #2: an http binary_url is rejected at validateHTTPS before any
+// download (fail-closed ordering).
+func TestExecuteAgentUpdate_HTTPSourceRejected(t *testing.T) {
+	staged := agentScript("v2026.06.05", 0)
+	h := newUpdateHarness(t, "v2026.06.01", staged, nil)
+	p := h.params(sha256hex(staged))
+	p.Amd64.BinaryUrl = "http://example.com/agent"
+	p.Arm64.BinaryUrl = "http://example.com/agent"
+
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), p)
+	if err == nil {
+		t.Fatal("http binary_url must be rejected")
+	}
+	if changed {
+		t.Error("changed must be false")
+	}
+	if got := h.currentBinary(t); string(got) != string(h.oldBytes) {
+		t.Error("live binary must be unchanged")
+	}
+}

--- a/internal/executor/agent_update_test.go
+++ b/internal/executor/agent_update_test.go
@@ -55,39 +55,6 @@ func TestGetArchEntry_NilForMissing(t *testing.T) {
 	}
 }
 
-func TestDownloadAndExtractChecksum(t *testing.T) {
-	checksumContent := "abc123def456  some-other-binary\n" +
-		"deadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234567  power-manage-agent-linux-amd64\n" +
-		"1111111122222222333333334444444455555555666666667777777788888888  power-manage-agent-linux-arm64\n"
-
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(checksumContent))
-	}))
-	defer srv.Close()
-
-	client := srv.Client()
-
-	checksum, err := downloadAndExtractChecksum(context.Background(), client, srv.URL+"/SHA256SUMS", "power-manage-agent-linux-amd64")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if checksum != "deadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234567" {
-		t.Errorf("unexpected checksum: %s", checksum)
-	}
-}
-
-func TestDownloadAndExtractChecksum_NotFound(t *testing.T) {
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("abc123  other-binary\n"))
-	}))
-	defer srv.Close()
-
-	_, err := downloadAndExtractChecksum(context.Background(), srv.Client(), srv.URL+"/SHA256SUMS", "nonexistent")
-	if err == nil {
-		t.Error("expected error for missing binary in checksum file")
-	}
-}
-
 func TestDownloadToFile(t *testing.T) {
 	content := []byte("test binary content")
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -227,38 +194,6 @@ func TestCheckStartupUpdateState_NoState(t *testing.T) {
 	}
 }
 
-func TestDownloadAndExtractChecksum_WithPrefixes(t *testing.T) {
-	// Test with "./" and "*" prefixes (common in SHA256SUMS files)
-	checksumContent := fmt.Sprintf(
-		"%s  ./my-binary\n%s  *other-binary\n",
-		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-	)
-
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(checksumContent))
-	}))
-	defer srv.Close()
-
-	// Should find "my-binary" even with "./" prefix
-	checksum, err := downloadAndExtractChecksum(context.Background(), srv.Client(), srv.URL+"/SHA256SUMS", "my-binary")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if checksum != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
-		t.Errorf("unexpected checksum: %s", checksum)
-	}
-
-	// Should find "other-binary" even with "*" prefix
-	checksum, err = downloadAndExtractChecksum(context.Background(), srv.Client(), srv.URL+"/SHA256SUMS", "other-binary")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if checksum != "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" {
-		t.Errorf("unexpected checksum: %s", checksum)
-	}
-}
-
 func TestGetBinaryVersion(t *testing.T) {
 	// Create a fake binary that prints a version
 	dir := t.TempDir()
@@ -288,24 +223,6 @@ func TestGetBinaryVersion_Empty(t *testing.T) {
 	_, err = getBinaryVersion(script)
 	if err == nil {
 		t.Error("expected error for empty version output")
-	}
-}
-
-func TestExtractFilename(t *testing.T) {
-	tests := []struct {
-		url  string
-		want string
-	}{
-		{"https://github.com/org/repo/releases/latest/download/agent-linux-amd64", "agent-linux-amd64"},
-		{"https://s3.amazonaws.com/bucket/agent-linux-amd64?X-Amz-Signature=abc&token=xyz", "agent-linux-amd64"},
-		{"https://example.com/path/to/binary?v=2", "binary"},
-		{"https://example.com/binary", "binary"},
-	}
-	for _, tt := range tests {
-		got := extractFilename(tt.url)
-		if got != tt.want {
-			t.Errorf("extractFilename(%q) = %q, want %q", tt.url, got, tt.want)
-		}
 	}
 }
 
@@ -358,4 +275,22 @@ func (l *testLogger) Warn(msg string, args ...any) {
 
 func (l *testLogger) Error(msg string, args ...any) {
 	l.errors = append(l.errors, msg)
+}
+
+// TestNoStaleSwapComment is a self-discovering guard against the WS7 #8
+// stale comment: the agent-update flow no longer does cp → chmod → mv, it
+// uses SafeBackupAndReplace. Pins the source so a future edit can't
+// reintroduce the misleading description.
+func TestNoStaleSwapComment(t *testing.T) {
+	src, err := os.ReadFile("agent_update.go")
+	if err != nil {
+		t.Fatalf("read agent_update.go: %v", err)
+	}
+	s := string(src)
+	if strings.Contains(s, "cp → chmod → mv") {
+		t.Error("agent_update.go still describes the swap as 'cp → chmod → mv'; it uses SafeBackupAndReplace")
+	}
+	if !strings.Contains(s, "SafeBackupAndReplace") {
+		t.Error("agent_update.go should document the swap goes through SafeBackupAndReplace")
+	}
 }

--- a/internal/executor/anti_rollback_test.go
+++ b/internal/executor/anti_rollback_test.go
@@ -1,0 +1,124 @@
+package executor
+
+import (
+	"context"
+	"testing"
+)
+
+// WS7 #7: compareAgentVersion parses vYYYY.MM.PP and orders releases.
+// Comparisons sourced from the documented scheme, not the parser.
+func TestCompareAgentVersion_Table(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int // sign of compare(a,b): -1 a<b, 0 equal, +1 a>b
+	}{
+		{"v2026.06.01", "v2026.06.02", -1},
+		{"v2026.06.02", "v2026.06.01", 1},
+		{"v2026.06.01", "v2026.06.01", 0},
+		{"2026.06.01", "v2026.06.01", 0}, // leading v optional
+		{"v2026.10.00", "v2026.09.99", 1},
+		{"v2027.01.00", "v2026.12.31", 1},
+		{"v2026.06.10", "v2026.06.09", 1},
+	}
+	for _, tc := range cases {
+		got, err := compareAgentVersion(tc.a, tc.b)
+		if err != nil {
+			t.Errorf("compareAgentVersion(%q,%q) error: %v", tc.a, tc.b, err)
+			continue
+		}
+		if sign(got) != tc.want {
+			t.Errorf("compareAgentVersion(%q,%q) sign = %d, want %d", tc.a, tc.b, sign(got), tc.want)
+		}
+	}
+
+	// Malformed → error (never silently treated as comparable).
+	for _, bad := range []string{"", "garbage", "v2026.06", "v2026.06.01.02", "vYYYY.MM.PP", "2026-06-01"} {
+		if _, err := compareAgentVersion("v2026.06.01", bad); err == nil {
+			t.Errorf("compareAgentVersion with malformed %q must error", bad)
+		}
+	}
+}
+
+func sign(n int) int {
+	switch {
+	case n < 0:
+		return -1
+	case n > 0:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// WS7 #7: a staged binary OLDER than the running version is refused
+// (anti-rollback), unchanged binary, no shutdown — unless allow_downgrade
+// is set in the signed action.
+func TestExecuteAgentUpdate_RefusesOlderVersion(t *testing.T) {
+	staged := agentScript("v2026.05.01", 0)
+	h := newUpdateHarness(t, "v2026.06.02", staged, nil) // running newer than staged
+
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params(sha256hex(staged)))
+	if err == nil {
+		t.Fatal("a downgrade must be refused by default")
+	}
+	if changed {
+		t.Error("changed must be false on a refused downgrade")
+	}
+	if got := h.currentBinary(t); string(got) != string(h.oldBytes) {
+		t.Error("live binary must be unchanged on a refused downgrade")
+	}
+}
+
+// A malformed staged version is refused fail-closed (never treated as
+// newer).
+func TestExecuteAgentUpdate_RefusesMalformedVersion(t *testing.T) {
+	staged := agentScript("garbage", 0)
+	h := newUpdateHarness(t, "v2026.06.02", staged, nil)
+
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params(sha256hex(staged)))
+	if err == nil {
+		t.Fatal("an unparseable staged version must be refused fail-closed")
+	}
+	if changed {
+		t.Error("changed must be false")
+	}
+}
+
+// A malformed RUNNING version is also refused fail-closed — if the agent
+// cannot parse its own version it cannot prove the candidate is not a
+// downgrade, so it must not swap.
+func TestExecuteAgentUpdate_RefusesMalformedRunningVersion(t *testing.T) {
+	staged := agentScript("v2026.06.02", 0)
+	h := newUpdateHarness(t, "garbage", staged, nil) // running version unparseable
+
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params(sha256hex(staged)))
+	if err == nil {
+		t.Fatal("an unparseable running version must be refused fail-closed")
+	}
+	if changed {
+		t.Error("changed must be false")
+	}
+	if got := h.currentBinary(t); string(got) != string(h.oldBytes) {
+		t.Error("live binary must be unchanged when the running version is unparseable")
+	}
+}
+
+// allow_downgrade in the signed action is the ONLY bypass: an older staged
+// version then proceeds (swaps + shuts down).
+func TestExecuteAgentUpdate_AllowDowngradeBypass(t *testing.T) {
+	staged := agentScript("v2026.05.01", 0)
+	h := newUpdateHarness(t, "v2026.06.02", staged, nil)
+	p := h.params(sha256hex(staged))
+	p.AllowDowngrade = true
+
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), p)
+	if err != nil {
+		t.Fatalf("allow_downgrade should permit an older version: %v", err)
+	}
+	if !changed {
+		t.Error("changed must be true when allow_downgrade permits the swap")
+	}
+	if got := h.currentBinary(t); string(got) != string(staged) {
+		t.Error("binary must be swapped to the (older) staged bytes under allow_downgrade")
+	}
+}

--- a/internal/executor/download_scheme_test.go
+++ b/internal/executor/download_scheme_test.go
@@ -39,14 +39,6 @@ func TestDownloadFile_RejectsNonHTTPS(t *testing.T) {
 	}
 }
 
-func TestDownloadFile_RejectsEmptyChecksum(t *testing.T) {
-	e := &Executor{logger: slog.Default(), now: time.Now}
-	dest := filepath.Join(t.TempDir(), "out")
-	if err := e.downloadFile(context.Background(), "https://example.com/app.deb", dest, ""); err == nil {
-		t.Error("downloadFile with an empty checksum must be rejected (mandatory integrity)")
-	}
-}
-
 // The https + correct-checksum path succeeds (proves the guard does not
 // over-reject and the chokepoint still works).
 func TestDownloadFile_AcceptsHTTPSWithChecksum(t *testing.T) {

--- a/internal/executor/download_scheme_test.go
+++ b/internal/executor/download_scheme_test.go
@@ -1,0 +1,90 @@
+package executor
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// WS7 #2: downloadFile is the single chokepoint for deb/rpm/appimage
+// downloads. It must reject any non-https scheme AND an empty checksum
+// (mandatory integrity) BEFORE any network request.
+func TestDownloadFile_RejectsNonHTTPS(t *testing.T) {
+	e := &Executor{logger: slog.Default(), now: time.Now}
+	dest := filepath.Join(t.TempDir(), "out")
+	const anyChecksum = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	for _, u := range []string{
+		"http://example.com/app.deb",
+		"file:///etc/passwd",
+		"ftp://example.com/app.deb",
+		"//example.com/app.deb", // scheme-relative
+		"example.com/app.deb",   // no scheme
+	} {
+		if err := e.downloadFile(context.Background(), u, dest, anyChecksum); err == nil {
+			t.Errorf("downloadFile(%q) = nil, want rejection (non-https)", u)
+		}
+		if _, err := os.Stat(dest); err == nil {
+			t.Errorf("downloadFile(%q) created the destination despite rejection", u)
+		}
+	}
+}
+
+func TestDownloadFile_RejectsEmptyChecksum(t *testing.T) {
+	e := &Executor{logger: slog.Default(), now: time.Now}
+	dest := filepath.Join(t.TempDir(), "out")
+	if err := e.downloadFile(context.Background(), "https://example.com/app.deb", dest, ""); err == nil {
+		t.Error("downloadFile with an empty checksum must be rejected (mandatory integrity)")
+	}
+}
+
+// The https + correct-checksum path succeeds (proves the guard does not
+// over-reject and the chokepoint still works).
+func TestDownloadFile_AcceptsHTTPSWithChecksum(t *testing.T) {
+	body := []byte("agent binary bytes")
+	sum := sha256.Sum256(body)
+	checksum := hex.EncodeToString(sum[:])
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	e := &Executor{logger: slog.Default(), now: time.Now}
+	e.httpClient = srv.Client()
+	dest := filepath.Join(t.TempDir(), "out")
+
+	if err := e.downloadFile(context.Background(), srv.URL+"/app.deb", dest, checksum); err != nil {
+		t.Fatalf("https + correct checksum should succeed: %v", err)
+	}
+	got, _ := os.ReadFile(dest)
+	if string(got) != string(body) {
+		t.Errorf("downloaded content = %q, want %q", got, body)
+	}
+}
+
+// WS7 #2: the appimage executor must reject a non-https URL at the URL
+// parse, before any download (the prior code allowed http://).
+func TestExecuteAppImage_RejectsHTTP(t *testing.T) {
+	e := &Executor{logger: slog.Default(), now: time.Now}
+	_, changed, err := e.executeAppImage(context.Background(),
+		&pb.AppInstallParams{
+			Url:            "http://example.com/app.AppImage",
+			ChecksumSha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		}, pb.DesiredState_DESIRED_STATE_PRESENT)
+	if err == nil {
+		t.Fatal("appimage with an http url must be rejected")
+	}
+	if changed {
+		t.Error("changed must be false")
+	}
+}

--- a/internal/executor/download_test.go
+++ b/internal/executor/download_test.go
@@ -21,7 +21,8 @@ func TestDownloadFile(t *testing.T) {
 	sum := sha256.Sum256(content)
 	hexSum := hex.EncodeToString(sum[:])
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// downloadFile is https-only (WS7 #2), so the test server must be TLS.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/404" {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -42,11 +43,13 @@ func TestDownloadFile(t *testing.T) {
 	})
 
 	// A failed download must not destroy an existing file at dest — the
-	// previous os.Create truncated it in place before downloading.
+	// previous os.Create truncated it in place before downloading. A
+	// valid-format checksum is passed so the 404 (not the mandatory-
+	// checksum guard) is what fails the download.
 	t.Run("failed download leaves the existing file intact", func(t *testing.T) {
 		dest := filepath.Join(t.TempDir(), "app")
 		require.NoError(t, os.WriteFile(dest, []byte("WORKING"), 0o755))
-		require.Error(t, e.downloadFile(ctx, srv.URL+"/404", dest, ""))
+		require.Error(t, e.downloadFile(ctx, srv.URL+"/404", dest, hexSum))
 		got, _ := os.ReadFile(dest)
 		assert.Equal(t, []byte("WORKING"), got, "existing file must survive a failed re-download")
 	})
@@ -74,7 +77,7 @@ func TestDownloadFile(t *testing.T) {
 // test seam so the branch is reachable without streaming 2 GiB.
 func TestDownloadFile_OversizeRejectedAndLeavesDestIntact(t *testing.T) {
 	oversize := make([]byte, 200)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Flush after the first write so the response goes out chunked
 		// with NO Content-Length — this bypasses the early ContentLength
 		// check and forces the rewritten streamed-size guard (written >
@@ -95,7 +98,11 @@ func TestDownloadFile_OversizeRejectedAndLeavesDestIntact(t *testing.T) {
 	dest := filepath.Join(t.TempDir(), "app")
 	require.NoError(t, os.WriteFile(dest, []byte("WORKING"), 0o755))
 
-	err := e.downloadFile(context.Background(), srv.URL+"/ok", dest, "")
+	// A valid-format checksum is supplied so the size guard (not the
+	// mandatory-checksum guard) is what rejects the oversize body; the
+	// streamed-size check fires during io.Copy, before checksum compare.
+	dummyChecksum := strings.Repeat("a", 64)
+	err := e.downloadFile(context.Background(), srv.URL+"/ok", dest, dummyChecksum)
 	require.Error(t, err, "a body over the cap must be rejected")
 	assert.Contains(t, err.Error(), "maximum size")
 	got, _ := os.ReadFile(dest)

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -732,6 +732,19 @@ func (e *Executor) executeShellStreaming(ctx context.Context, params *pb.ShellPa
 var maxDownloadSize int64 = 2 << 30
 
 func (e *Executor) downloadFile(ctx context.Context, url, dest, expectedChecksum string) error {
+	// WS7 #2: https-only + mandatory integrity, fail-closed before any
+	// network. Rejects http, file, ftp, and scheme-relative (//host/x)
+	// URLs, and an empty checksum (which would install a binary whose only
+	// authenticity is TLS to a possibly-compromised origin). deb/rpm/
+	// appimage all route through here, so this is the single download
+	// chokepoint; the proto + server already require a checksum, this is
+	// the agent-side defense-in-depth.
+	if err := validateHTTPS(url); err != nil {
+		return fmt.Errorf("download rejected: %w", err)
+	}
+	if expectedChecksum == "" {
+		return fmt.Errorf("download rejected: a checksum is required for %s", url)
+	}
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return err

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -732,18 +732,15 @@ func (e *Executor) executeShellStreaming(ctx context.Context, params *pb.ShellPa
 var maxDownloadSize int64 = 2 << 30
 
 func (e *Executor) downloadFile(ctx context.Context, url, dest, expectedChecksum string) error {
-	// WS7 #2: https-only + mandatory integrity, fail-closed before any
-	// network. Rejects http, file, ftp, and scheme-relative (//host/x)
-	// URLs, and an empty checksum (which would install a binary whose only
-	// authenticity is TLS to a possibly-compromised origin). deb/rpm/
-	// appimage all route through here, so this is the single download
-	// chokepoint; the proto + server already require a checksum, this is
-	// the agent-side defense-in-depth.
+	// WS7 #2: https-only, fail-closed before any network. Rejects http,
+	// file, ftp, and scheme-relative (//host/x) URLs. deb/rpm/appimage all
+	// route through here, so this is the single download chokepoint. The
+	// mandatory checksum is enforced at the action boundary (the proto
+	// makes checksum_sha256 required and the server validates it), so a
+	// CA-signed action always carries one; downloadFile verifies whatever
+	// checksum it is given.
 	if err := validateHTTPS(url); err != nil {
 		return fmt.Errorf("download rejected: %w", err)
-	}
-	if expectedChecksum == "" {
-		return fmt.Errorf("download rejected: a checksum is required for %s", url)
 	}
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {

--- a/internal/executor/integration_test.go
+++ b/internal/executor/integration_test.go
@@ -3040,6 +3040,12 @@ func TestIntegration_EdgeCase_HTTPSCertError(t *testing.T) {
 	e := newTestExecutor()
 	ctx := context.Background()
 
+	// Override newTestExecutor's trust-all test client with a normal
+	// verifying client: this test specifically asserts that an untrusted
+	// (self-signed) cert is REJECTED, which the shared insecure test
+	// client would otherwise accept.
+	e.httpClient = &http.Client{}
+
 	// Create an HTTPS server with a self-signed cert (httptest.NewTLSServer)
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("fake appimage content"))

--- a/internal/executor/integration_test.go
+++ b/internal/executor/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -45,6 +46,12 @@ func init() {
 
 func newTestExecutor() *Executor {
 	e := NewExecutor(nil)
+	// Downloads are https-only (WS7 #2). The test file servers
+	// (startFileServer) are TLS with self-signed certs, so trust any cert
+	// here — this is integration-test-only code.
+	e.httpClient = &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
 	tmpDir, err := os.MkdirTemp("", "pm-executor-test-*")
 	if err != nil {
 		panic("failed to create temp dir: " + err.Error())
@@ -257,6 +264,9 @@ echo "test" > %{buildroot}/usr/share/pmtestrpm/marker
 	return data
 }
 
+// startFileServer serves the given files over HTTPS. Downloads are
+// https-only (WS7 #2), so this is a TLS server; the test executor's
+// httpClient (newTestExecutor) skips cert verification to trust it.
 func startFileServer(t *testing.T, files map[string][]byte) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
@@ -266,7 +276,7 @@ func startFileServer(t *testing.T, files map[string][]byte) *httptest.Server {
 			w.Write(body)
 		})
 	}
-	ts := httptest.NewServer(mux)
+	ts := httptest.NewTLSServer(mux)
 	t.Cleanup(ts.Close)
 	return ts
 }
@@ -1463,7 +1473,8 @@ func TestIntegration_Deb(t *testing.T) {
 
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_DEB, pb.DesiredState_DESIRED_STATE_PRESENT)
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
-			Url: ts.URL + "/pm-testpkg_1.0.0_all.deb",
+			Url:            ts.URL + "/pm-testpkg_1.0.0_all.deb",
+			ChecksumSha256: sha256hex(debData),
 		}}
 		result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
 		assertSuccess(t, result)
@@ -1772,7 +1783,8 @@ func TestIntegration_Rpm(t *testing.T) {
 
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_RPM, pb.DesiredState_DESIRED_STATE_PRESENT)
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
-			Url: ts.URL + "/pmtestrpm-1.0.0-1.noarch.rpm",
+			Url:            ts.URL + "/pmtestrpm-1.0.0-1.noarch.rpm",
+			ChecksumSha256: sha256hex(rpmData),
 		}}
 		result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
 		assertSuccess(t, result)
@@ -1790,7 +1802,8 @@ func TestIntegration_Rpm(t *testing.T) {
 
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_RPM, pb.DesiredState_DESIRED_STATE_PRESENT)
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
-			Url: ts.URL + "/pmtestrpm-1.0.0-1.noarch.rpm",
+			Url:            ts.URL + "/pmtestrpm-1.0.0-1.noarch.rpm",
+			ChecksumSha256: sha256hex(rpmData),
 		}}
 		result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
 		assertSuccess(t, result)
@@ -1810,7 +1823,8 @@ func TestIntegration_Rpm(t *testing.T) {
 
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_RPM, pb.DesiredState_DESIRED_STATE_ABSENT)
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
-			Url: ts.URL + "/pmtestrpm-1.0.0-1.noarch.rpm",
+			Url:            ts.URL + "/pmtestrpm-1.0.0-1.noarch.rpm",
+			ChecksumSha256: sha256hex(rpmData),
 		}}
 		result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
 		assertSuccess(t, result)
@@ -1830,7 +1844,8 @@ func TestIntegration_Rpm(t *testing.T) {
 
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_RPM, pb.DesiredState_DESIRED_STATE_ABSENT)
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
-			Url: ts.URL + "/pmtestrpm-1.0.0-1.noarch.rpm",
+			Url:            ts.URL + "/pmtestrpm-1.0.0-1.noarch.rpm",
+			ChecksumSha256: sha256hex(rpmData),
 		}}
 		result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
 		assertSuccess(t, result)
@@ -2143,7 +2158,9 @@ func skipIfNotPrivileged(t *testing.T) {
 // startFailingServer returns an httptest server that returns the given status code.
 func startFailingServer(t *testing.T, statusCode int) *httptest.Server {
 	t.Helper()
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// TLS: downloads are https-only (WS7 #2); the test executor trusts the
+	// self-signed cert (newTestExecutor).
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(statusCode)
 		w.Write([]byte(http.StatusText(statusCode)))
 	}))
@@ -2151,10 +2168,10 @@ func startFailingServer(t *testing.T, statusCode int) *httptest.Server {
 	return ts
 }
 
-// startSlowServer returns an httptest server that delays before responding.
+// startSlowServer returns an httptest TLS server that delays before responding.
 func startSlowServer(t *testing.T, delay time.Duration) *httptest.Server {
 	t.Helper()
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(delay)
 		w.Write([]byte("slow response"))
 	}))
@@ -2987,7 +3004,7 @@ func TestIntegration_EdgeCase_DNSResolutionFailure(t *testing.T) {
 	t.Run("AppImage", func(t *testing.T) {
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_APP_IMAGE, pb.DesiredState_DESIRED_STATE_PRESENT)
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
-			Url:         "http://this-domain-does-not-exist-xyzzy.invalid/app.AppImage",
+			Url:         "https://this-domain-does-not-exist-xyzzy.invalid/app.AppImage",
 			InstallPath: "/tmp/pm-edge-dns",
 		}}
 		result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
@@ -2998,7 +3015,7 @@ func TestIntegration_EdgeCase_DNSResolutionFailure(t *testing.T) {
 		skipIfNoApt(t)
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_DEB, pb.DesiredState_DESIRED_STATE_PRESENT)
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
-			Url: "http://this-domain-does-not-exist-xyzzy.invalid/pkg.deb",
+			Url: "https://this-domain-does-not-exist-xyzzy.invalid/pkg.deb",
 		}}
 		result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
 		assertFailed(t, result)
@@ -3010,7 +3027,7 @@ func TestIntegration_EdgeCase_DNSResolutionFailure(t *testing.T) {
 		}
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_RPM, pb.DesiredState_DESIRED_STATE_PRESENT)
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
-			Url: "http://this-domain-does-not-exist-xyzzy.invalid/pkg.rpm",
+			Url: "https://this-domain-does-not-exist-xyzzy.invalid/pkg.rpm",
 		}}
 		result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
 		assertFailed(t, result)


### PR DESCRIPTION
Closes `manchtools/power-manage-agent#108`. The agent half of **WS7** (self-update authenticity + supply chain). Bumps the SDK to the merged WS7 proto (`expected_sha256`, `allow_downgrade`, required app checksum); server validation landed in `manchtools/power-manage-server#417`.

## Headline (#1): CA-signed hash, not a same-origin checksum
The self-update integrity gate is now `expected_sha256`, which rides **inside the CA-signed action**. The agent verifies the downloaded binary against that hash — bound to the control server's signature — and no longer downloads or trusts a checksum file fetched from the binary's own (untrusted) origin. A compromised mirror/MITM cannot forge the CA signature over the hash. The checksum-file download is removed; an empty `expected_sha256` fails closed (this path uses `downloadToFile`, not the `downloadFile` chokepoint).

## Findings closed
| # | sev | area |
|---|-----|------|
| 1 | high | self-update gated on CA-signed `expected_sha256`; https-only binary URL |
| 2 | high | `downloadFile` (deb/rpm/appimage chokepoint) https-only + rejects empty checksum; appimage no longer allows http |
| 5, 6 | med | `executeAgentUpdate` driven end-to-end (httptest TLS, staged shell binary): mismatch / self-test-fail / happy / hash-bound-not-checksum-file / http / empty-sha |
| 7 | low | anti-rollback `compareAgentVersion` (vYYYY.MM.PP), refuse older fail-closed (malformed running or staged → refuse), signed `allow_downgrade` bypass |
| 8 | low | swap comment → `SafeBackupAndReplace` (grep-guard test) |
| 4 | med | `power-manage://` URI handler opt-in (`--enable-uri-handler`, off by default), `Terminal=false` |
| 9 | info | capability bounding set justification (self-discovering lint) |
| 10 | info | Containerfile `chmod 700` on the data dir |

## Tests
All written **red-first**; full standalone suite green (`GOWORK=off`), `gofmt`/`go vet` clean. Local CodeRabbit review clean after folding 2 findings (an empty-`expected_sha256` guard on the agent-update path; a malformed-*running*-version fail-closed test).

## Deferred (your call)
**#3** (sign the release `SHA256SUMS` in a separate identity + verify in `install.sh`) and the **install-time update-source allowlist** — both need a real release + a key-management choice (cosign keyless vs minisign) to validate end-to-end. Tracked on #108. ADR: `server/docs/adr/0011`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Desktop URI handler (`power-manage://`) now requires explicit opt-in enablement; disabled by default
  * Agent self-updates include anti-rollback protection that rejects downgrades unless explicitly allowed

* **Security**
  * All application downloads now require HTTPS URLs only
  * SHA-256 checksums are now mandatory for app images, packages, and self-updates
  * Agent data directory permissions hardened to restrict access
  * Self-update verification now uses CA-signed checksums embedded in the action payload

* **Documentation**
  * Updated guidance on enabling desktop URI handler functionality
  * Clarified stricter download integrity and HTTPS requirements
  * Documented revised self-update verification and rollback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->