### PR TITLE
fix(executor): agent-update falls back to checksum_url when expected_sha256 unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,13 +690,18 @@ journalctl -u power-manage-agent -f
 
 ## Auto-Update
 
-The agent self-updates via the `ACTION_TYPE_AGENT_UPDATE` action. Admins schedule this action on their managed devices; the action payload carries, per architecture, an HTTPS `binary_url` and the **CA-signed `expected_sha256`** of that binary.
+The agent self-updates via the `ACTION_TYPE_AGENT_UPDATE` action. Admins schedule this action on their managed devices; the action payload carries, per architecture, an HTTPS `binary_url` and an integrity source. The action is CA-signed, so its fields cannot be tampered in transit.
 
-### Authenticity: CA-signed hash, not a same-origin checksum (WS7)
+### Integrity: your choice of `checksum_url` (default) or a pinned `expected_sha256`
 
-The integrity gate is `expected_sha256`, which travels **inside the CA-signed action**. The agent verifies the downloaded binary against that hash — a value bound to the control server's signature — **not** against a checksum file fetched from the binary's own (untrusted) download origin. A compromised mirror or a man-in-the-middle on the download cannot vouch for a tampered binary: it cannot forge the CA signature over `expected_sha256`. `binary_url` must be HTTPS.
+Each arch must provide **at least one** of:
 
-> Binary code-signing is a future enhancement; this interim model binds the hash to the existing enrolled-CA trust root. Any future signing key must be operator-pinnable, never a hardcoded project key. Signing of the *release* `SHA256SUMS` (the initial-install integrity, separate from self-update) is tracked separately.
+- **`checksum_url`** (default) — a `SHA256SUMS` file the agent fetches and verifies the binary against. This is the **hands-off** option: point `binary_url` + `checksum_url` at your `releases/latest/...` assets and the fleet tracks new releases with no per-release action change. Authenticity here is **origin-trust** (TLS + your release host).
+- **`expected_sha256`** (opt-in) — an exact, lowercase-hex hash. When set it **overrides** `checksum_url` and is the authoritative gate: it travels inside the CA-signed action, so the agent verifies against a hash bound to the control server's signature, not a file from the download origin. Use it to **pin an exact binary** (staged rollouts) or for stronger authenticity. The trade-off: a new version means updating + re-signing the action, so it's opt-in, not the default.
+
+`binary_url` (and `checksum_url`, when used) must be HTTPS. An action with neither integrity source is rejected at create time and by the agent.
+
+> **Accepted risk (default mode):** with `checksum_url`, a compromised download origin serving a malicious binary *and* a matching checksum file would not be detected — the checksum is self-attesting. The control plane provides ease of use, not artifact provenance. If you need a stronger guarantee: pin `expected_sha256`, host `checksum_url` on a **separate host** from the binary, or — since this is open source — **build and distribute the binaries yourself** and pin hashes as you require. Binary code-signing and signing of the release `SHA256SUMS` are possible future backstops, not current guarantees.
 
 ### Anti-rollback
 
@@ -704,7 +709,7 @@ The agent refuses a candidate **older** than the running version (`vYYYY.MM.PP` 
 
 ### Update Process
 
-1. Download binary to `/var/lib/power-manage/update/agent-update-*.tmp` and verify its SHA256 against the CA-signed `expected_sha256` (no checksum file is fetched or trusted)
+1. Download binary to `/var/lib/power-manage/update/agent-update-*.tmp` and verify its SHA256 against the pinned `expected_sha256` if set, otherwise against the hash from `checksum_url`
 2. Run `<tmpPath> version`, compare with running — skip if same; refuse a downgrade unless `allow_downgrade`
 3. Run `<tmpPath> self-test` as a subprocess (60s timeout). The self-test:
    - Loads stored credentials

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 // it. There is no automatic floating tag — that's intentional, because
 // SDK proto/Go API drifts between commits should be reviewable in the
 // same PR as the agent change that consumes them.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260614074439-f08e3153fa4b
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260614093038-dcaee55a819e
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260614074439-f08e3153fa4b h1:pbMiax9QoJNlKqcV7FxoIliFijWxrGPRkwAUKtkbrsI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260614074439-f08e3153fa4b/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260614093038-dcaee55a819e h1:C6DZ7+Zh8T8v70V9UdS6s05Zc7vhyKbmNsXEzmlKaCE=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260614093038-dcaee55a819e/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/executor/agent_update.go
+++ b/internal/executor/agent_update.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"bufio"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -108,20 +109,31 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 		return nil, false, fmt.Errorf("binary URL validation: %w", err)
 	}
 
-	// Step 4: The AUTHORITATIVE integrity gate is the CA-signed
-	// expected_sha256 (WS7 #1). It rides inside the signed action, so a
-	// compromised download origin — or a checksum file fetched from that
-	// same origin — cannot vouch for a tampered binary. We deliberately do
-	// NOT download or trust a same-origin checksum file; checksum_url is
-	// retained on the action only as operator-facing metadata.
+	// Step 4: determine the expected binary hash. Operator's choice (WS7):
+	//   - expected_sha256 set → AUTHORITATIVE, CA-signed pin. It rides
+	//     inside the signed action, so even a compromised download origin
+	//     cannot vouch for a tampered binary. Overrides checksum_url.
+	//   - otherwise → fetch the operator's checksum_url (SHA256SUMS) and
+	//     verify against it. This is the default that lets binary_url +
+	//     checksum_url track "latest" hands-off; authenticity is
+	//     origin-trust (the action is signed, so only an origin-manipulated
+	//     hash is a concern, which an operator can mitigate by hosting the
+	//     checksum file on a separate host).
+	// At least one must be present (also enforced server-side) so an update
+	// never runs with no integrity check.
 	expectedChecksum := strings.ToLower(arch.ExpectedSha256)
-	// Defense-in-depth: the server + proto require expected_sha256, but
-	// fail closed here too rather than downloading and reporting a
-	// confusing "expected , got <hash>" mismatch. (This path uses
-	// downloadToFile, not the downloadFile chokepoint, so the guard must
-	// live here.)
 	if expectedChecksum == "" {
-		return nil, false, fmt.Errorf("agent update rejected: expected_sha256 is empty in the signed action")
+		if arch.ChecksumUrl == "" {
+			return nil, false, fmt.Errorf("agent update rejected: action sets neither expected_sha256 nor checksum_url")
+		}
+		if err := validateHTTPS(arch.ChecksumUrl); err != nil {
+			return nil, false, fmt.Errorf("checksum URL validation: %w", err)
+		}
+		fileChecksum, err := downloadAndExtractChecksum(ctx, e.httpClient, arch.ChecksumUrl, extractFilename(arch.BinaryUrl))
+		if err != nil {
+			return nil, false, fmt.Errorf("download checksum: %w", err)
+		}
+		expectedChecksum = fileChecksum
 	}
 
 	// Step 5: Download binary to temp file in DataDir (agent-owned).
@@ -318,6 +330,58 @@ func parseAgentVersion(v string) ([3]int, error) {
 		out[i] = n
 	}
 	return out, nil
+}
+
+// extractFilename returns the filename from a URL, stripping query parameters.
+func extractFilename(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return filepath.Base(rawURL)
+	}
+	return filepath.Base(u.Path)
+}
+
+// downloadAndExtractChecksum downloads a SHA256SUMS-style file and extracts
+// the checksum for the given filename (format: "<hex>  <filename>"). Used
+// as the default integrity source when the action does not pin
+// expected_sha256 (WS7: operator tracks "latest" via checksum_url).
+func downloadAndExtractChecksum(ctx context.Context, client *http.Client, checksumURL, filename string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, checksumURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("download: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) != 2 {
+			continue
+		}
+		checksumHex := parts[0]
+		name := strings.TrimPrefix(strings.TrimPrefix(parts[1], "./"), "*")
+		if name == filename {
+			if len(checksumHex) != 64 {
+				return "", fmt.Errorf("invalid checksum length for %s: %d", filename, len(checksumHex))
+			}
+			return strings.ToLower(checksumHex), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read checksum file: %w", err)
+	}
+	return "", fmt.Errorf("checksum for %q not found in checksum file", filename)
 }
 
 // getArchEntry returns the AgentUpdateArch for the current runtime architecture.

--- a/internal/executor/agent_update_orchestration_test.go
+++ b/internal/executor/agent_update_orchestration_test.go
@@ -212,16 +212,85 @@ func TestExecuteAgentUpdate_HappyPathSwapsAndShutsDown(t *testing.T) {
 	}
 }
 
-// WS7 #1 defense-in-depth: an empty expected_sha256 in the (signed)
-// action is refused fail-closed before any download — the agent-update
-// path uses downloadToFile, which has no checksum chokepoint of its own.
-func TestExecuteAgentUpdate_RefusesEmptyExpectedSha256(t *testing.T) {
+// WS7 (revised): an action with NEITHER expected_sha256 NOR checksum_url
+// has no integrity source and is refused fail-closed (also enforced
+// server-side). The agent-update path uses downloadToFile, which has no
+// checksum chokepoint of its own.
+func TestExecuteAgentUpdate_RefusesNoIntegritySource(t *testing.T) {
 	staged := agentScript("v2026.06.05", 0)
 	h := newUpdateHarness(t, "v2026.06.01", staged, nil)
 
-	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params("")) // empty expected_sha256
+	// No expected_sha256 AND no checksum_url.
+	noIntegrity := &pb.AgentUpdateParams{
+		Amd64: &pb.AgentUpdateArch{BinaryUrl: h.srv.URL + "/agent"},
+		Arm64: &pb.AgentUpdateArch{BinaryUrl: h.srv.URL + "/agent"},
+	}
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), noIntegrity)
 	if err == nil {
-		t.Fatal("an empty expected_sha256 must be refused")
+		t.Fatal("an action with no integrity source must be refused")
+	}
+	if changed {
+		t.Error("changed must be false")
+	}
+	if got := h.currentBinary(t); string(got) != string(h.oldBytes) {
+		t.Error("live binary must be unchanged")
+	}
+}
+
+// WS7 (revised): the DEFAULT path — no pinned expected_sha256, integrity
+// verified against the operator's checksum_url (SHA256SUMS). This is what
+// lets binary_url/checksum_url track "latest" hands-off. A correct
+// checksum file + newer version → swap + shutdown.
+func TestExecuteAgentUpdate_ChecksumURLFallback(t *testing.T) {
+	staged := agentScript("v2026.06.05", 0)
+	// SHA256SUMS line for the binary served at /agent (filename "agent").
+	sums := []byte(sha256hex(staged) + "  agent\n")
+	h := newUpdateHarness(t, "v2026.06.01", staged, sums)
+
+	// No expected_sha256 → agent fetches + verifies via checksum_url.
+	p := &pb.AgentUpdateParams{
+		Amd64: &pb.AgentUpdateArch{BinaryUrl: h.srv.URL + "/agent", ChecksumUrl: h.srv.URL + "/sums"},
+		Arm64: &pb.AgentUpdateArch{BinaryUrl: h.srv.URL + "/agent", ChecksumUrl: h.srv.URL + "/sums"},
+	}
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), p)
+	if err != nil {
+		t.Fatalf("checksum_url fallback update failed: %v", err)
+	}
+	if !changed {
+		t.Error("changed must be true on a successful checksum_url-verified update")
+	}
+	if got := h.currentBinary(t); string(got) != string(staged) {
+		t.Error("binary must be swapped to the staged bytes")
+	}
+	bak, err := os.ReadFile(h.binaryPath + ".bak")
+	if err != nil {
+		t.Fatalf("read .bak: %v", err)
+	}
+	if string(bak) != string(h.oldBytes) {
+		t.Error(".bak must hold the previous binary")
+	}
+	if !h.shutdownCalled() {
+		t.Error("Shutdown must be invoked after a successful update")
+	}
+}
+
+// A checksum_url whose SHA256SUMS does NOT match the downloaded binary is
+// rejected (no swap).
+func TestExecuteAgentUpdate_ChecksumURLMismatchRejected(t *testing.T) {
+	staged := agentScript("v2026.06.05", 0)
+	tampered := append([]byte{}, staged...)
+	tampered[len(tampered)-2] ^= 0xff
+	// SHA256SUMS vouches for the GENUINE bytes; the server serves TAMPERED.
+	sums := []byte(sha256hex(staged) + "  agent\n")
+	h := newUpdateHarness(t, "v2026.06.01", tampered, sums)
+
+	p := &pb.AgentUpdateParams{
+		Amd64: &pb.AgentUpdateArch{BinaryUrl: h.srv.URL + "/agent", ChecksumUrl: h.srv.URL + "/sums"},
+		Arm64: &pb.AgentUpdateArch{BinaryUrl: h.srv.URL + "/agent", ChecksumUrl: h.srv.URL + "/sums"},
+	}
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), p)
+	if err == nil {
+		t.Fatal("a checksum_url mismatch must abort the update")
 	}
 	if changed {
 		t.Error("changed must be false")


### PR DESCRIPTION
WS7 follow-up to #109. Restores the hands-off "track latest" update workflow that the required `expected_sha256` broke. `executeAgentUpdate`:

- `expected_sha256` set → authoritative CA-signed pin (overrides `checksum_url`).
- otherwise → fetch `checksum_url` (`SHA256SUMS`) and verify (restored `downloadAndExtractChecksum`/`extractFilename`). Lets `binary_url`/`checksum_url` point at `releases/latest/...` and track new releases with no per-release action change; origin-trust authenticity.
- **neither set → fail closed** (also enforced server-side).

Tests: pinned path (existing), checksum_url happy path (+ `.bak` + shutdown), checksum_url mismatch rejected, no-integrity-source rejected. README revised to the operator-choice model + **accepted risk** (default `checksum_url` is origin-trust; pin / separate-host / build-yourself for stronger guarantees).

Bumps the SDK to the merged optional-field proto. `go test`/`vet`/`gofmt` green standalone; local CodeRabbit clean after folding one finding (`.bak`/shutdown assertions on the checksum_url happy path). Pairs with `power-manage-server#418`.