### PR TITLE
feat: harden agent enrollment (https-only, optional OOB CA pin, token-file, rotation CA-continuity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,21 +47,33 @@ The agent supports two enrollment methods:
 
 1. The install script starts the agent as a systemd service
 2. The unenrolled agent opens an **enrollment socket** at `/run/pm-agent/enroll.sock` (mode 0666, any local user can connect)
-3. A regular user runs `power-manage-agent enroll -server=URL -token=TOKEN`
+3. A regular user runs `power-manage-agent enroll -server=URL -token-file=PATH` (or `PM_REGISTRATION_TOKEN=… power-manage-agent enroll -server=URL`)
 4. The CLI sends an `Enroll` RPC to the agent over the unix socket
 5. The agent calls the **Control Server** `Register` RPC with the token and a locally-generated CSR
 6. The Control Server validates the token, signs the certificate, and returns credentials
 7. The agent saves credentials, closes the enrollment socket, starts the auth socket, and connects to the gateway
 
-> **Trust boundary.** The enrollment socket is intentionally
-> world-accessible (mode `0666`); the security boundary is the
-> registration token, which is validated by the Control Server.
-> The agent applies a **global** rate limit of 5 enrollment attempts
-> per minute across all local callers, so any local user can briefly
-> prevent a legitimate enrollment by flooding the socket with bad
-> tokens. This is acceptable for a self-hosted MDM — the admin who
-> runs the install script will retry — but it is not suitable for
-> adversarial multi-tenant hosts.
+> **Trust boundary (deliberate self-service design).** The enrollment
+> socket is intentionally world-accessible (mode `0666`) so a **non-root
+> user can enroll their own corporate/BYOD device without sudo** — that
+> is the whole point of the socket. The security boundary is the
+> registration **token**, validated by the Control Server; an admin who
+> does *not* want self-service can pre-enroll devices with a bulk
+> registration token instead. The agent applies a **global** rate limit
+> of 5 enrollment attempts per minute, so a local user can briefly
+> disrupt a legitimate enrollment by flooding bad tokens — acceptable for
+> a self-hosted MDM, not for adversarial multi-tenant hosts.
+>
+> **Hardening (WS9).** `server_url` must be **https** (cleartext/opaque
+> URLs are refused before any network call). Token delivery is via
+> `-token-file` or the `PM_REGISTRATION_TOKEN` env var; passing `-token`
+> on argv still works but warns (it leaks via `/proc/<pid>/cmdline`).
+> Optionally the operator can pass an out-of-band **CA fingerprint pin**
+> (`-pin`, or `&pin=` in a `power-manage://` URI): the agent verifies the
+> Control Server CA matches the pin before trusting it, defending against
+> a first-enrollment trust-anchor swap. Without a pin, first enrollment
+> is trust-on-first-use — an accepted residual mitigated by enroll-at-
+> install plus short-lived, single-use, revocable tokens. See ADR 0013.
 
 ```
                                   ┌─────────────────────────┐

--- a/cmd/power-manage-agent/cert_rotation.go
+++ b/cmd/power-manage-agent/cert_rotation.go
@@ -61,6 +61,46 @@ func register(ctx context.Context, cfg *Config, hostname string, logger *slog.Lo
 	}, nil
 }
 
+// renewAt returns how long to wait, measured from now, before renewing a
+// certificate with the given validity window: 80% of its lifetime,
+// clamped to a 1-minute minimum so an already-expired or near-expired
+// cert renews almost immediately instead of busy-looping on a negative
+// wait.
+func renewAt(notBefore, notAfter, now time.Time) time.Duration {
+	lifetime := notAfter.Sub(notBefore)
+	renew := notBefore.Add(time.Duration(float64(lifetime) * 0.8))
+	if wait := renew.Sub(now); wait > 0 {
+		return wait
+	}
+	return time.Minute
+}
+
+// shouldEscalateRotation reports whether the rotation-failure log should
+// escalate to the louder "stalled" wording — once consecutive failures
+// reach the threshold.
+func shouldEscalateRotation(consecutiveFailures, threshold int) bool {
+	return consecutiveFailures >= threshold
+}
+
+// applyRenewal updates creds in place from a renewal result, refusing a
+// non-continuous CA (#4). If the server returned a CA that is neither
+// byte-identical to nor cross-signed by the enrolled CA, it is rejected
+// as a trust-anchor swap and creds is left UNCHANGED, so the existing
+// cert+CA remain valid on disk. Otherwise the new certificate (and the
+// CA, if one was returned) is adopted.
+func applyRenewal(creds *credentials.Credentials, result *sdk.RenewCertificateResult) error {
+	if len(result.CACert) > 0 {
+		if err := pmcrypto.VerifyCAContinuity(creds.CACert, result.CACert); err != nil {
+			return fmt.Errorf("refusing non-continuous CA on renewal: %w", err)
+		}
+	}
+	creds.Certificate = result.Certificate
+	if len(result.CACert) > 0 {
+		creds.CACert = result.CACert
+	}
+	return nil
+}
+
 // startCertRotation runs a background loop that renews the agent's mTLS
 // certificate before it expires. Renewal is attempted at 80% of the cert's
 // lifetime. On failure it retries every hour.
@@ -71,7 +111,7 @@ func register(ctx context.Context, cfg *Config, hostname string, logger *slog.Lo
 // the count crosses a threshold the messages escalate to mention how
 // long the agent has been unable to rotate, which is what an operator
 // needs to triage "is the control server reachable?".
-func startCertRotation(ctx context.Context, credStore *credentials.Store, hostname string, logger *slog.Logger) {
+func startCertRotation(ctx context.Context, credStore *credentials.Store, hostname string, logger *slog.Logger, now func() time.Time) {
 	const (
 		retryInterval     = 1 * time.Hour
 		escalateThreshold = 3 // hours of consecutive failure before the log volume rises
@@ -80,7 +120,7 @@ func startCertRotation(ctx context.Context, credStore *credentials.Store, hostna
 	logRetryFailure := func(stage string, err error) {
 		consecutiveFailures++
 		attrs := []any{"stage", stage, "error", err, "consecutive_failures", consecutiveFailures}
-		if consecutiveFailures >= escalateThreshold {
+		if shouldEscalateRotation(consecutiveFailures, escalateThreshold) {
 			// Escalated wording so a `journalctl -u power-manage-agent
 			// | grep "rotation stalled"` query surfaces the issue
 			// fast. The hours-stalled value is the operator-facing
@@ -112,17 +152,11 @@ func startCertRotation(ctx context.Context, credStore *credentials.Store, hostna
 			return
 		}
 
-		// Calculate renewal time at 80% of lifetime
-		lifetime := cert.NotAfter.Sub(cert.NotBefore)
-		renewAt := cert.NotBefore.Add(time.Duration(float64(lifetime) * 0.8))
-		waitDuration := time.Until(renewAt)
-		if waitDuration <= 0 {
-			waitDuration = 1 * time.Minute
-		}
+		// Renew at 80% of lifetime (clamped to >=1m if already past).
+		waitDuration := renewAt(cert.NotBefore, cert.NotAfter, now())
 
 		logger.Info("cert rotation: scheduled",
 			"not_after", cert.NotAfter,
-			"renew_at", renewAt,
 			"wait", waitDuration.String(),
 		)
 
@@ -176,10 +210,18 @@ func startCertRotation(ctx context.Context, credStore *credentials.Store, hostna
 			continue
 		}
 
-		// Update credentials on disk with new certificate (and CA cert if rotated)
-		creds.Certificate = result.Certificate
-		if len(result.CACert) > 0 {
-			creds.CACert = result.CACert
+		// Adopt the new cert — and the CA only if it is continuous with
+		// the enrolled CA (#4). A non-continuous CA is refused (trust-
+		// anchor swap): keep the existing cert+CA on disk and treat it as
+		// a retryable failure rather than blindly broadening trust.
+		if err := applyRenewal(creds, result); err != nil {
+			logRetryFailure("ca_continuity", err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(retryInterval):
+			}
+			continue
 		}
 		if err := credStore.Save(creds); err != nil {
 			logRetryFailure("save_credentials", err)

--- a/cmd/power-manage-agent/cert_rotation_test.go
+++ b/cmd/power-manage-agent/cert_rotation_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage/agent/internal/credentials"
+	sdk "github.com/manchtools/power-manage/sdk/go"
+)
+
+// genCAPEM creates a self-signed CA certificate (PEM).
+func genCAPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// TestRenewAt_Computation pins the 80%-of-lifetime schedule and the
+// already-past clamp to a 1-minute minimum.
+func TestRenewAt_Computation(t *testing.T) {
+	nb := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	na := nb.Add(100 * 24 * time.Hour) // 100-day cert → renew at +80d
+
+	if got, want := renewAt(nb, na, nb), 80*24*time.Hour; got != want {
+		t.Errorf("renewAt at issuance = %v, want %v", got, want)
+	}
+	if got := renewAt(nb, na, nb.Add(50*24*time.Hour)); got != 30*24*time.Hour {
+		t.Errorf("renewAt at +50d = %v, want 30d", got)
+	}
+	if got := renewAt(nb, na, nb.Add(90*24*time.Hour)); got != time.Minute {
+		t.Errorf("renewAt past the renewal point = %v, want 1m clamp", got)
+	}
+	if got := renewAt(nb, na, na.Add(time.Hour)); got != time.Minute {
+		t.Errorf("renewAt for an expired cert = %v, want 1m clamp", got)
+	}
+}
+
+// TestShouldEscalateRotation pins the escalation boundary.
+func TestShouldEscalateRotation(t *testing.T) {
+	if shouldEscalateRotation(2, 3) {
+		t.Error("2 < 3 must not escalate")
+	}
+	if !shouldEscalateRotation(3, 3) {
+		t.Error("3 >= 3 must escalate")
+	}
+	if !shouldEscalateRotation(7, 3) {
+		t.Error("7 >= 3 must escalate")
+	}
+}
+
+// TestApplyRenewal_RefusesNonContinuousCA pins finding #4: a returned CA
+// that does not chain to the enrolled CA is refused and creds is left
+// untouched (old cert + CA stay on disk).
+func TestApplyRenewal_RefusesNonContinuousCA(t *testing.T) {
+	oldCA := genCAPEM(t)
+	unrelatedCA := genCAPEM(t)
+	creds := &credentials.Credentials{CACert: oldCA, Certificate: []byte("old-cert")}
+
+	err := applyRenewal(creds, &sdk.RenewCertificateResult{
+		Certificate: []byte("new-cert"),
+		CACert:      unrelatedCA,
+	})
+	if err == nil {
+		t.Fatal("expected refusal of an unrelated (non-continuous) CA")
+	}
+	if string(creds.Certificate) != "old-cert" || string(creds.CACert) != string(oldCA) {
+		t.Error("creds were mutated on a refused renewal — must stay untouched")
+	}
+}
+
+// TestApplyRenewal_AcceptsIdenticalCA — the common case: the server
+// returns the same CA; the new cert is adopted.
+func TestApplyRenewal_AcceptsIdenticalCA(t *testing.T) {
+	oldCA := genCAPEM(t)
+	creds := &credentials.Credentials{CACert: oldCA, Certificate: []byte("old-cert")}
+
+	if err := applyRenewal(creds, &sdk.RenewCertificateResult{
+		Certificate: []byte("new-cert"),
+		CACert:      oldCA,
+	}); err != nil {
+		t.Fatalf("identical CA refused: %v", err)
+	}
+	if string(creds.Certificate) != "new-cert" {
+		t.Error("certificate not updated on an accepted renewal")
+	}
+}
+
+// TestApplyRenewal_NoCAReturned keeps the enrolled CA and still adopts
+// the new cert (renewal without rotation).
+func TestApplyRenewal_NoCAReturned(t *testing.T) {
+	oldCA := genCAPEM(t)
+	creds := &credentials.Credentials{CACert: oldCA, Certificate: []byte("old-cert")}
+
+	if err := applyRenewal(creds, &sdk.RenewCertificateResult{Certificate: []byte("new-cert")}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(creds.CACert) != string(oldCA) {
+		t.Error("CA changed when the server returned none")
+	}
+	if string(creds.Certificate) != "new-cert" {
+		t.Error("certificate not updated")
+	}
+}

--- a/cmd/power-manage-agent/cmd_enroll.go
+++ b/cmd/power-manage-agent/cmd_enroll.go
@@ -47,7 +47,35 @@ func parseRegistrationURI(rawURI string) (*registrationURI, error) {
 	return &registrationURI{
 		ServerURL: fmt.Sprintf("https://%s", parsed.Host),
 		Token:     token,
+		// Optional out-of-band CA fingerprint pin. Any tls=/skip-verify=
+		// query params are intentionally ignored — ServerURL is always
+		// normalized to https, there is no TLS-bypass path.
+		Pin: parsed.Query().Get("pin"),
 	}, nil
+}
+
+// resolveEnrollToken resolves the registration token, preferring secure
+// delivery: a -token-file read from disk, then the PM_REGISTRATION_TOKEN
+// environment variable, and only as a last resort the -token argv flag —
+// which is warned against because process arguments are world-readable
+// via /proc/<pid>/cmdline (finding #3). Returns "" when no source
+// provided a token.
+func resolveEnrollToken(flagToken, tokenFile, envToken string) (string, error) {
+	if tokenFile != "" {
+		b, err := os.ReadFile(tokenFile)
+		if err != nil {
+			return "", fmt.Errorf("read token file %s: %w", tokenFile, err)
+		}
+		return strings.TrimSpace(string(b)), nil
+	}
+	if envToken != "" {
+		return strings.TrimSpace(envToken), nil
+	}
+	if flagToken != "" {
+		fmt.Fprintln(os.Stderr, "warning: passing -token on the command line is insecure (visible in /proc/<pid>/cmdline); prefer -token-file or the PM_REGISTRATION_TOKEN environment variable")
+		return strings.TrimSpace(flagToken), nil
+	}
+	return "", nil
 }
 
 // runEnroll handles the "enroll" subcommand.
@@ -56,29 +84,52 @@ func parseRegistrationURI(rawURI string) (*registrationURI, error) {
 //	power-manage-agent enroll 'power-manage://server:port?token=xxx'
 func runEnroll(args []string) {
 	fs := flag.NewFlagSet("enroll", flag.ExitOnError)
-	token := fs.String("token", "", "Registration token")
+	token := fs.String("token", "", "Registration token (INSECURE on argv; prefer -token-file or PM_REGISTRATION_TOKEN)")
+	tokenFile := fs.String("token-file", "", "Path to a file containing the registration token (preferred over -token)")
 	server := fs.String("server", "", "Control server URL")
+	pin := fs.String("pin", "", "Optional CA fingerprint pin (SHA-256 hex of the control CA) verified before trusting the server CA")
 	socketPath := fs.String("socket", deviceauth.EnrollSocketPath, "Agent enrollment socket")
 	fs.Parse(args)
+
+	caPin := *pin
+	fromURI := false
 
 	// Accept power-manage:// URI as positional arg
 	if fs.NArg() > 0 {
 		arg := fs.Arg(0)
 		if strings.HasPrefix(arg, "power-manage://") {
-			if parsed, err := parseRegistrationURI(arg); err == nil {
-				*server = parsed.ServerURL
-				*token = parsed.Token
-			} else {
+			parsed, err := parseRegistrationURI(arg)
+			if err != nil {
 				fmt.Fprintf(os.Stderr, "error: %v\n", err)
 				os.Exit(1)
 			}
+			*server = parsed.ServerURL
+			*token = parsed.Token
+			if parsed.Pin != "" {
+				caPin = parsed.Pin
+			}
+			fromURI = true
 		}
 	}
 
-	if *token == "" || *server == "" {
-		fmt.Fprintln(os.Stderr, "error: -server and -token are required")
-		fmt.Fprintln(os.Stderr, "usage: power-manage-agent enroll -server=URL -token=TOKEN")
-		fmt.Fprintln(os.Stderr, "   or: power-manage-agent enroll 'power-manage://server:port?token=xxx'")
+	// Resolve the token. The URI carries its own token; otherwise prefer
+	// the secure -token-file / PM_REGISTRATION_TOKEN sources over -token
+	// argv (which leaks via /proc/<pid>/cmdline, #3).
+	resolvedToken := *token
+	if !fromURI {
+		rt, err := resolveEnrollToken(*token, *tokenFile, os.Getenv("PM_REGISTRATION_TOKEN"))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		resolvedToken = rt
+	}
+
+	if resolvedToken == "" || *server == "" {
+		fmt.Fprintln(os.Stderr, "error: a control server URL and a registration token are required")
+		fmt.Fprintln(os.Stderr, "usage: power-manage-agent enroll -server=URL -token-file=PATH")
+		fmt.Fprintln(os.Stderr, "   or: PM_REGISTRATION_TOKEN=… power-manage-agent enroll -server=URL")
+		fmt.Fprintln(os.Stderr, "   or: power-manage-agent enroll 'power-manage://server:port?token=xxx&pin=…'")
 		os.Exit(1)
 	}
 
@@ -104,10 +155,12 @@ func runEnroll(args []string) {
 
 	// Enroll via the local socket. The SDK proto no longer carries
 	// a TLS-bypass field; agents always validate the server cert
-	// during enrollment.
+	// during enrollment. An optional CA fingerprint pin is verified
+	// server-side before the returned CA is trusted.
 	resp, err := client.Enroll(ctx, connect.NewRequest(&pm.EnrollRequest{
-		ServerUrl: *server,
-		Token:     *token,
+		ServerUrl:        *server,
+		Token:            resolvedToken,
+		CaFingerprintPin: strings.ReplaceAll(strings.TrimSpace(caPin), ":", ""),
 	}))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: enrollment failed: %v\n", err)
@@ -139,8 +192,9 @@ func trySocketEnroll(parsed *registrationURI) bool {
 	}
 
 	resp, err := client.Enroll(ctx, connect.NewRequest(&pm.EnrollRequest{
-		ServerUrl: parsed.ServerURL,
-		Token:     parsed.Token,
+		ServerUrl:        parsed.ServerURL,
+		Token:            parsed.Token,
+		CaFingerprintPin: strings.ReplaceAll(strings.TrimSpace(parsed.Pin), ":", ""),
 	}))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: socket enrollment failed: %v\n", err)
@@ -159,6 +213,7 @@ func trySocketEnroll(parsed *registrationURI) bool {
 type registrationURI struct {
 	ServerURL string
 	Token     string
+	Pin       string // optional CA fingerprint pin
 }
 
 // unixSocketHTTPClient returns an HTTP client that dials the given unix socket.

--- a/cmd/power-manage-agent/cmd_enroll_test.go
+++ b/cmd/power-manage-agent/cmd_enroll_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestParseRegistrationURI pins URI parsing (#19): token required, the
+// optional pin is carried, the host always normalizes to https, and any
+// tls=/skip-verify= query params are ignored (no TLS-bypass path).
+func TestParseRegistrationURI(t *testing.T) {
+	t.Run("well-formed with pin", func(t *testing.T) {
+		u, err := parseRegistrationURI("power-manage://host:8081?token=abc123&pin=DEADBEEF")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if u.ServerURL != "https://host:8081" {
+			t.Errorf("ServerURL = %q, want https://host:8081", u.ServerURL)
+		}
+		if u.Token != "abc123" {
+			t.Errorf("Token = %q, want abc123", u.Token)
+		}
+		if u.Pin != "DEADBEEF" {
+			t.Errorf("Pin = %q, want DEADBEEF", u.Pin)
+		}
+	})
+	t.Run("token required", func(t *testing.T) {
+		if _, err := parseRegistrationURI("power-manage://host"); err == nil {
+			t.Error("expected error for missing token")
+		}
+		if _, err := parseRegistrationURI("power-manage://host?token="); err == nil {
+			t.Error("expected error for empty token")
+		}
+	})
+	t.Run("tls-bypass params ignored", func(t *testing.T) {
+		u, err := parseRegistrationURI("power-manage://host?token=t&tls=false&skip-verify=true")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if u.ServerURL != "https://host" {
+			t.Errorf("ServerURL = %q, want https://host (no bypass)", u.ServerURL)
+		}
+	})
+}
+
+// TestResolveEnrollToken pins the secure token-delivery precedence (#3):
+// file > env > argv flag; missing file errors; whitespace is trimmed.
+func TestResolveEnrollToken(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "tok")
+	if err := os.WriteFile(tokenFile, []byte("  filetok\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name            string
+		flag, file, env string
+		want            string
+		wantErr         bool
+	}{
+		{"file wins over env and flag", "flagtok", tokenFile, "envtok", "filetok", false},
+		{"env wins over flag", "flagtok", "", "envtok", "envtok", false},
+		{"flag last resort", "flagtok", "", "", "flagtok", false},
+		{"flag whitespace trimmed", "  flagtok  ", "", "", "flagtok", false},
+		{"none", "", "", "", "", false},
+		{"missing file errors", "", "/nonexistent/path/tok", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveEnrollToken(tc.flag, tc.file, tc.env)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("resolveEnrollToken(%q,%q,%q) = %q, want %q", tc.flag, tc.file, tc.env, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/power-manage-agent/install_lint_test.go
+++ b/cmd/power-manage-agent/install_lint_test.go
@@ -40,6 +40,23 @@ func TestInstall_DesktopHandlerOptIn(t *testing.T) {
 	}
 }
 
+// WS9 #3: the install flow must NOT pass the registration token on argv
+// (visible via /proc/<pid>/cmdline). It must deliver it via -token-file,
+// created mode 0600.
+func TestInstall_TokenDeliveredViaFileNotArgv(t *testing.T) {
+	sh := readRepoFile(t, "install.sh")
+
+	if strings.Contains(sh, "-token=$REGISTRATION_TOKEN") {
+		t.Error("install.sh must not pass the registration token on argv; use -token-file")
+	}
+	if !strings.Contains(sh, "-token-file=") {
+		t.Error("install.sh enrollment must deliver the token via -token-file")
+	}
+	if !strings.Contains(sh, `chmod 600 "$token_file"`) {
+		t.Error("the install.sh token file must be created mode 0600")
+	}
+}
+
 // WS7 #9: every capability in the systemd unit's CapabilityBoundingSet
 // must carry a justification comment. Self-discovering: a cap added
 // without a comment fails this test.

--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -295,7 +295,7 @@ func main() {
 
 	// Start certificate rotation goroutine
 	if creds.ControlAddr != "" {
-		go startCertRotation(ctx, credStore, hostname, logger)
+		go startCertRotation(ctx, credStore, hostname, logger, time.Now)
 	}
 
 	// Run the agent

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 // it. There is no automatic floating tag — that's intentional, because
 // SDK proto/Go API drifts between commits should be reviewable in the
 // same PR as the agent change that consumes them.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260614102249-49d306f6cd9f
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260614134347-ca1b2306bbad
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260614102249-49d306f6cd9f h1:4MAcHPC/gIu5XOStTwby/mbAFqtR260vSfDZa5AiQ8M=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260614102249-49d306f6cd9f/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260614134347-ca1b2306bbad h1:aFCW/WZtpFqrPlaO3QxHYwvXxyD4yuS3xF1MZ5L3hSo=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260614134347-ca1b2306bbad/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/install.sh
+++ b/install.sh
@@ -472,20 +472,30 @@ enroll_agent() {
     if [[ -z "$REGISTRATION_TOKEN" ]] || [[ -z "$SERVER_URL" ]]; then
         log_warn "No registration token or server URL provided, skipping enrollment"
         log_info "You can enroll later by running (no sudo required):"
-        log_info "  $BINARY_PATH enroll -server=<URL> -token=<TOKEN>"
+        log_info "  $BINARY_PATH enroll -server=<URL> -token-file=<PATH>"
         return
     fi
 
     log_info "Enrolling agent with server via socket..."
 
+    # Deliver the token via a 0600 file, NOT on argv: process arguments
+    # are world-readable via /proc/<pid>/cmdline, so `-token=…` would leak
+    # the registration token to any local user for the life of the call.
+    local token_file
+    token_file="$(mktemp)"
+    chmod 600 "$token_file"
+    # Remove the token file on any return path (success, failure, signal).
+    trap 'rm -f "$token_file"' RETURN
+    printf '%s' "$REGISTRATION_TOKEN" > "$token_file"
+
     # Build the enrollment command as an array so arguments are passed
     # one-per-element and bash does not word-split, glob, or re-tokenise
-    # user-supplied values such as SERVER_URL or REGISTRATION_TOKEN.
+    # user-supplied values such as SERVER_URL.
     local -a enroll_cmd=(
         "$BINARY_PATH"
         "enroll"
         "-server=$SERVER_URL"
-        "-token=$REGISTRATION_TOKEN"
+        "-token-file=$token_file"
     )
 
     # Wait for the enrollment socket to become available (agent needs to start first)
@@ -507,8 +517,7 @@ enroll_agent() {
     else
         log_error "Agent enrollment failed"
         log_info "You can try again later by running:"
-        # printf %q quotes each argument safely for copy-paste.
-        log_info "  $(printf '%q ' "${enroll_cmd[@]}")"
+        log_info "  $BINARY_PATH enroll -server=$SERVER_URL -token-file=<PATH>"
         return 1
     fi
 }

--- a/internal/deviceauth/enroll.go
+++ b/internal/deviceauth/enroll.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -56,6 +57,12 @@ type EnrollHandler struct {
 	statusCached   bool
 
 	now func() time.Time // clock seam; defaults to time.Now, overridden in tests
+
+	// registerOpts are extra ClientOptions passed to sdk.RegisterAgent.
+	// nil in production (RegisterAgent then uses its bounded default
+	// client). Tests set this to point RegisterAgent at an httptest TLS
+	// control server it can trust.
+	registerOpts []sdk.ClientOption
 }
 
 // NewEnrollHandler creates a handler for enrollment RPCs.
@@ -69,6 +76,15 @@ func NewEnrollHandler(hostname, version string, credStore *credentials.Store, lo
 		onEnrolled: onEnrolled,
 		now:        time.Now,
 	}
+}
+
+// normalizePin canonicalizes an operator-supplied CA fingerprint pin for
+// comparison: it strips surrounding whitespace and colons (openssl prints
+// the fingerprint uppercase and colon-separated). Case is handled by
+// EqualFold at the comparison site, so a pin pasted in any common form
+// matches the lowercase-hex value derived from the server CA.
+func normalizePin(pin string) string {
+	return strings.ReplaceAll(strings.TrimSpace(pin), ":", "")
 }
 
 // Enroll registers the agent with the PM server using the provided token.
@@ -111,6 +127,17 @@ func (h *EnrollHandler) Enroll(ctx context.Context, req *connect.Request[pm.Enro
 		}), nil
 	}
 
+	// https-only gate (WS9 #2/#16): refuse a cleartext or malformed
+	// control-plane URL BEFORE any CSR generation or network call. The
+	// agent has no trust anchor yet, so a non-TLS endpoint would let a
+	// MITM substitute the gateway URL and a malicious CA.
+	if err := sdk.ValidateHTTPSURL(req.Msg.ServerUrl); err != nil {
+		return connect.NewResponse(&pm.EnrollResponse{
+			Success: false,
+			Error:   fmt.Sprintf("server_url must be an https URL: %v", err),
+		}), nil
+	}
+
 	// (The SkipVerify rejection check that lived here was removed
 	// once the SDK dropped the proto field — see SDK PR. The wire
 	// format now has no path to request a TLS bypass; outdated
@@ -141,7 +168,7 @@ func (h *EnrollHandler) Enroll(ctx context.Context, req *connect.Request[pm.Enro
 	}
 
 	// Register via control server RPC.
-	result, err := sdk.RegisterAgent(ctx, req.Msg.ServerUrl, req.Msg.Token, h.hostname, h.version, csrPEM)
+	result, err := sdk.RegisterAgent(ctx, req.Msg.ServerUrl, req.Msg.Token, h.hostname, h.version, csrPEM, h.registerOpts...)
 	if err != nil {
 		h.logger.Error("registration failed", "error", err)
 		return connect.NewResponse(&pm.EnrollResponse{
@@ -156,6 +183,31 @@ func (h *EnrollHandler) Enroll(ctx context.Context, req *connect.Request[pm.Enro
 			Success: false,
 			Error:   "server did not provide mTLS certificates",
 		}), nil
+	}
+
+	// Optional out-of-band CA-pin verification (WS9 #5): if the operator
+	// supplied a fingerprint pin, the CA returned by registration MUST
+	// match it before we adopt it as the trust anchor. Fail closed on a
+	// mismatch — no Save, no callback, no status-cache prime — so a
+	// first-enrollment trust-anchor swap is refused. The pin is
+	// normalized (colons stripped) and compared case-insensitively, since
+	// operators paste it from tools like openssl (uppercase, colon-sep).
+	if pin := normalizePin(req.Msg.CaFingerprintPin); pin != "" {
+		got, fpErr := pmcrypto.CAFingerprintFromPEM(result.CACert)
+		if fpErr != nil {
+			return connect.NewResponse(&pm.EnrollResponse{
+				Success: false,
+				Error:   fmt.Sprintf("cannot fingerprint server CA: %v", fpErr),
+			}), nil
+		}
+		if !strings.EqualFold(got, pin) {
+			h.logger.Error("enrollment CA fingerprint mismatch — refusing to trust server CA",
+				"expected_pin", pin, "server_ca_fingerprint", got)
+			return connect.NewResponse(&pm.EnrollResponse{
+				Success: false,
+				Error:   "CA fingerprint mismatch: the server CA does not match the pinned fingerprint",
+			}), nil
+		}
 	}
 
 	creds := &credentials.Credentials{

--- a/internal/deviceauth/enroll_hardening_test.go
+++ b/internal/deviceauth/enroll_hardening_test.go
@@ -1,0 +1,167 @@
+package deviceauth
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+
+	"github.com/manchtools/power-manage/agent/internal/credentials"
+)
+
+// failingStore wraps a real store but fails Save — for the
+// save-fail-closed test (#14).
+type failingStore struct {
+	credentialStore
+	saveErr error
+}
+
+func (f *failingStore) Save(*credentials.Credentials) error { return f.saveErr }
+
+// TestEnroll_RateLimitRejectsSixthInWindow pins the brute-force guard
+// (#6): five attempts in the window reach the network; the sixth is
+// rejected BEFORE any registration call (guard-before-work). Registration
+// is made to fail so each of the first five is a genuine attempt rather
+// than enrolling and short-circuiting the rest.
+func TestEnroll_RateLimitRejectsSixthInWindow(t *testing.T) {
+	var registerCalls int32
+	mock := &mockRegisterService{
+		registerFunc: func(_ context.Context, _ *connect.Request[pm.RegisterRequest]) (*connect.Response[pm.RegisterResponse], error) {
+			atomic.AddInt32(&registerCalls, 1)
+			return nil, connect.NewError(connect.CodePermissionDenied, nil)
+		},
+	}
+	srv := startMockControlServer(t, mock)
+
+	credStore := credentials.NewStore(t.TempDir())
+	h := NewEnrollHandler("test-host", "dev", credStore, slog.Default(), nil)
+	h.registerOpts = trustServer(srv)
+	fixed := time.Now()
+	h.now = func() time.Time { return fixed } // all attempts land in one window
+
+	for i := 0; i < 5; i++ {
+		resp, err := h.Enroll(context.Background(), connect.NewRequest(&pm.EnrollRequest{
+			ServerUrl: srv.URL, Token: "tok",
+		}))
+		require.NoError(t, err)
+		assert.Contains(t, resp.Msg.Error, "registration failed", "attempt %d should reach (and fail) registration", i+1)
+	}
+
+	resp, err := h.Enroll(context.Background(), connect.NewRequest(&pm.EnrollRequest{
+		ServerUrl: srv.URL, Token: "tok",
+	}))
+	require.NoError(t, err)
+	assert.False(t, resp.Msg.Success)
+	assert.Contains(t, resp.Msg.Error, "rate limit")
+	assert.EqualValues(t, 5, atomic.LoadInt32(&registerCalls), "the 6th attempt must not reach the network")
+}
+
+// TestEnroll_RejectsMissingMTLSCerts pins fail-closed when the server
+// omits a cert (#13): no creds saved, status not primed.
+func TestEnroll_RejectsMissingMTLSCerts(t *testing.T) {
+	cases := []struct {
+		name     string
+		ca, cert []byte
+	}{
+		{"ca only", []byte("ca"), nil},
+		{"cert only", nil, []byte("cert")},
+		{"both empty", nil, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &mockRegisterService{
+				registerFunc: func(_ context.Context, _ *connect.Request[pm.RegisterRequest]) (*connect.Response[pm.RegisterResponse], error) {
+					return connect.NewResponse(&pm.RegisterResponse{
+						DeviceId:    &pm.DeviceId{Value: "01HZZZZZZZZZZZZZZZZZZZZZZZZ"},
+						CaCert:      tc.ca,
+						Certificate: tc.cert,
+						GatewayUrl:  "https://gw.example.com",
+					}), nil
+				},
+			}
+			srv := startMockControlServer(t, mock)
+			credStore := credentials.NewStore(t.TempDir())
+			h := NewEnrollHandler("test-host", "dev", credStore, slog.Default(), nil)
+			h.registerOpts = trustServer(srv)
+
+			resp, err := h.Enroll(context.Background(), connect.NewRequest(&pm.EnrollRequest{
+				ServerUrl: srv.URL, Token: "tok",
+			}))
+			require.NoError(t, err)
+			assert.False(t, resp.Msg.Success)
+			assert.Contains(t, resp.Msg.Error, "mTLS certificates")
+			assert.False(t, credStore.Exists())
+		})
+	}
+}
+
+// TestEnroll_BindsOutboundRegisterRequest pins that the agent sends its
+// token, hostname, and version, and a valid self-signed CSR whose key it
+// keeps (#8) — the "private key never leaves the agent" contract.
+func TestEnroll_BindsOutboundRegisterRequest(t *testing.T) {
+	var captured *pm.RegisterRequest
+	mock := &mockRegisterService{
+		registerFunc: func(_ context.Context, req *connect.Request[pm.RegisterRequest]) (*connect.Response[pm.RegisterResponse], error) {
+			captured = req.Msg
+			return connect.NewResponse(&pm.RegisterResponse{
+				DeviceId:    &pm.DeviceId{Value: "01HZZZZZZZZZZZZZZZZZZZZZZZZ"},
+				CaCert:      []byte(fakeLeafPEM),
+				Certificate: []byte(fakeLeafPEM),
+				GatewayUrl:  "https://gw.example.com",
+			}), nil
+		},
+	}
+	srv := startMockControlServer(t, mock)
+	credStore := credentials.NewStore(t.TempDir())
+	h := NewEnrollHandler("test-host", "dev", credStore, slog.Default(), nil)
+	h.registerOpts = trustServer(srv)
+
+	resp, err := h.Enroll(context.Background(), connect.NewRequest(&pm.EnrollRequest{
+		ServerUrl: srv.URL, Token: "test-token",
+	}))
+	require.NoError(t, err)
+	require.True(t, resp.Msg.Success, "%s", resp.Msg.Error)
+
+	require.NotNil(t, captured)
+	assert.Equal(t, "test-token", captured.Token)
+	assert.Equal(t, "test-host", captured.Hostname)
+	assert.Equal(t, "dev", captured.AgentVersion)
+
+	block, _ := pem.Decode(captured.Csr)
+	require.NotNil(t, block, "CSR must be PEM")
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	require.NoError(t, err)
+	require.NoError(t, csr.CheckSignature(), "CSR signature must verify")
+}
+
+// TestEnroll_SaveFailureFailsClosed pins #14: a Save error fails the
+// enrollment closed — no callback, status not primed.
+func TestEnroll_SaveFailureFailsClosed(t *testing.T) {
+	srv := startMockControlServer(t, caReturningMock([]byte(fakeLeafPEM)))
+	called := false
+	h := NewEnrollHandler("test-host", "dev", credentials.NewStore(t.TempDir()), slog.Default(), func(*credentials.Credentials) { called = true })
+	h.registerOpts = trustServer(srv)
+	h.credStore = &failingStore{credentialStore: h.credStore, saveErr: errors.New("disk full")}
+
+	resp, err := h.Enroll(context.Background(), connect.NewRequest(&pm.EnrollRequest{
+		ServerUrl: srv.URL, Token: "tok",
+	}))
+	require.NoError(t, err)
+	assert.False(t, resp.Msg.Success)
+	assert.Contains(t, resp.Msg.Error, "save credentials")
+	assert.False(t, called, "onEnrolled must not fire when Save fails")
+
+	st, err := h.GetEnrollmentStatus(context.Background(), connect.NewRequest(&pm.GetEnrollmentStatusRequest{}))
+	require.NoError(t, err)
+	assert.False(t, st.Msg.Enrolled, "status cache must not be primed on Save failure")
+}

--- a/internal/deviceauth/enroll_pin_test.go
+++ b/internal/deviceauth/enroll_pin_test.go
@@ -1,0 +1,141 @@
+package deviceauth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"log/slog"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+
+	"github.com/manchtools/power-manage/agent/internal/credentials"
+	pmcrypto "github.com/manchtools/power-manage/sdk/go/crypto"
+)
+
+const fakeLeafPEM = "-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----\n"
+
+// genTestCAPEM creates a self-signed CA certificate (PEM) for pin tests.
+func genTestCAPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func caReturningMock(caPEM []byte) *mockRegisterService {
+	return &mockRegisterService{
+		registerFunc: func(_ context.Context, _ *connect.Request[pm.RegisterRequest]) (*connect.Response[pm.RegisterResponse], error) {
+			return connect.NewResponse(&pm.RegisterResponse{
+				DeviceId:    &pm.DeviceId{Value: "01HZZZZZZZZZZZZZZZZZZZZZZZZ"},
+				CaCert:      caPEM,
+				Certificate: []byte(fakeLeafPEM),
+				GatewayUrl:  "https://gw.example.com:8443",
+			}), nil
+		},
+	}
+}
+
+// TestEnroll_CAPinMatchAccepted pins the optional OOB CA-pin happy path
+// (#5): when the returned CA matches the pin, enrollment proceeds.
+func TestEnroll_CAPinMatchAccepted(t *testing.T) {
+	caPEM := genTestCAPEM(t)
+	wantFP, err := pmcrypto.CAFingerprintFromPEM(caPEM)
+	require.NoError(t, err)
+
+	srv := startMockControlServer(t, caReturningMock(caPEM))
+	credStore := credentials.NewStore(t.TempDir())
+	h := NewEnrollHandler("test-host", "dev", credStore, slog.Default(), nil)
+	h.registerOpts = trustServer(srv)
+
+	resp, err := h.Enroll(context.Background(), connect.NewRequest(&pm.EnrollRequest{
+		ServerUrl:        srv.URL,
+		Token:            "tok",
+		CaFingerprintPin: wantFP,
+	}))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.Success, "matching pin must enroll: %s", resp.Msg.Error)
+	assert.True(t, credStore.Exists())
+}
+
+// TestEnroll_CAPinMatchNormalized pins case-insensitive + colon-stripped
+// matching (operators paste from openssl: uppercase, colon-separated).
+func TestEnroll_CAPinMatchNormalized(t *testing.T) {
+	caPEM := genTestCAPEM(t)
+	fp, err := pmcrypto.CAFingerprintFromPEM(caPEM)
+	require.NoError(t, err)
+
+	// Uppercase + colon-separated, as openssl prints it.
+	var b strings.Builder
+	up := strings.ToUpper(fp)
+	for i := 0; i < len(up); i += 2 {
+		if i > 0 {
+			b.WriteByte(':')
+		}
+		b.WriteString(up[i : i+2])
+	}
+	pinPasted := b.String()
+
+	srv := startMockControlServer(t, caReturningMock(caPEM))
+	credStore := credentials.NewStore(t.TempDir())
+	h := NewEnrollHandler("test-host", "dev", credStore, slog.Default(), nil)
+	h.registerOpts = trustServer(srv)
+
+	resp, err := h.Enroll(context.Background(), connect.NewRequest(&pm.EnrollRequest{
+		ServerUrl:        srv.URL,
+		Token:            "tok",
+		CaFingerprintPin: pinPasted,
+	}))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.Success, "normalized (uppercase, colon) pin must match: %s", resp.Msg.Error)
+}
+
+// TestEnroll_CAPinMismatchRejected pins fail-closed on a wrong pin (#5):
+// no Save, no callback, no status — the trust-anchor swap is refused.
+func TestEnroll_CAPinMismatchRejected(t *testing.T) {
+	caPEM := genTestCAPEM(t)
+	srv := startMockControlServer(t, caReturningMock(caPEM))
+
+	credStore := credentials.NewStore(t.TempDir())
+	called := false
+	h := NewEnrollHandler("test-host", "dev", credStore, slog.Default(), func(*credentials.Credentials) { called = true })
+	h.registerOpts = trustServer(srv)
+
+	resp, err := h.Enroll(context.Background(), connect.NewRequest(&pm.EnrollRequest{
+		ServerUrl:        srv.URL,
+		Token:            "tok",
+		CaFingerprintPin: strings.Repeat("0", 64), // wrong pin
+	}))
+	require.NoError(t, err)
+	assert.False(t, resp.Msg.Success)
+	assert.Contains(t, resp.Msg.Error, "fingerprint mismatch")
+	assert.False(t, credStore.Exists(), "no credentials on a pin mismatch")
+	assert.False(t, called, "onEnrolled must not fire on a pin mismatch")
+
+	// Status cache must not be primed.
+	st, err := h.GetEnrollmentStatus(context.Background(), connect.NewRequest(&pm.GetEnrollmentStatusRequest{}))
+	require.NoError(t, err)
+	assert.False(t, st.Msg.Enrolled)
+}

--- a/internal/deviceauth/enroll_test.go
+++ b/internal/deviceauth/enroll_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
 
 	"github.com/manchtools/power-manage/agent/internal/credentials"
+	sdk "github.com/manchtools/power-manage/sdk/go"
 )
 
 // mockRegisterService implements the Register RPC of ControlServiceHandler.
@@ -34,14 +35,23 @@ func (m *mockRegisterService) Register(ctx context.Context, req *connect.Request
 	return nil, connect.NewError(connect.CodeUnimplemented, nil)
 }
 
+// startMockControlServer starts an httptest TLS control server (the
+// agent enforces https-only enrollment, so a plain-http test server
+// would be rejected by the gate before RegisterAgent runs).
 func startMockControlServer(t *testing.T, mock *mockRegisterService) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
 	path, handler := pmv1connect.NewControlServiceHandler(mock)
 	mux.Handle(path, handler)
-	srv := httptest.NewServer(mux)
+	srv := httptest.NewTLSServer(mux)
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+// trustServer returns the registerOpts that make sdk.RegisterAgent trust
+// the httptest TLS server's self-signed certificate.
+func trustServer(srv *httptest.Server) []sdk.ClientOption {
+	return []sdk.ClientOption{sdk.WithHTTPClient(srv.Client())}
 }
 
 func TestEnroll_Success(t *testing.T) {
@@ -64,6 +74,7 @@ func TestEnroll_Success(t *testing.T) {
 	handler := NewEnrollHandler("test-host", "dev", credStore, logger, func(creds *credentials.Credentials) {
 		enrolledCreds = creds
 	})
+	handler.registerOpts = trustServer(srv)
 
 	resp, err := handler.Enroll(context.Background(), connect.NewRequest(&pm.EnrollRequest{
 		ServerUrl: srv.URL,
@@ -136,6 +147,7 @@ func TestEnroll_RegistrationFails(t *testing.T) {
 	credStore := credentials.NewStore(t.TempDir())
 	logger := slog.Default()
 	handler := NewEnrollHandler("test-host", "dev", credStore, logger, nil)
+	handler.registerOpts = trustServer(srv)
 
 	resp, err := handler.Enroll(context.Background(), connect.NewRequest(&pm.EnrollRequest{
 		ServerUrl: srv.URL,
@@ -196,6 +208,7 @@ func TestEnrollServer_EndToEnd(t *testing.T) {
 	enrollHandler := NewEnrollHandler("test-host", "dev", credStore, logger, func(creds *credentials.Credentials) {
 		enrollCh <- creds
 	})
+	enrollHandler.registerOpts = trustServer(controlSrv)
 
 	socketPath := filepath.Join(t.TempDir(), "enroll.sock")
 	enrollServer := NewEnrollServer(enrollHandler, socketPath, logger)

--- a/internal/deviceauth/enroll_url_test.go
+++ b/internal/deviceauth/enroll_url_test.go
@@ -1,0 +1,76 @@
+package deviceauth
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+
+	"github.com/manchtools/power-manage/agent/internal/credentials"
+)
+
+// TestEnroll_RejectsNonHTTPSServerURL pins the https-only gate (#2/#16):
+// a cleartext/opaque/hostless server_url is refused BEFORE any network
+// call. The error names the https requirement (distinct from a
+// "registration failed" downstream error), and nothing is persisted — so
+// even if the gate were removed, the test would not pass on a
+// connection-refused error.
+func TestEnroll_RejectsNonHTTPSServerURL(t *testing.T) {
+	cases := []string{
+		"http://control.example.com", // cleartext
+		"HTTP://control.example.com", // case variant of cleartext
+		"ftp://control.example.com",  // wrong scheme
+		"control.example.com",        // scheme-less
+		"https:foo",                  // opaque
+		"https:",                     // no host
+		"https://user:pass@host",     // embedded credentials
+	}
+	for _, u := range cases {
+		t.Run(u, func(t *testing.T) {
+			credStore := credentials.NewStore(t.TempDir())
+			h := NewEnrollHandler("h", "dev", credStore, slog.Default(), nil)
+
+			resp, err := h.Enroll(context.Background(), connect.NewRequest(&pm.EnrollRequest{
+				ServerUrl: u,
+				Token:     "some-token",
+			}))
+			require.NoError(t, err)
+			assert.False(t, resp.Msg.Success)
+			assert.Contains(t, resp.Msg.Error, "https")
+			assert.False(t, credStore.Exists(), "no credentials must be saved on a rejected URL")
+		})
+	}
+}
+
+// TestEnroll_PerFieldRequired pins per-field required validation (#15):
+// each of server_url / token absent is rejected before any network call.
+func TestEnroll_PerFieldRequired(t *testing.T) {
+	cases := []struct {
+		name       string
+		url, token string
+	}{
+		{"token absent", "https://control.example.com", ""},
+		{"server_url absent", "", "tok"},
+		{"both absent", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			credStore := credentials.NewStore(t.TempDir())
+			h := NewEnrollHandler("h", "dev", credStore, slog.Default(), nil)
+
+			resp, err := h.Enroll(context.Background(), connect.NewRequest(&pm.EnrollRequest{
+				ServerUrl: tc.url,
+				Token:     tc.token,
+			}))
+			require.NoError(t, err)
+			assert.False(t, resp.Msg.Success)
+			assert.Contains(t, resp.Msg.Error, "required")
+			assert.False(t, credStore.Exists())
+		})
+	}
+}


### PR DESCRIPTION
Closes #113. Consumes `manchtools/power-manage-sdk#104` (merged). WS9, Option 1 — optional OOB CA pin, no server-signed artifact.

**Self-service preserved:** the enrollment socket stays `0666` (non-root corporate/BYOD self-enroll is the point; admins pre-enroll with a bulk token if they prefer).

## Hardening
- https-only `server_url` gate (`sdk.ValidateHTTPSURL`) before any network call (#2/#16)
- optional OOB **CA-fingerprint pin** verified vs the registration-returned CA, fail-closed on mismatch; case-insensitive, colon-stripped (#5)
- bounded register/renew transport (timeout + TLS 1.3) — via the SDK
- token via `-token-file` / `PM_REGISTRATION_TOKEN`; install.sh writes a 0600 file; `-token` warns (leaks via /proc/<pid>/cmdline) (#3)
- cert-rotation **CA continuity** (`crypto.VerifyCAContinuity`): refuse a non-continuous CA on renewal, keep the enrolled cert+CA, retry (#4); extracted `renewAt`/`shouldEscalateRotation`/`applyRenewal` seams (#9/#10)
- `&pin=` parsed from the `power-manage://` URI (#19)

## Tests
rate-limit (#6), mTLS-cert rejection (#13), outbound-request binding (#8), save-fail-closed (#14), per-field required (#15), https-gate (#2/#16), CA-pin match/mismatch/normalize (#5), renewAt/escalation/applyRenewal, parseURI/resolveToken, install lint (token-file).

Accepted residual (no-pin first-enroll = TOFU) documented in server ADR 0013. Local cr clean (1 minor flag-trim folded; 2 findings were false positives — `fakeLeafPEM`/`caReturningMock` are defined in a sibling `_test.go` in the same package).