### PR TITLE
fix(executor): validate package/repo/gpg/flatpak args against intent and pass after -- (#111)

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,8 @@ Manage package manager repositories.
 
 Only one repository type should be set per action. The matching type is determined by the detected package manager.
 
+**Argument hardening:** `dnf.baseurl` / `zypper.url` / `pacman.server` must be **HTTPS** (these fetch root-installed packages, so the transport is the trust boundary); `apt.url` is exempt because apt's security is the gpg-signed Release file. `dnf`/`zypper` `gpgkey` refs are restricted to an https URL, a `file:///abs` path, or an absolute path (never a flag, `http://`, or rpm `ext::` transport) and are imported via `rpm --import -- <ref>`. `gpgcheck` is an **operator choice** — an https mirror with `gpgcheck=false` is permitted (the transport is still verified; package-signature verification is the operator's call, mirroring the auto-update `checksum_url` posture). See ADR 0012.
+
 **Desired State:**
 - `PRESENT`: Add or update the repository configuration
 - `ABSENT`: Remove the repository configuration and GPG keys
@@ -628,6 +630,25 @@ under that surface's disjoint domain. **Raw SQL is permitted only when signed**
 at the boundary first. A missing verifier fails closed (production always has
 one — the CA cert is required at startup). Agent-initiated periodic inventory
 collection is the agent's own decision and needs no signature.
+
+### Package / Repository Argument Hardening (WS8)
+
+Every value that reaches a package-manager `argv` is validated against its
+intent before the command runs, and positionals are passed after an explicit
+`--` end-of-options separator (via the SDK's `exec.SeparatePositionals`) so a
+flag-shaped value can never be reparsed as an option:
+
+| Surface | Validation | Argv |
+|---------|-----------|------|
+| `RPM` `%{NAME}` (read off the downloaded `.rpm`) | `pkg.ValidateRpmPackageName` — a crafted `.rpm` cannot name itself `--eval=%{lua:…}` | `rpm -q -- <name>`, `rpm -e -- <name>` |
+| `RPM`/`DEB`/`APP_IMAGE` artifact | https + non-empty checksum, fail-closed **before** any privileged remount or download | — |
+| dnf/zypper/pacman base URL | `pkg.ValidateRepoBaseURL` (https + host) | written to the repo config |
+| dnf/zypper GPG key ref | `pkg.ValidateGpgKeyRef` (https / `file://` abs / abs path) | `rpm --import -- <ref>` |
+| `FLATPAK` app-id / remote | `pkg.ValidatePackageName` / `pkg.ValidateRemoteName`, **before** dispatch | `flatpak install … -- <remote> <appId>` |
+
+A self-discovering test walks every string field of each repository proto and
+fails closed if a newly-added field forgets its config-injection guard. See
+ADR 0012.
 
 ### Enrollment Rate Limiting
 

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 // it. There is no automatic floating tag — that's intentional, because
 // SDK proto/Go API drifts between commits should be reviewable in the
 // same PR as the agent change that consumes them.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260614093038-dcaee55a819e
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260614102249-49d306f6cd9f
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260614093038-dcaee55a819e h1:C6DZ7+Zh8T8v70V9UdS6s05Zc7vhyKbmNsXEzmlKaCE=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260614093038-dcaee55a819e/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260614102249-49d306f6cd9f h1:4MAcHPC/gIu5XOStTwby/mbAFqtR260vSfDZa5AiQ8M=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260614102249-49d306f6cd9f/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/executor/action_flatpak.go
+++ b/internal/executor/action_flatpak.go
@@ -10,12 +10,36 @@ import (
 	"strings"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/pkg"
 	"github.com/manchtools/power-manage/sdk/go/sys/desktop"
+	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
 func (e *Executor) executeFlatpak(ctx context.Context, params *pb.FlatpakParams, state pb.DesiredState) (*pb.CommandOutput, bool, error) {
 	if params == nil {
 		return nil, false, fmt.Errorf("flatpak params required")
+	}
+
+	// Validate app-id and remote BEFORE the flatpak lookup or any
+	// dispatch (WS8 finding 7). Both reach `flatpak install` as operands,
+	// so a flag-shaped value (`--system`, `--from=…`) must be rejected up
+	// front. Validating before the lookup also means a malformed action
+	// is rejected on every host, not silently skipped on one without
+	// flatpak.
+	if params.AppId == "" {
+		return nil, false, fmt.Errorf("flatpak app_id is required")
+	}
+	if err := pkg.ValidatePackageName(params.AppId); err != nil {
+		return nil, false, fmt.Errorf("invalid flatpak app_id: %w", err)
+	}
+
+	// Default to flathub if no remote specified
+	remote := params.Remote
+	if remote == "" {
+		remote = "flathub"
+	}
+	if err := pkg.ValidateRemoteName(remote); err != nil {
+		return nil, false, fmt.Errorf("invalid flatpak remote: %w", err)
 	}
 
 	// Skip on systems without flatpak
@@ -26,20 +50,26 @@ func (e *Executor) executeFlatpak(ctx context.Context, params *pb.FlatpakParams,
 		return nil, false, fmt.Errorf("flatpak lookup: %w", err)
 	}
 
-	if params.AppId == "" {
-		return nil, false, fmt.Errorf("flatpak app_id is required")
-	}
-
-	// Default to flathub if no remote specified
-	remote := params.Remote
-	if remote == "" {
-		remote = "flathub"
-	}
-
 	if params.SystemWide {
 		return e.executeFlatpakSystem(ctx, params, state, remote)
 	}
 	return e.executeFlatpakPerUser(ctx, params, state, remote)
+}
+
+// flatpakInstallArgs builds `flatpak install -y --noninteractive <scope>
+// -- <remote> <appId>` so the remote and app-id sit after the `--`
+// end-of-options separator and can never be reparsed as flatpak options
+// (`--from=…`, `--sideload-repo=…`, …).
+func flatpakInstallArgs(scopeFlag, remote, appId string) []string {
+	return sysexec.SeparatePositionals([]string{"install", "-y", "--noninteractive", scopeFlag}, remote, appId)
+}
+
+// flatpakUninstallArgs is the install counterpart: `flatpak uninstall -y
+// --noninteractive <scope> -- <appId>`. The app-id is already
+// grammar-validated at executeFlatpak's entry, but passing it after `--`
+// keeps the install/uninstall argv discipline symmetric.
+func flatpakUninstallArgs(scopeFlag, appId string) []string {
+	return sysexec.SeparatePositionals([]string{"uninstall", "-y", "--noninteractive", scopeFlag}, appId)
 }
 
 // executeFlatpakSystem implements the system-wide install/uninstall
@@ -84,7 +114,7 @@ func (e *Executor) executeFlatpakSystem(ctx context.Context, params *pb.FlatpakP
 			return out, false, err
 		}
 
-		output, err := runSudoCmd(ctx, "flatpak", "install", "-y", "--noninteractive", systemFlag, remote, params.AppId)
+		output, err := runSudoCmd(ctx, "flatpak", flatpakInstallArgs(systemFlag, remote, params.AppId)...)
 		if err != nil {
 			return output, false, fmt.Errorf("flatpak install failed: %w", err)
 		}
@@ -124,7 +154,7 @@ func (e *Executor) executeFlatpakSystem(ctx context.Context, params *pb.FlatpakP
 				"app_id", params.AppId, "error", err)
 		}
 
-		output, err := runSudoCmd(ctx, "flatpak", "uninstall", "-y", "--noninteractive", systemFlag, params.AppId)
+		output, err := runSudoCmd(ctx, "flatpak", flatpakUninstallArgs(systemFlag, params.AppId)...)
 		return output, true, err
 	}
 
@@ -203,7 +233,7 @@ func (e *Executor) executeFlatpakPerUser(ctx context.Context, params *pb.Flatpak
 				continue
 			}
 
-			out, runErr := runAsUserCmd(ctx, s, nil, "flatpak", "install", "-y", "--noninteractive", "--user", remote, params.AppId)
+			out, runErr := runAsUserCmd(ctx, s, nil, "flatpak", flatpakInstallArgs("--user", remote, params.AppId)...)
 			if runErr != nil {
 				if firstFailure == nil {
 					firstFailure = fmt.Errorf("user %s: install failed: %w", s.Username, runErr)
@@ -264,7 +294,7 @@ func (e *Executor) executeFlatpakPerUser(ctx context.Context, params *pb.Flatpak
 					"user", u.Username, "app_id", params.AppId, "error", err)
 			}
 
-			out, runErr := runAsUserCmd(ctx, u, nil, "flatpak", "uninstall", "-y", "--noninteractive", "--user", params.AppId)
+			out, runErr := runAsUserCmd(ctx, u, nil, "flatpak", flatpakUninstallArgs("--user", params.AppId)...)
 			perUserOut.WriteString("user=")
 			perUserOut.WriteString(u.Username)
 			perUserOut.WriteString(": ")

--- a/internal/executor/action_flatpak_argv_test.go
+++ b/internal/executor/action_flatpak_argv_test.go
@@ -1,0 +1,75 @@
+package executor
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// TestFlatpakInstallArgs_AfterEndOfOptions pins that the remote and
+// app-id reach `flatpak install` after a "--" so neither can be reparsed
+// as a flatpak option (`--from=…`, `--sideload-repo=…`, …).
+func TestFlatpakInstallArgs_AfterEndOfOptions(t *testing.T) {
+	if got, want := flatpakInstallArgs("--system", "flathub", "org.videolan.VLC"),
+		[]string{"install", "-y", "--noninteractive", "--system", "--", "flathub", "org.videolan.VLC"}; !slices.Equal(got, want) {
+		t.Errorf("flatpakInstallArgs(system) = %v, want %v", got, want)
+	}
+	if got, want := flatpakInstallArgs("--user", "flathub", "org.gnome.Calculator"),
+		[]string{"install", "-y", "--noninteractive", "--user", "--", "flathub", "org.gnome.Calculator"}; !slices.Equal(got, want) {
+		t.Errorf("flatpakInstallArgs(user) = %v, want %v", got, want)
+	}
+	// install/uninstall argv discipline is symmetric.
+	if got, want := flatpakUninstallArgs("--system", "org.videolan.VLC"),
+		[]string{"uninstall", "-y", "--noninteractive", "--system", "--", "org.videolan.VLC"}; !slices.Equal(got, want) {
+		t.Errorf("flatpakUninstallArgs(system) = %v, want %v", got, want)
+	}
+}
+
+// TestExecuteFlatpak_ValidatesAppIdAndRemote pins finding 7: app-id and
+// remote are validated BEFORE any dispatch, so a flag-shaped value can
+// never reach `flatpak`. Hermetic: validation runs before the flatpak
+// binary lookup, so no flatpak install is required.
+func TestExecuteFlatpak_ValidatesAppIdAndRemote(t *testing.T) {
+	e := &Executor{logger: slog.Default(), now: time.Now}
+	ctx := context.Background()
+
+	reject := []*pb.FlatpakParams{
+		{AppId: "--system"}, // flag-shaped app id
+		{AppId: "-y"},       // flag-shaped app id
+		{AppId: "a b"},      // embedded space → argv confusion
+		{AppId: "org.ok.App", Remote: "--from=evil"}, // flag-shaped remote
+		{AppId: "org.ok.App", Remote: "-x"},          // flag-shaped remote
+		{AppId: ""},                                  // ABSENT — existing required error preserved
+	}
+	// The rejection must be a VALIDATION error — not an incidental
+	// downstream failure (e.g. desktop-session enumeration) that would
+	// mask a missing validation gate.
+	isValidationErr := func(err error) bool {
+		if err == nil {
+			return false
+		}
+		m := err.Error()
+		return strings.Contains(m, "invalid") || strings.Contains(m, "is required") || strings.Contains(m, "is empty")
+	}
+	for i, p := range reject {
+		_, _, err := e.executeFlatpak(ctx, p, pb.DesiredState_DESIRED_STATE_PRESENT)
+		if !isValidationErr(err) {
+			t.Errorf("reject case %d (%+v): want a validation error, got %v", i, p, err)
+		}
+	}
+
+	// correct app-id + remote must pass validation. On a host without
+	// flatpak this returns the skip no-op (nil err); on a host with
+	// flatpak it may fail the real install — assert only that it is NOT a
+	// validation rejection.
+	if _, _, err := e.executeFlatpak(ctx, &pb.FlatpakParams{AppId: "org.videolan.VLC", Remote: "flathub"}, pb.DesiredState_DESIRED_STATE_PRESENT); err != nil {
+		if strings.Contains(err.Error(), "invalid") || strings.Contains(err.Error(), "is required") {
+			t.Errorf("valid app-id/remote produced a validation error: %v", err)
+		}
+	}
+}

--- a/internal/executor/action_repository.go
+++ b/internal/executor/action_repository.go
@@ -14,7 +14,16 @@ import (
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/go/pkg"
+	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
+
+// rpmImportArgs builds `rpm --import -- <ref>` so a flag-shaped GPG key
+// ref can never be reparsed as an option to `rpm --import`. The ref's
+// grammar is enforced upstream by pkg.ValidateGpgKeyRef in
+// validateRepositoryParams; this is the argv-shape half of that guard.
+func rpmImportArgs(ref string) []string {
+	return sysexec.SeparatePositionals([]string{"--import"}, ref)
+}
 
 // executeRepository configures an external package repository.
 func (e *Executor) executeRepository(ctx context.Context, params *pb.RepositoryParams, state pb.DesiredState) (*pb.CommandOutput, bool, error) {
@@ -560,7 +569,7 @@ func (e *Executor) executeDnfRepository(ctx context.Context, name string, repo *
 		// Import GPG key if provided.
 		// rpm --import is idempotent - re-importing an existing key is a no-op.
 		if repo.Gpgkey != "" {
-			keyOutput, keyErr := runSudoCmd(ctx, "rpm", "--import", repo.Gpgkey)
+			keyOutput, keyErr := runSudoCmd(ctx, "rpm", rpmImportArgs(repo.Gpgkey)...)
 			if keyOutput != nil && keyOutput.Stdout != "" {
 				output.WriteString(keyOutput.Stdout)
 			}
@@ -770,7 +779,7 @@ func (e *Executor) executeZypperRepository(ctx context.Context, name string, rep
 
 		// Import GPG key if provided
 		if repo.Gpgkey != "" {
-			keyOutput, keyErr := runSudoCmd(ctx, "rpm", "--import", repo.Gpgkey)
+			keyOutput, keyErr := runSudoCmd(ctx, "rpm", rpmImportArgs(repo.Gpgkey)...)
 			if keyOutput != nil && keyOutput.Stdout != "" {
 				output.WriteString(keyOutput.Stdout)
 			}

--- a/internal/executor/action_repository_test.go
+++ b/internal/executor/action_repository_test.go
@@ -1,0 +1,51 @@
+package executor
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// TestRpmImportGpgArgv_AfterEndOfOptions pins that a dnf/zypper GPG key
+// import builds `rpm --import -- <ref>` so a flag-shaped ref can never be
+// reparsed as an option to `rpm --import`.
+func TestRpmImportGpgArgv_AfterEndOfOptions(t *testing.T) {
+	if got, want := rpmImportArgs("https://m/key.asc"), []string{"--import", "--", "https://m/key.asc"}; !slices.Equal(got, want) {
+		t.Errorf("rpmImportArgs = %v, want %v", got, want)
+	}
+	a := rpmImportArgs("--import=/etc/shadow")
+	if n := len(a); n < 2 || a[n-1] != "--import=/etc/shadow" || a[n-2] != "--" {
+		t.Errorf("flag-shaped ref must be the final operand preceded by --; args=%v", a)
+	}
+}
+
+// TestExecuteRepository_RejectsBeforePrivilegedRemount pins finding 5:
+// a malformed repository action (bad name, oversized name, non-https
+// base URL) is rejected BEFORE any privileged filesystem
+// remount/repair. The repairFS seam records zero invocations.
+func TestExecuteRepository_RejectsBeforePrivilegedRemount(t *testing.T) {
+	var remountCalls int
+	e := &Executor{logger: slog.Default(), now: time.Now, repairFS: func(context.Context) bool {
+		remountCalls++
+		return true
+	}}
+	bad := []*pb.RepositoryParams{
+		{Name: "r", Dnf: &pb.DnfRepository{Baseurl: "http://evil", Gpgcheck: true}}, // non-https base URL
+		{Name: "../etc"},                 // path-traversing name
+		{Name: strings.Repeat("a", 200)}, // oversized name
+	}
+	for i, p := range bad {
+		out, changed, err := e.executeRepository(context.Background(), p, pb.DesiredState_DESIRED_STATE_PRESENT)
+		if err == nil {
+			t.Errorf("case %d: malformed repo action accepted: out=%v changed=%v", i, out, changed)
+		}
+	}
+	if remountCalls != 0 {
+		t.Errorf("privileged remount ran %d times for rejected actions; want 0", remountCalls)
+	}
+}

--- a/internal/executor/action_rpm.go
+++ b/internal/executor/action_rpm.go
@@ -10,11 +10,22 @@ import (
 	"strings"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/pkg"
+	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
 func (e *Executor) executeRpm(ctx context.Context, params *pb.AppInstallParams, state pb.DesiredState) (*pb.CommandOutput, bool, error) {
 	if params == nil {
 		return nil, false, fmt.Errorf("app params required")
+	}
+
+	// Fail closed before any privileged remount or network round-trip:
+	// the artifact URL must be https and carry a checksum. The control
+	// plane already mandates both; this is the executor-boundary defense
+	// in depth (WS8 finding 1). Runs before the rpm lookup so a malformed
+	// action is rejected on every host, not silently skipped.
+	if err := requireVerifiedArtifact(params.Url, params.ChecksumSha256); err != nil {
+		return nil, false, err
 	}
 
 	// Skip on non-rpm systems
@@ -53,14 +64,12 @@ func (e *Executor) executeRpm(ctx context.Context, params *pb.AppInstallParams, 
 		}
 
 		// Ask rpm itself for the canonical package NAME from the
-		// downloaded file — authoritative across naming conventions.
-		queryOut, _, qErr := queryCmdOutput("rpm", "-qp", "--qf", "%{NAME}", tmpFile.Name())
-		if qErr != nil {
-			return nil, false, fmt.Errorf("rpm -qp NAME: %w", qErr)
-		}
-		pkgName := strings.TrimSpace(queryOut)
-		if pkgName == "" {
-			return nil, false, fmt.Errorf("rpm -qp NAME returned empty for %s", params.Url)
+		// downloaded file — authoritative across naming conventions —
+		// and validate it: a crafted .rpm can set %{NAME} to a
+		// flag-shaped or metacharacter-bearing value.
+		pkgName, err := rpmPackageName(queryCmdOutput, tmpFile.Name())
+		if err != nil {
+			return nil, false, err
 		}
 
 		if e.isRpmInstalled(pkgName) {
@@ -70,8 +79,10 @@ func (e *Executor) executeRpm(ctx context.Context, params *pb.AppInstallParams, 
 			}, false, nil
 		}
 
-		// Install with rpm (requires sudo)
-		output, err := runSudoCmd(ctx, "rpm", "-i", tmpFile.Name())
+		// Install with rpm (requires sudo). The path is a temp file we
+		// created, but pass it after `--` for consistency with the rest
+		// of the rpm argv discipline.
+		output, err := runSudoCmd(ctx, "rpm", "-i", "--", tmpFile.Name())
 		return output, true, err
 
 	case pb.DesiredState_DESIRED_STATE_ABSENT:
@@ -97,13 +108,9 @@ func (e *Executor) executeRpm(ctx context.Context, params *pb.AppInstallParams, 
 			// Surface that explicitly instead of a bare "download" error.
 			return nil, false, fmt.Errorf("cannot determine rpm package to remove: artifact %s is unreachable (%w); re-point the action at a reachable URL or remove the package manually", params.Url, err)
 		}
-		queryOut, _, qErr := queryCmdOutput("rpm", "-qp", "--qf", "%{NAME}", tmpFile.Name())
-		if qErr != nil {
-			return nil, false, fmt.Errorf("rpm -qp NAME: %w", qErr)
-		}
-		pkgName := strings.TrimSpace(queryOut)
-		if pkgName == "" {
-			return nil, false, fmt.Errorf("rpm -qp NAME returned empty for %s", params.Url)
+		pkgName, err := rpmPackageName(queryCmdOutput, tmpFile.Name())
+		if err != nil {
+			return nil, false, err
 		}
 		if !e.isRpmInstalled(pkgName) {
 			return &pb.CommandOutput{
@@ -112,7 +119,7 @@ func (e *Executor) executeRpm(ctx context.Context, params *pb.AppInstallParams, 
 			}, false, nil
 		}
 
-		output, err := runSudoCmd(ctx, "rpm", "-e", pkgName)
+		output, err := runSudoCmd(ctx, "rpm", rpmEraseArgs(pkgName)...)
 		return output, true, err
 	}
 
@@ -121,5 +128,50 @@ func (e *Executor) executeRpm(ctx context.Context, params *pb.AppInstallParams, 
 
 // isRpmInstalled checks if an rpm package is installed.
 func (e *Executor) isRpmInstalled(pkgName string) bool {
-	return checkCmdSuccess("rpm", "-q", pkgName)
+	return checkCmdSuccess("rpm", rpmQueryArgs(pkgName)...)
+}
+
+// rpmQueryFunc matches queryCmdOutput's signature; injectable so tests
+// can supply a crafted %{NAME} without a real rpm binary or .rpm file.
+type rpmQueryFunc func(name string, args ...string) (string, int, error)
+
+// rpmPackageName asks rpm for the canonical %{NAME} of the .rpm at path
+// and validates it. The name a (possibly crafted) .rpm reports is
+// untrusted input, so it MUST pass pkg.ValidateRpmPackageName before it
+// can reach `rpm -q`/`rpm -e` argv — parity with the deb-side
+// validDebPkgName check. An empty/whitespace name is rejected by the
+// validator (no separate empty check needed).
+func rpmPackageName(queryFn rpmQueryFunc, path string) (string, error) {
+	out, _, err := queryFn("rpm", "-qp", "--qf", "%{NAME}", path)
+	if err != nil {
+		return "", fmt.Errorf("rpm -qp NAME: %w", err)
+	}
+	name := strings.TrimSpace(out)
+	if err := pkg.ValidateRpmPackageName(name); err != nil {
+		return "", fmt.Errorf("rpm reported an unsafe package name: %w", err)
+	}
+	return name, nil
+}
+
+// rpmQueryArgs / rpmEraseArgs build rpm argv with the package NAME passed
+// after a `--` end-of-options separator, so a name that slipped past
+// validation (or a future caller that skips it) can still never be
+// reparsed as an rpm option.
+func rpmQueryArgs(name string) []string { return sysexec.SeparatePositionals([]string{"-q"}, name) }
+func rpmEraseArgs(name string) []string { return sysexec.SeparatePositionals([]string{"-e"}, name) }
+
+// requireVerifiedArtifact fails closed unless rawURL is https and a
+// non-empty checksum is present. A download-and-install artifact whose
+// only authenticity is TLS to a possibly-compromised origin — or which
+// carries no checksum at all — must never be installed. The control
+// plane mandates both (proto + server validation); this is the
+// agent-side defense in depth at the executor boundary.
+func requireVerifiedArtifact(rawURL, checksum string) error {
+	if err := validateHTTPS(rawURL); err != nil {
+		return fmt.Errorf("artifact rejected: %w", err)
+	}
+	if strings.TrimSpace(checksum) == "" {
+		return fmt.Errorf("artifact rejected: checksum_sha256 is required (refusing to install an unverified binary)")
+	}
+	return nil
 }

--- a/internal/executor/action_rpm_test.go
+++ b/internal/executor/action_rpm_test.go
@@ -1,0 +1,112 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// TestRpmQueryArgv_PassesNameAfterEndOfOptions pins the intent that the
+// package NAME reaches `rpm -q` / `rpm -e` as an operand, never an
+// option — even when a crafted .rpm makes the name flag-shaped.
+func TestRpmQueryArgv_PassesNameAfterEndOfOptions(t *testing.T) {
+	if got, want := rpmQueryArgs("bash"), []string{"-q", "--", "bash"}; !slices.Equal(got, want) {
+		t.Errorf("rpmQueryArgs(bash) = %v, want %v", got, want)
+	}
+	if got, want := rpmEraseArgs("bash"), []string{"-e", "--", "bash"}; !slices.Equal(got, want) {
+		t.Errorf("rpmEraseArgs(bash) = %v, want %v", got, want)
+	}
+	// present-but-WRONG: a flag-shaped "name" must be the final operand,
+	// preceded by the "--" separator (so it can never be reparsed as an
+	// option even though it equals a flag).
+	for _, name := range []string{"-e", "--eval=%{lua:os.execute('id')}"} {
+		for _, args := range [][]string{rpmQueryArgs(name), rpmEraseArgs(name)} {
+			if n := len(args); n < 2 || args[n-1] != name || args[n-2] != "--" {
+				t.Errorf("name %q must be the final operand preceded by --; args=%v", name, args)
+			}
+		}
+	}
+}
+
+// TestRpmPackageName_RejectsCraftedName drives the real rpmPackageName
+// extraction through a swappable query seam — intent: a malicious .rpm
+// can set %{NAME} to anything, so the value rpm reports is untrusted and
+// must be validated before it reaches argv.
+func TestRpmPackageName_RejectsCraftedName(t *testing.T) {
+	reports := func(name string) rpmQueryFunc {
+		return func(string, ...string) (string, int, error) { return name, 0, nil }
+	}
+	// correct
+	if got, err := rpmPackageName(reports("bash"), "/tmp/x.rpm"); err != nil || got != "bash" {
+		t.Errorf("rpmPackageName(bash) = %q, %v; want bash, nil", got, err)
+	}
+	// present-but-WRONG crafted names (sourced from intent, not the regex)
+	for _, bad := range []string{"--eval=%{lua:os.execute('id')}", "-e", "  ", "", "pkg;rm -rf /"} {
+		if got, err := rpmPackageName(reports(bad), "/tmp/x.rpm"); err == nil {
+			t.Errorf("rpmPackageName(%q) = %q, nil; want error", bad, got)
+		}
+	}
+	// the underlying rpm query failing must propagate, not yield a name
+	failing := func(string, ...string) (string, int, error) { return "", 1, fmt.Errorf("boom") }
+	if _, err := rpmPackageName(failing, "/tmp/x.rpm"); err == nil {
+		t.Error("rpmPackageName must propagate a query error")
+	}
+}
+
+// TestRequireVerifiedArtifact pins the MITM-hardening contract for a
+// download-and-install artifact: https only, and a non-empty checksum
+// (fail-closed — never install an unverified binary).
+func TestRequireVerifiedArtifact(t *testing.T) {
+	validHex := strings.Repeat("a", 64)
+	if err := requireVerifiedArtifact("https://x/x.rpm", validHex); err != nil {
+		t.Errorf("valid https+checksum rejected: %v", err)
+	}
+	bad := []struct{ url, sum string }{
+		{"http://x/x.rpm", validHex}, // non-https → MITM
+		{"ftp://x/x.rpm", validHex},
+		{"https://x/x.rpm", ""},    // empty checksum → unverified
+		{"https://x/x.rpm", "   "}, // whitespace-only checksum
+	}
+	for _, tc := range bad {
+		if err := requireVerifiedArtifact(tc.url, tc.sum); err == nil {
+			t.Errorf("requireVerifiedArtifact(%q,%q) = nil; want error", tc.url, tc.sum)
+		}
+	}
+}
+
+// TestExecuteRpm_RejectsBeforeRemount pins that a non-https URL or an
+// absent checksum is rejected BEFORE any privileged filesystem
+// remount/repair — no temp file, no sudo side effect. Hermetic: the
+// guard runs before the `rpm` lookup, so no rpm binary is required.
+func TestExecuteRpm_RejectsBeforeRemount(t *testing.T) {
+	validHex := strings.Repeat("a", 64)
+	cases := []struct {
+		name string
+		p    *pb.AppInstallParams
+	}{
+		{"http url", &pb.AppInstallParams{Url: "http://mirror/x.rpm", ChecksumSha256: validHex}},
+		{"empty checksum", &pb.AppInstallParams{Url: "https://x/x.rpm", ChecksumSha256: ""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var remountCalls int
+			e := &Executor{logger: slog.Default(), now: time.Now, repairFS: func(context.Context) bool {
+				remountCalls++
+				return true
+			}}
+			out, changed, err := e.executeRpm(context.Background(), tc.p, pb.DesiredState_DESIRED_STATE_PRESENT)
+			if err == nil {
+				t.Fatalf("expected rejection, got out=%v changed=%v", out, changed)
+			}
+			if remountCalls != 0 {
+				t.Errorf("privileged remount ran %d times before validation; want 0", remountCalls)
+			}
+		})
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -103,6 +103,12 @@ func validateRepositoryParams(params *pb.RepositoryParams) error {
 		if containsNewline(apt.GpgKeyUrl) {
 			return reject("apt.gpg_key_url")
 		}
+		// apt.gpg_key (the ASCII-armored key BLOB, distinct from
+		// gpg_key_url) is intentionally NOT newline-guarded: it is
+		// multi-line content written verbatim to a keyring file, never
+		// spliced into a config line or argv. The self-discovering
+		// coverage test (repository_validation_test.go) lists it as the
+		// sole multi-line-content exclusion.
 	}
 	if dnf := params.Dnf; dnf != nil {
 		if containsNewline(dnf.Baseurl) {
@@ -114,6 +120,12 @@ func validateRepositoryParams(params *pb.RepositoryParams) error {
 		if containsNewline(dnf.Gpgkey) {
 			return reject("dnf.gpgkey")
 		}
+		if dnf.Baseurl != "" && pkg.ValidateRepoBaseURL(dnf.Baseurl) != nil {
+			return badShape("dnf.baseurl")
+		}
+		if dnf.Gpgkey != "" && pkg.ValidateGpgKeyRef(dnf.Gpgkey) != nil {
+			return badShape("dnf.gpgkey")
+		}
 	}
 	if pac := params.Pacman; pac != nil {
 		if containsNewline(pac.Server) {
@@ -124,6 +136,9 @@ func validateRepositoryParams(params *pb.RepositoryParams) error {
 		}
 		if pac.SigLevel != "" && !validPacmanSigLevel.MatchString(pac.SigLevel) {
 			return badShape("pacman.sig_level")
+		}
+		if pac.Server != "" && pkg.ValidateRepoBaseURL(pac.Server) != nil {
+			return badShape("pacman.server")
 		}
 	}
 	if zyp := params.Zypper; zyp != nil {
@@ -142,7 +157,21 @@ func validateRepositoryParams(params *pb.RepositoryParams) error {
 		if zyp.Type != "" && !validZypperType.MatchString(zyp.Type) {
 			return badShape("zypper.type")
 		}
+		if zyp.Url != "" && pkg.ValidateRepoBaseURL(zyp.Url) != nil {
+			return badShape("zypper.url")
+		}
+		if zyp.Gpgkey != "" && pkg.ValidateGpgKeyRef(zyp.Gpgkey) != nil {
+			return badShape("zypper.gpgkey")
+		}
 	}
+	// NOTE — gpgcheck is an OPERATOR CHOICE, not a hard gate. We enforce
+	// the https transport on base URLs (above), but a dnf/zypper repo with
+	// gpgcheck=false is permitted: package-signature verification is the
+	// operator's call, mirroring the WS7 checksum_url "lenient but the
+	// transport is still verified" posture. Re-introducing a refusal here
+	// would break legitimate internal-mirror configurations; the accepted
+	// risk is documented in ADR 0012. See
+	// TestValidateRepositoryParams_AllowsOperatorChoiceGpgcheck.
 	return nil
 }
 
@@ -190,6 +219,13 @@ type Executor struct {
 	luksTimestampFailCount map[string]int
 
 	now func() time.Time // clock seam; defaults to time.Now, overridden in tests
+
+	// repairFS is a seam over repairFilesystem so tests can record
+	// whether a privileged remount/repair was attempted (proving that a
+	// malformed/rejected action never reaches the privileged side
+	// effects). nil in production → requireWritableFS calls the real
+	// e.repairFilesystem.
+	repairFS func(ctx context.Context) bool
 }
 
 // NewExecutor creates a new action executor.

--- a/internal/executor/helpers.go
+++ b/internal/executor/helpers.go
@@ -18,7 +18,11 @@ var errReadOnlyFS = errors.New("filesystem is read-only")
 // requireWritableFS checks if the filesystem is writable and attempts repair if not.
 // Returns nil, nil if writable. Returns (output, error) if repair failed.
 func (e *Executor) requireWritableFS(ctx context.Context) (*pb.CommandOutput, error) {
-	if e.repairFilesystem(ctx) {
+	repair := e.repairFilesystem
+	if e.repairFS != nil {
+		repair = e.repairFS
+	}
+	if repair(ctx) {
 		return nil, nil
 	}
 	return &pb.CommandOutput{

--- a/internal/executor/integration_test.go
+++ b/internal/executor/integration_test.go
@@ -2452,6 +2452,10 @@ func TestIntegration_EdgeCase_DownloadHttp500(t *testing.T) {
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_RPM, pb.DesiredState_DESIRED_STATE_PRESENT)
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
 			Url: ts.URL + "/test-1.0-1.noarch.rpm",
+			// Checksum is server-mandated and the agent fails closed
+			// without it before downloading (WS8); the value is
+			// irrelevant here — the download errors with the status first.
+			ChecksumSha256: strings.Repeat("a", 64),
 		}}
 		result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
 		assertFailed(t, result)
@@ -2500,6 +2504,10 @@ func TestIntegration_EdgeCase_DownloadHttp404(t *testing.T) {
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_RPM, pb.DesiredState_DESIRED_STATE_PRESENT)
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
 			Url: ts.URL + "/test-1.0-1.noarch.rpm",
+			// Checksum is server-mandated and the agent fails closed
+			// without it before downloading (WS8); the value is
+			// irrelevant here — the download errors with the status first.
+			ChecksumSha256: strings.Repeat("a", 64),
 		}}
 		result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
 		assertFailed(t, result)

--- a/internal/executor/repository_validation_test.go
+++ b/internal/executor/repository_validation_test.go
@@ -1,8 +1,11 @@
 package executor
 
 import (
+	"reflect"
 	"strings"
 	"testing"
+
+	"google.golang.org/protobuf/proto"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 )
@@ -107,5 +110,182 @@ func TestValidateRepositoryParams_RejectsInjection(t *testing.T) {
 				t.Errorf("error should name the repository field; got: %v", err)
 			}
 		})
+	}
+}
+
+// protoFieldName extracts the snake_case proto field name from the
+// generated struct's `protobuf:"...,name=foo,..."` tag, or "" for the
+// proto-internal fields (state/sizeCache/unknownFields have no tag).
+func protoFieldName(f reflect.StructField) string {
+	for _, part := range strings.Split(f.Tag.Get("protobuf"), ",") {
+		if strings.HasPrefix(part, "name=") {
+			return strings.TrimPrefix(part, "name=")
+		}
+	}
+	return ""
+}
+
+// TestValidateRepositoryParams_SelfDiscoversEveryStringField is the
+// self-discovering replacement for the stale hardcoded subset (finding
+// 4). It reflection-walks every string / []string field of every repo
+// proto, injects a newline-bearing value into exactly one field, and
+// asserts the validator rejects it AND names that field. A newly-added
+// proto field that forgets its newline guard makes this FAIL — the test
+// fails CLOSED: a field is "must be guarded" unless it is consciously
+// listed in `multiLineContent` with a justification.
+func TestValidateRepositoryParams_SelfDiscoversEveryStringField(t *testing.T) {
+	// Fields whose value is legitimately multi-line content written to a
+	// file (not spliced into a config line or argv), so the newline guard
+	// must NOT apply. NOT a fail-open allowlist: a new field is absent
+	// here by default and therefore REQUIRED to carry the newline guard.
+	multiLineContent := map[string]bool{
+		"apt.gpg_key": true, // ASCII-armored key blob, written verbatim to a keyring file
+	}
+
+	managers := []struct {
+		prefix string
+		empty  func() proto.Message
+		wrap   func(proto.Message) *pb.RepositoryParams
+	}{
+		{"apt", func() proto.Message { return &pb.AptRepository{} }, func(m proto.Message) *pb.RepositoryParams {
+			return &pb.RepositoryParams{Name: "r", Apt: m.(*pb.AptRepository)}
+		}},
+		{"dnf", func() proto.Message { return &pb.DnfRepository{} }, func(m proto.Message) *pb.RepositoryParams {
+			return &pb.RepositoryParams{Name: "r", Dnf: m.(*pb.DnfRepository)}
+		}},
+		{"pacman", func() proto.Message { return &pb.PacmanRepository{} }, func(m proto.Message) *pb.RepositoryParams {
+			return &pb.RepositoryParams{Name: "r", Pacman: m.(*pb.PacmanRepository)}
+		}},
+		{"zypper", func() proto.Message { return &pb.ZypperRepository{} }, func(m proto.Message) *pb.RepositoryParams {
+			return &pb.RepositoryParams{Name: "r", Zypper: m.(*pb.ZypperRepository)}
+		}},
+	}
+
+	const payload = "x\nEvil: 1"
+	covered, urlish := 0, 0
+	for _, mgr := range managers {
+		rt := reflect.TypeOf(mgr.empty()).Elem()
+		for i := 0; i < rt.NumField(); i++ {
+			f := rt.Field(i)
+			snake := protoFieldName(f)
+			if snake == "" {
+				continue
+			}
+			isString := f.Type.Kind() == reflect.String
+			isStringSlice := f.Type.Kind() == reflect.Slice && f.Type.Elem().Kind() == reflect.String
+			if !isString && !isStringSlice {
+				continue
+			}
+			key := mgr.prefix + "." + snake
+			if multiLineContent[key] {
+				continue
+			}
+
+			fresh := reflect.New(rt)
+			fv := fresh.Elem().Field(i)
+			if isString {
+				fv.SetString(payload)
+			} else {
+				fv.Set(reflect.ValueOf([]string{payload}))
+			}
+			params := mgr.wrap(fresh.Interface().(proto.Message))
+
+			err := validateRepositoryParams(params)
+			if err == nil {
+				t.Errorf("%s: newline-injected value accepted (field unguarded)", key)
+				continue
+			}
+			if !strings.Contains(err.Error(), snake) {
+				t.Errorf("%s: error should name the field %q; got: %v", key, snake, err)
+			}
+			covered++
+			if l := strings.ToLower(snake); strings.Contains(l, "url") || strings.Contains(l, "server") || strings.Contains(l, "gpgkey") {
+				urlish++
+			}
+		}
+	}
+	if covered == 0 {
+		t.Fatal("self-discovering walk covered 0 fields — reflection is broken")
+	}
+	if urlish == 0 {
+		t.Fatal("no URL-ish field (url/server/gpgkey) was exercised — guard/walk mismatch")
+	}
+}
+
+// TestValidateRepositoryParams_RejectsNonHttpsBaseURL pins finding 3:
+// dnf baseurl / zypper url / pacman server (where ROOT packages are
+// fetched) must be https. Gpgcheck is set so the zero-integrity rule
+// does not mask the scheme check.
+func TestValidateRepositoryParams_RejectsNonHttpsBaseURL(t *testing.T) {
+	reject := []*pb.RepositoryParams{
+		{Name: "r", Dnf: &pb.DnfRepository{Baseurl: "http://m/r", Gpgcheck: true}},
+		{Name: "r", Zypper: &pb.ZypperRepository{Url: "http://m/r", Gpgcheck: true}},
+		{Name: "r", Pacman: &pb.PacmanRepository{Server: "http://m/r"}},
+		{Name: "r", Dnf: &pb.DnfRepository{Baseurl: "ftp://x", Gpgcheck: true}},
+		{Name: "r", Dnf: &pb.DnfRepository{Baseurl: "file:///etc", Gpgcheck: true}},
+	}
+	for i, p := range reject {
+		if err := validateRepositoryParams(p); err == nil {
+			t.Errorf("reject case %d: non-https base URL accepted", i)
+		}
+	}
+	accept := []*pb.RepositoryParams{
+		{Name: "r", Dnf: &pb.DnfRepository{Baseurl: "https://m/$releasever", Gpgcheck: true}},
+		{Name: "r", Pacman: &pb.PacmanRepository{Server: "https://m/$arch", SigLevel: "Optional TrustAll"}},
+	}
+	for i, p := range accept {
+		if err := validateRepositoryParams(p); err != nil {
+			t.Errorf("accept case %d: https base URL rejected: %v", i, err)
+		}
+	}
+}
+
+// TestValidateRepositoryParams_RejectsBadGpgKeyRef pins finding 2:
+// dnf/zypper Gpgkey passed to `rpm --import` must be https/file/abs-path
+// — never a flag, plaintext http, or rpm's ext:: command transport.
+func TestValidateRepositoryParams_RejectsBadGpgKeyRef(t *testing.T) {
+	reject := []*pb.RepositoryParams{
+		{Name: "r", Dnf: &pb.DnfRepository{Baseurl: "https://m/r", Gpgcheck: true, Gpgkey: "http://evil/key"}},
+		{Name: "r", Dnf: &pb.DnfRepository{Baseurl: "https://m/r", Gpgcheck: true, Gpgkey: "-"}},
+		{Name: "r", Dnf: &pb.DnfRepository{Baseurl: "https://m/r", Gpgcheck: true, Gpgkey: "--import=/etc/shadow"}},
+		{Name: "r", Dnf: &pb.DnfRepository{Baseurl: "https://m/r", Gpgcheck: true, Gpgkey: "ext::sh -c id"}},
+		{Name: "r", Zypper: &pb.ZypperRepository{Url: "https://m/r", Gpgcheck: true, Gpgkey: "http://evil/key"}},
+	}
+	for i, p := range reject {
+		if err := validateRepositoryParams(p); err == nil {
+			t.Errorf("reject case %d: bad gpg key ref accepted", i)
+		}
+	}
+	accept := []*pb.RepositoryParams{
+		{Name: "r", Dnf: &pb.DnfRepository{Baseurl: "https://m/r", Gpgcheck: true, Gpgkey: "https://m/key.asc"}},
+		{Name: "r", Dnf: &pb.DnfRepository{Baseurl: "https://m/r", Gpgcheck: true, Gpgkey: "file:///etc/pki/rpm-gpg/KEY"}},
+		{Name: "r", Zypper: &pb.ZypperRepository{Url: "https://m/r", Gpgcheck: true, Gpgkey: "/etc/pki/rpm-gpg/KEY"}},
+	}
+	for i, p := range accept {
+		if err := validateRepositoryParams(p); err != nil {
+			t.Errorf("accept case %d: good gpg key ref rejected: %v", i, err)
+		}
+	}
+}
+
+// TestValidateRepositoryParams_AllowsOperatorChoiceGpgcheck pins the
+// deliberate decision (ADR 0012): gpgcheck is an OPERATOR CHOICE, not a
+// hard gate. An https base URL with gpgcheck=false and no key is a
+// legitimate (if less-verified) internal-mirror configuration and must
+// NOT be rejected — mirroring the WS7 checksum_url posture (the https
+// transport is still enforced; package-signature verification is the
+// operator's call). This guards against a future contributor
+// re-introducing a refusal that would break real operators.
+func TestValidateRepositoryParams_AllowsOperatorChoiceGpgcheck(t *testing.T) {
+	accept := []*pb.RepositoryParams{
+		{Name: "r", Dnf: &pb.DnfRepository{Baseurl: "https://m/r", Gpgcheck: false}},                        // gpgcheck off, no key — operator choice
+		{Name: "r", Dnf: &pb.DnfRepository{Baseurl: "https://m/r", Gpgcheck: true}},                         // gpgcheck on
+		{Name: "r", Dnf: &pb.DnfRepository{Baseurl: "https://m/r", Gpgcheck: false, Gpgkey: "https://m/k"}}, // key supplied
+		{Name: "r", Zypper: &pb.ZypperRepository{Url: "https://m/r", Gpgcheck: false}},
+	}
+	for i, p := range accept {
+		if err := validateRepositoryParams(p); err != nil {
+			t.Errorf("accept case %d: legitimate operator-choice config rejected: %v", i, err)
+		}
 	}
 }


### PR DESCRIPTION
Closes #111. Implements the agent surface of `manchtools/power-manage-sdk#88` by consuming the new SDK argv validators + `exec.SeparatePositionals`.

## Hardening

| Surface | Validation | Argv |
|---------|-----------|------|
| `RPM` `%{NAME}` (read off the downloaded `.rpm`) | `pkg.ValidateRpmPackageName` — a crafted `.rpm` can't name itself `--eval=%{lua:…}` | `rpm -q -- <name>` / `rpm -e -- <name>` / `rpm -i -- <tmp>` |
| `RPM`/`DEB`/`APP_IMAGE` artifact | https + non-empty checksum, fail-closed **before** any privileged remount/download | — |
| dnf/zypper/pacman base URL | `pkg.ValidateRepoBaseURL` (https + host) | repo config |
| dnf/zypper GPG key ref | `pkg.ValidateGpgKeyRef` (https / `file://` abs / abs path) | `rpm --import -- <ref>` |
| `FLATPAK` app-id / remote | `pkg.ValidatePackageName` / `pkg.ValidateRemoteName`, **before** dispatch | `flatpak install\|uninstall … -- …` |

A **self-discovering** test reflection-walks every string field of every repository proto and fails closed if a newly-added field forgets its newline/config-injection guard (sole documented exclusion: `apt.gpg_key`, armored key content).

## Deliberate decision — `gpgcheck` is an operator choice

The workplan floated refusing a dnf/zypper base URL when `gpgcheck=false`. I **did not** add that refusal: it would break legitimate internal-mirror configs (an https mirror run with `gpgcheck=false`), which are in active use (existing integration fixtures). https on the base URL closes the transport-MITM; package-signature verification is the operator's call — the same posture as the auto-update `checksum_url` (ADR 0011). Pinned by `TestValidateRepositoryParams_AllowsOperatorChoiceGpgcheck` and documented as accepted risk in ADR 0012.

## Tests (red-first)

- rpm name/argv + `requireVerifiedArtifact` + reject-before-remount (via a recorded `repairFS` seam)
- repository self-discovering walk + non-https base URL + bad GPG key ref grammar
- flatpak app-id/remote validation (isolates a *validation* error, not an incidental session-enumeration failure) + install/uninstall argv shape

Workspace + standalone (`GOWORK=off`) build/vet/test green; gofmt clean; SDK pin bumped to the merged `sdk#103`.