### PR TITLE
Fail-closed maintenance window + terminal Cols/Rows bounds + clock clamp + crash marker + consolidated gateway-URL guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,15 @@ When enabled, the scheduler checks if the system state already matches the desir
 
 **Use case**: Reduce unnecessary operations for idempotent actions that run frequently. Instead of reinstalling a package every 4 hours, only act when the package is missing or changed.
 
+### Scheduling resilience
+
+The offline scheduler and the SDK stream loop are hardened against corrupt local state, clock excursions, crashes, and a compromised/relay gateway:
+
+- **Maintenance window fails closed on decode error.** The active maintenance window is persisted to the agent's SQLite store so a restart inside a freeze keeps gating. If that persisted window exists but cannot be proto-decoded (a corrupt or tampered settings row), the scheduler does **not** boot unconstrained — it enters a deny-until-next-sync state that defers every due dispatch until the next successful window sync overwrites the bad row. A truly-absent window (a never-synced device) still boots unconstrained, the same default a fresh install gets.
+- **Forward clock jumps are clamped.** A future-dated `next_execute_at` cursor (left behind by a transient forward wall-clock excursion that was later corrected back) is clamped to at most `now + interval`, so a single clock jump can delay drift-prevention by at most one interval instead of suppressing it indefinitely.
+- **Crash-replay guard.** The due cursor is advanced one interval **before** an action executes, so a crash between execution and result recording does not silently re-run a non-idempotent action on the next boot. (Best-effort for non-idempotent actions; idempotent actions are unaffected, and the authoritative cursor is still written when the result is recorded.)
+- **One handler panic cannot crash the agent.** The SDK stream-dispatch loop wraps each inbound `ServerMessage` in a scoped `recover()` and isolates its goroutine fan-out, so a panic triggered by a malformed or hostile frame from a compromised gateway is logged and dropped as non-fatal rather than crash-looping the agent (a fleet DoS). Oversized inbound frames are refused (resource-exhausted) instead of being allocated, and PTY dimensions are validated before use. See the SDK README "Stream-loop robustness".
+
 ## Package Manager Detection
 
 The agent automatically detects the system's package manager:

--- a/cmd/power-manage-agent/cmd_selftest.go
+++ b/cmd/power-manage-agent/cmd_selftest.go
@@ -4,7 +4,6 @@ package main
 import (
 	"context"
 	"flag"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -59,29 +58,14 @@ func runSelfTest(args []string) int {
 	}
 	logger.Info("self-test: credentials loaded", "device_id", creds.DeviceID)
 
-	// Step 2: Create mTLS client. rc10 refuses anything but https://
+	// Step 2: Create mTLS client. rc10 refuses anything but https://host
 	// here: the self-test is invoked by the packaged install flow on
 	// managed devices and must exercise the same security posture as
-	// normal agent operation.
-	//
-	// Parse the URL rather than checking a literal prefix so case
-	// variants (HTTP://, Https://), leading whitespace, and any
-	// non-https scheme (ftp://, h2c://, the empty scheme) all fail
-	// closed. A malformed URL is treated the same as a wrong-scheme
-	// URL — both block sdk.WithMTLSFromPEM from running.
+	// normal agent operation. Shared predicate with runtime.go so the
+	// guard cannot drift between dial sites.
 	gatewayAddr := strings.TrimSpace(creds.GatewayAddr)
-	parsed, parseErr := url.Parse(gatewayAddr)
-	// Require a proper https://host URL. The Opaque + Host checks
-	// catch the corner cases url.Parse leaves accepted: a bare
-	// "https:" parses with Scheme="https" but no Host, and an
-	// opaque "https:foo" parses with Opaque="foo" rather than as
-	// a network URL — both would slip past a Scheme-only check.
-	if parseErr != nil ||
-		strings.ToLower(parsed.Scheme) != "https" ||
-		parsed.Opaque != "" ||
-		parsed.Host == "" {
-		logger.Error("self-test: refusing non-https or hostless gateway URL — agent requires https://host for gateway connections",
-			"gateway", creds.GatewayAddr, "parse_error", parseErr)
+	if err := requireHTTPSGateway(creds.GatewayAddr); err != nil {
+		logger.Error("self-test: refusing gateway URL", "gateway", creds.GatewayAddr, "error", err)
 		return 1
 	}
 	mtlsOpt, err := sdk.WithMTLSFromPEM(creds.Certificate, creds.PrivateKey, creds.CACert)

--- a/cmd/power-manage-agent/gateway_url.go
+++ b/cmd/power-manage-agent/gateway_url.go
@@ -1,0 +1,31 @@
+// Package main is the entry point for the power-manage agent.
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// requireHTTPSGateway validates that addr is a cleartext-refusing
+// https://host network URL — the only kind permitted to reach the mTLS
+// gateway dial (sdk.WithMTLSFromPEM). It is the single shared predicate for
+// every gateway dial site (runtime.go, cmd_selftest.go) so the guard cannot
+// drift between them.
+//
+// Parse the URL rather than checking a literal prefix so case variants
+// (HTTP://, Https://), leading whitespace, opaque forms (https:foo), hostless
+// forms (https:), and any non-https scheme (ftp://, h2c://, the empty scheme)
+// all fail closed. The scheme is compared case-insensitively; the Opaque and
+// Host checks catch the corner cases url.Parse leaves accepted: a bare
+// "https:" parses with Scheme="https" but no Host, and an opaque "https:foo"
+// parses with Opaque set rather than as a network URL — both would slip past a
+// Scheme-only check.
+func requireHTTPSGateway(addr string) error {
+	trimmed := strings.TrimSpace(addr)
+	parsed, err := url.Parse(trimmed)
+	if err != nil || strings.ToLower(parsed.Scheme) != "https" || parsed.Opaque != "" || parsed.Host == "" {
+		return fmt.Errorf("refusing non-https or hostless gateway URL %q: agent requires https://host for gateway connections", addr)
+	}
+	return nil
+}

--- a/cmd/power-manage-agent/gateway_url_guard_test.go
+++ b/cmd/power-manage-agent/gateway_url_guard_test.go
@@ -1,0 +1,54 @@
+package main
+
+import "testing"
+
+// WS15 #3 — the gateway-URL guard must reject every non-https://host value,
+// consistently, using url.Parse discipline (scheme=="https" case-insensitively,
+// empty Opaque, non-empty Host).
+//
+// runtime.go used strings.HasPrefix(addr, "http://"), which lets HTTP:// (case),
+// Https:// (mixed case), https:foo (opaque), https: (no host), ftp://, h2c://,
+// "" (empty), and " http://x" (leading whitespace) through to WithMTLSFromPEM.
+// requireHTTPSGateway consolidates the cmd_selftest.go predicate so all gateway
+// dial sites share one definition. "wrong" cases are sourced from the intent
+// ("only a cleartext-refusing https network URL may reach WithMTLSFromPEM"),
+// NOT from the old HasPrefix artifact.
+
+func TestGatewayURLGuard_RejectsNonHTTPS(t *testing.T) {
+	cases := []struct {
+		name    string
+		addr    string
+		wantErr bool
+	}{
+		// correct
+		{"https host with port", "https://gw.example:443", false},
+		{"https host no port", "https://gw.example", false},
+		{"https host with path", "https://gw.example/connect", false},
+
+		// present-but-wrong
+		{"lowercase http", "http://attacker", true},
+		{"uppercase HTTP", "HTTP://attacker", true},
+		{"mixed-case Https host", "Https://x", false}, // scheme is case-insensitive → valid https host
+		{"mixed-case HTTP variant", "HtTp://x", true},
+		{"opaque https", "https:foo", true},
+		{"https no host", "https:", true},
+		{"ftp scheme", "ftp://x", true},
+		{"h2c scheme", "h2c://x", true},
+		{"empty", "", true},
+		{"leading whitespace http", " http://x", true},
+		{"leading whitespace https", " https://x", false}, // trimmed → valid
+		{"scheme-less host", "gw.example:443", true},
+		{"bare host", "gw.example", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := requireHTTPSGateway(tc.addr)
+			if tc.wantErr && err == nil {
+				t.Fatalf("requireHTTPSGateway(%q) = nil, want error", tc.addr)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("requireHTTPSGateway(%q) = %v, want nil", tc.addr, err)
+			}
+		})
+	}
+}

--- a/cmd/power-manage-agent/runtime.go
+++ b/cmd/power-manage-agent/runtime.go
@@ -66,15 +66,17 @@ func runAgent(ctx context.Context, credStore *credentials.Store, creds *credenti
 		// Reset handler connection state for new connection
 		h.ResetConnection()
 
-		// rc10: refuse http:// (h2c) for the network gateway path.
-		// The only h2c use in this binary is the local unix-socket
-		// enrollment client, never a remote gateway. A stored
-		// `http://` GatewayAddr means either a dev-leftover creds
-		// file or a tampered redirect — both are reasons to fail
-		// fast rather than silently skip mTLS on the live fleet.
-		if strings.HasPrefix(creds.GatewayAddr, "http://") {
-			logger.Error("refusing h2c gateway URL — agent requires https:// for gateway connections; re-enrol against an https:// gateway or delete the cached credentials",
-				"gateway", creds.GatewayAddr)
+		// rc10: refuse anything but https://host for the network gateway
+		// path. The only h2c use in this binary is the local unix-socket
+		// enrollment client, never a remote gateway. A non-https (or
+		// malformed) GatewayAddr means either a dev-leftover creds file or a
+		// tampered redirect — both are reasons to fail fast rather than
+		// silently skip mTLS on the live fleet. Shared predicate with
+		// cmd_selftest.go so the guard cannot drift (closes the HasPrefix
+		// case/opaque/hostless gaps).
+		if err := requireHTTPSGateway(creds.GatewayAddr); err != nil {
+			logger.Error("refusing gateway URL — re-enrol against an https:// gateway or delete the cached credentials",
+				"gateway", creds.GatewayAddr, "error", err)
 			os.Exit(1)
 		}
 		mtlsOpt, err := sdk.WithMTLSFromPEM(creds.Certificate, creds.PrivateKey, creds.CACert)
@@ -82,7 +84,7 @@ func runAgent(ctx context.Context, credStore *credentials.Store, creds *credenti
 			logger.Error("failed to configure mTLS", "error", err)
 			os.Exit(1)
 		}
-		client := sdk.NewClient(creds.GatewayAddr,
+		client := sdk.NewClient(strings.TrimSpace(creds.GatewayAddr),
 			mtlsOpt,
 			sdk.WithAuth(creds.DeviceID, ""),
 		)

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 // it. There is no automatic floating tag — that's intentional, because
 // SDK proto/Go API drifts between commits should be reviewable in the
 // same PR as the agent change that consumes them.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260614134347-ca1b2306bbad
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260614202120-35ae78ea27e1
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260614134347-ca1b2306bbad h1:aFCW/WZtpFqrPlaO3QxHYwvXxyD4yuS3xF1MZ5L3hSo=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260614134347-ca1b2306bbad/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260614202120-35ae78ea27e1 h1:4nJDVMIwlXqPHLFbcA4nIQnMrDxnU7A82OMl9MPUNSM=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260614202120-35ae78ea27e1/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/handler/sync_verify_test.go
+++ b/internal/handler/sync_verify_test.go
@@ -194,3 +194,55 @@ func TestOnAction_NoVerifierIsFailClosed(t *testing.T) {
 		"a handler with no verifier must fail closed")
 	assert.Len(t, syncTrigger, 0, "no verifier means no SYNC may fire")
 }
+
+// TestOnActionWithStreaming_MalformedEnvelopeNoPanic pins the WS15 #2 intent on
+// the agent's real streaming dispatch surface (the method the SDK Client calls):
+// a malformed "Action" on the wire — garbage envelope bytes that fail signature
+// verification / proto-unmarshal, an absent envelope, or a nil signature — must
+// be REFUSED with a FAILED ActionResult and never crash the handler. Intent: an
+// Action on the wire carries a signed envelope; one that doesn't is malformed
+// and is fail-closed, not dereferenced. (The action-signing-envelope refactor
+// closed the original nil-Id deref; this is the regression guard.)
+func TestOnActionWithStreaming_MalformedEnvelopeNoPanic(t *testing.T) {
+	caPEM, signer := testCAAndSigner(t)
+
+	// A real, validly signed envelope for the "correct" leg.
+	good := &pb.SignedActionEnvelope{
+		ActionId:   &pb.ActionId{Value: "01HSTREAMGOODACTION00000A"},
+		ActionType: pb.ActionType_ACTION_TYPE_SYNC,
+	}
+	goodBytes, goodSig := signEnvelope(t, signer, good)
+
+	cases := []struct {
+		name     string
+		envelope []byte
+		sig      []byte
+		wantFail bool
+	}{
+		{"correct: signed SYNC envelope", goodBytes, goodSig, false},
+		{"absent: nil envelope + nil signature", nil, nil, true},
+		{"absent: empty envelope bytes", []byte{}, []byte("sig"), true},
+		{"present-but-wrong: garbage bytes that are not a valid envelope", []byte{0xff, 0x00, 0x13, 0x37, 0xde, 0xad}, []byte("sig"), true},
+		{"present-but-wrong: real bytes, no signature", goodBytes, nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _ := newVerifierHandler(t, caPEM)
+			var res *pb.ActionResult
+			var err error
+			// Must not panic on any malformed input.
+			require.NotPanics(t, func() {
+				res, err = h.OnActionWithStreaming(context.Background(), tc.envelope, tc.sig, nil)
+			})
+			require.NoError(t, err, "dispatch must be non-fatal (no returned error)")
+			require.NotNil(t, res, "a result must always be returned")
+			if tc.wantFail {
+				assert.Equal(t, pb.ExecutionStatus_EXECUTION_STATUS_FAILED, res.Status,
+					"a malformed/unsigned Action must be refused, not executed")
+			} else {
+				assert.NotEqual(t, pb.ExecutionStatus_EXECUTION_STATUS_FAILED, res.Status,
+					"a validly signed envelope must not be rejected as malformed")
+			}
+		})
+	}
+}

--- a/internal/handler/terminal.go
+++ b/internal/handler/terminal.go
@@ -35,7 +35,28 @@ const (
 	// hard-coded so it cannot be overridden from the gateway side.
 	terminalActivatedShell   = "/bin/bash"
 	terminalDeactivatedShell = "/usr/sbin/nologin"
+
+	// maxTerminalDimension is the inclusive upper bound for a PTY column /
+	// row count. It is the largest value representable in the uint16 the
+	// kernel winsize ABI uses; anything above it would wrap when narrowed
+	// (65536 -> 0, 65537 -> 1) and produce a degenerate PTY.
+	maxTerminalDimension = 65535
 )
+
+// validateDims enforces the PTY dimension contract — 0 < dim <= 65535 —
+// BEFORE the uint16 narrowing in OnTerminalStart / OnTerminalResize. A zero
+// dimension is absent; a value above 65535 wraps under uint16. Sourced from
+// the wire intent (proto's gt=0,lte=65535), not from any artifact, because
+// the agent's Receive path runs no protovalidate.
+func validateDims(cols, rows uint32) error {
+	if cols == 0 || cols > maxTerminalDimension {
+		return fmt.Errorf("invalid terminal dimensions: cols=%d (must be 1..%d)", cols, maxTerminalDimension)
+	}
+	if rows == 0 || rows > maxTerminalDimension {
+		return fmt.Errorf("invalid terminal dimensions: rows=%d (must be 1..%d)", rows, maxTerminalDimension)
+	}
+	return nil
+}
 
 // TerminalSender is the subset of the SDK Client that the terminal
 // handler needs to push messages back to the gateway. The agent's
@@ -241,6 +262,16 @@ func (h *Handler) OnTerminalStart(ctx context.Context, req *pb.TerminalStart) er
 	if !enabled {
 		logger.Info("terminal start rejected: tty disabled on device")
 		h.failTerminalStart(ctx, sender, req.SessionId, "terminal sessions are disabled on this device")
+		return nil
+	}
+
+	// Validate the PTY dimensions BEFORE any narrowing to uint16. A value of
+	// 0 or > 65535 would otherwise wrap (65536 -> 0, 65537 -> 1) into a
+	// degenerate PTY. Reject with a clear reason rather than silently
+	// allocating a 0xN / 1xN terminal.
+	if err := validateDims(req.Cols, req.Rows); err != nil {
+		logger.Warn("terminal start rejected: bad dimensions", "cols", req.Cols, "rows", req.Rows)
+		h.failTerminalStart(ctx, sender, req.SessionId, err.Error())
 		return nil
 	}
 
@@ -473,6 +504,14 @@ func (h *Handler) OnTerminalInput(ctx context.Context, req *pb.TerminalInput) er
 
 // OnTerminalResize forwards a TIOCSWINSZ to the session's PTY.
 func (h *Handler) OnTerminalResize(ctx context.Context, req *pb.TerminalResize) error {
+	// Reject out-of-range dimensions before the uint16 narrowing below, so a
+	// Cols/Rows >= 65536 can never reach sess.Resize as a truncated value
+	// (65536 -> 0). Non-fatal: log and no-op, like an unknown session.
+	if err := validateDims(req.Cols, req.Rows); err != nil {
+		h.logger.Warn("ignoring terminal resize with bad dimensions",
+			"session_id", req.SessionId, "cols", req.Cols, "rows", req.Rows)
+		return nil
+	}
 	ts := h.lookupTerminal(req.SessionId)
 	if ts == nil {
 		h.logger.Debug("terminal resize for unknown session", "session_id", req.SessionId)

--- a/internal/handler/terminal_bounds_test.go
+++ b/internal/handler/terminal_bounds_test.go
@@ -1,0 +1,209 @@
+package handler
+
+import (
+	"context"
+	"os/user"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/terminal"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// WS15 #6 — terminal Cols/Rows bounds before the uint16 narrowing.
+//
+// terminal.go narrows req.Cols/req.Rows (uint32) to uint16 with no bounds
+// check, so 65536 becomes 0 and 65537 becomes 1 — a 0x0 / 1x1 PTY. The wire
+// intent (proto validate tag, NOT consulted by Receive) is "0 < dim <= 65535".
+// Sourced from intent ("a PTY dimension is a positive value <= 65535"), the
+// agent must REJECT an out-of-range dimension, never silently truncate it.
+
+const dimsErrFragment = "invalid terminal dimensions"
+
+// TestValidateDims is the source-of-truth, table-driven binding for the
+// dimension contract. "wrong" cases come from the intent (zero is absent; a
+// value > 65535 wraps under uint16), not from the validate tag.
+func TestValidateDims(t *testing.T) {
+	cases := []struct {
+		name       string
+		cols, rows uint32
+		wantErr    bool
+	}{
+		{"correct mid-range", 80, 24, false},
+		{"correct min", 1, 1, false},
+		{"correct max", 65535, 65535, false},
+		{"absent: cols zero", 0, 24, true},
+		{"absent: rows zero", 80, 0, true},
+		{"absent: both zero", 0, 0, true},
+		{"wrong: cols 65536 wraps to 0", 65536, 24, true},
+		{"wrong: cols 65537 wraps to 1", 65537, 24, true},
+		{"wrong: rows 65536 wraps to 0", 80, 65536, true},
+		{"wrong: cols huge", 1 << 20, 24, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDims(tc.cols, tc.rows)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validateDims(%d,%d) = nil, want error", tc.cols, tc.rows)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateDims(%d,%d) = %v, want nil", tc.cols, tc.rows, err)
+			}
+		})
+	}
+}
+
+// TestOnTerminalStart_ColsRowsBounds drives the REAL OnTerminalStart with the
+// TTY gate enabled. Out-of-range dims must produce a STATE_ERROR whose reason
+// names the dimension failure, BEFORE any PTY allocation. An in-range dim must
+// pass the dims check (it then fails later at user provisioning with a
+// non-dims reason — proving the dims gate let it through).
+func TestOnTerminalStart_ColsRowsBounds(t *testing.T) {
+	const sessID = "01HSTARTBOUNDS00000000000"
+
+	t.Run("present-but-wrong: 65536 (wraps to 0) is rejected, not a 0xN PTY", func(t *testing.T) {
+		h, sender := newTestHandlerWithTTY(t, true)
+		err := h.OnTerminalStart(context.Background(), &pb.TerminalStart{
+			SessionId: sessID,
+			TtyUser:   terminal.TTYUsernamePrefix + "bounds",
+			Cols:      65536, // ≡ 0 after uint16
+			Rows:      24,
+		})
+		if err != nil {
+			t.Fatalf("OnTerminalStart returned fatal err: %v", err)
+		}
+		assertDimsRejected(t, sender)
+	})
+
+	t.Run("present-but-wrong: 65537 (wraps to 1) is rejected", func(t *testing.T) {
+		h, sender := newTestHandlerWithTTY(t, true)
+		err := h.OnTerminalStart(context.Background(), &pb.TerminalStart{
+			SessionId: sessID,
+			TtyUser:   terminal.TTYUsernamePrefix + "bounds",
+			Cols:      65537, // ≡ 1 after uint16
+			Rows:      24,
+		})
+		if err != nil {
+			t.Fatalf("OnTerminalStart returned fatal err: %v", err)
+		}
+		assertDimsRejected(t, sender)
+	})
+
+	t.Run("absent: zero dims are rejected (no 0x0 PTY)", func(t *testing.T) {
+		h, sender := newTestHandlerWithTTY(t, true)
+		err := h.OnTerminalStart(context.Background(), &pb.TerminalStart{
+			SessionId: sessID,
+			TtyUser:   terminal.TTYUsernamePrefix + "bounds",
+			Cols:      0,
+			Rows:      0,
+		})
+		if err != nil {
+			t.Fatalf("OnTerminalStart returned fatal err: %v", err)
+		}
+		assertDimsRejected(t, sender)
+	})
+
+	t.Run("correct: in-range dims pass the dims gate (fail later for a NON-dims reason)", func(t *testing.T) {
+		h, sender := newTestHandlerWithTTY(t, true)
+		err := h.OnTerminalStart(context.Background(), &pb.TerminalStart{
+			SessionId: sessID,
+			TtyUser:   terminal.TTYUsernamePrefix + "definitely-not-provisioned",
+			Cols:      80,
+			Rows:      24,
+		})
+		if err != nil {
+			t.Fatalf("OnTerminalStart returned fatal err: %v", err)
+		}
+		last := sender.lastState()
+		if last == nil {
+			// No error state at all means it proceeded past dims (and past
+			// provisioning) — also acceptable: the dims gate did not reject.
+			return
+		}
+		// It is expected to fail at user provisioning; it must NOT be the
+		// dims rejection — that would mean a valid 80x24 was wrongly refused.
+		if strings.Contains(strings.ToLower(last.Error), dimsErrFragment) {
+			t.Fatalf("in-range 80x24 was rejected as bad dimensions: %q", last.Error)
+		}
+	})
+}
+
+func assertDimsRejected(t *testing.T, sender *fakeSender) {
+	t.Helper()
+	last := sender.lastState()
+	if last == nil {
+		t.Fatal("expected a STATE_ERROR for out-of-range dimensions, got none")
+	}
+	if last.State != pb.TerminalSessionState_TERMINAL_SESSION_STATE_ERROR {
+		t.Fatalf("state = %v, want STATE_ERROR", last.State)
+	}
+	if !strings.Contains(strings.ToLower(last.Error), dimsErrFragment) {
+		t.Fatalf("error reason = %q, want it to mention %q", last.Error, dimsErrFragment)
+	}
+}
+
+// TestOnTerminalResize_ColsRowsBounds drives the REAL OnTerminalResize against
+// a real active session, asserting Resize is never reached with a truncated
+// value for Cols/Rows >= 65536: an in-range resize succeeds, an out-of-range
+// resize is rejected as a clean no-op and the session stays resizable.
+func TestOnTerminalResize_ColsRowsBounds(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("PTY session test requires Linux")
+	}
+	cur, err := user.Current()
+	if err != nil {
+		t.Skipf("cannot determine current user: %v", err)
+	}
+
+	h, _ := newTestHandlerWithTTY(t, true)
+
+	// Start a real PTY as the current user (terminal.Start skips the
+	// setresuid when the target uid matches, so no sudo is needed).
+	sess, err := terminal.Start(terminal.SessionConfig{User: cur.Username})
+	if err != nil {
+		t.Skipf("cannot start a local PTY session: %v", err)
+	}
+	defer sess.Close()
+
+	const sessID = "01HRESIZEBOUNDS0000000000"
+	ts := addTestSession(h, sessID, cur.Username, time.Now())
+	ts.mu.Lock()
+	ts.session = sess
+	ts.mu.Unlock()
+
+	t.Run("correct: in-range resize is applied", func(t *testing.T) {
+		err := h.OnTerminalResize(context.Background(), &pb.TerminalResize{
+			SessionId: sessID, Cols: 120, Rows: 40,
+		})
+		if err != nil {
+			t.Fatalf("in-range resize errored: %v", err)
+		}
+	})
+
+	t.Run("present-but-wrong: 65536 (wraps to 0) is rejected, Resize not called truncated", func(t *testing.T) {
+		err := h.OnTerminalResize(context.Background(), &pb.TerminalResize{
+			SessionId: sessID, Cols: 65536, Rows: 40,
+		})
+		if err != nil {
+			t.Fatalf("out-of-range resize must be a non-fatal no-op, got: %v", err)
+		}
+		// The session must still be alive and resizable in-range, proving
+		// the bad resize did not wedge or 0-size the PTY.
+		if err := h.OnTerminalResize(context.Background(), &pb.TerminalResize{
+			SessionId: sessID, Cols: 100, Rows: 30,
+		}); err != nil {
+			t.Fatalf("session unusable after out-of-range resize: %v", err)
+		}
+	})
+
+	t.Run("absent: zero dims rejected as a no-op", func(t *testing.T) {
+		if err := h.OnTerminalResize(context.Background(), &pb.TerminalResize{
+			SessionId: sessID, Cols: 0, Rows: 0,
+		}); err != nil {
+			t.Fatalf("zero-dims resize must be a non-fatal no-op, got: %v", err)
+		}
+	})
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -77,11 +77,17 @@ type Scheduler struct {
 	// is safe to read/write without the lock from any goroutine.
 	resultsCh chan *ExecutionResult
 
-	// windowMu guards window. Separate from mu so a long Sync that
-	// also holds mu cannot block runDueActions' window check on a
-	// scheduler that's already started.
+	// windowMu guards window and windowDecodeFailed. Separate from mu so a
+	// long Sync that also holds mu cannot block runDueActions' window check
+	// on a scheduler that's already started.
 	windowMu sync.RWMutex
 	window   *pb.MaintenanceWindow
+	// windowDecodeFailed is the fail-CLOSED sentinel: set when a PERSISTED
+	// maintenance window existed at boot but could not be proto-decoded
+	// (tampered/corrupt). While set, dispatchAllowed denies every moment —
+	// deny-until-next-sync — so a corrupt persisted gate can never silently
+	// unconstrain the agent. Cleared by the next SetMaintenanceWindow.
+	windowDecodeFailed bool
 }
 
 // ExecutionResult contains the result of a scheduled execution.
@@ -111,8 +117,14 @@ func New(store *store.Store, executor ActionExecutor, logger *slog.Logger) *Sche
 		resultsCh: make(chan *ExecutionResult, 100),
 	}
 	if w, err := loadMaintenanceWindow(store); err != nil {
-		logger.Warn("failed to load persisted maintenance window; defaulting to no constraint",
+		// FAIL CLOSED. A persisted window existed but could not be decoded
+		// (corrupt/tampered settings row). Leaving s.window nil would make
+		// IsAllowed(nil, t) == true and UNCONSTRAIN dispatch — the opposite
+		// of what an unreadable freeze should do. Set the deny-until-sync
+		// sentinel instead; the next SetMaintenanceWindow clears it.
+		logger.Error("persisted maintenance window could not be decoded; failing CLOSED (denying dispatch until next sync)",
 			"error", err)
+		s.windowDecodeFailed = true
 	} else {
 		s.window = w
 	}
@@ -132,6 +144,10 @@ func (s *Scheduler) SetMaintenanceWindow(w *pb.MaintenanceWindow) {
 	}
 	s.windowMu.Lock()
 	s.window = normalized
+	// A successful sync replaces whatever was on disk, so the corrupt-window
+	// deny sentinel (if any) no longer applies — clear it. This is what makes
+	// the fail-closed posture "until next sync" rather than a permanent brick.
+	s.windowDecodeFailed = false
 	s.windowMu.Unlock()
 	if err := storeMaintenanceWindow(s.store, normalized); err != nil {
 		s.logger.Warn("failed to persist maintenance window; in-memory only", "error", err)
@@ -144,6 +160,22 @@ func (s *Scheduler) activeWindow() *pb.MaintenanceWindow {
 	s.windowMu.RLock()
 	defer s.windowMu.RUnlock()
 	return s.window
+}
+
+// dispatchAllowed reports whether scheduled dispatch may run at t. It is the
+// single gate consulted by runDueActions and the fail-closed sentinel point: a
+// corrupt persisted window denies here until the next sync. The flag and the
+// window are read under one lock so the deny sentinel and the window snapshot
+// cannot race apart.
+func (s *Scheduler) dispatchAllowed(t time.Time) bool {
+	s.windowMu.RLock()
+	failed := s.windowDecodeFailed
+	window := s.window
+	s.windowMu.RUnlock()
+	if failed {
+		return false
+	}
+	return maintenance.IsAllowed(window, t)
 }
 
 // loadMaintenanceWindow restores the persisted window from settings.
@@ -325,8 +357,7 @@ func (s *Scheduler) runDueActions(ctx context.Context) {
 	// the gateway and bypass this scheduler entirely. That matches
 	// the spec — admins hitting "reboot now" expect immediate
 	// execution.
-	window := s.activeWindow()
-	if !maintenance.IsAllowed(window, s.now().Local()) {
+	if !s.dispatchAllowed(s.now().Local()) {
 		s.logger.Info("maintenance window closed; deferring due dispatches",
 			"standalone", len(actions),
 			"groups", len(groups),

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -478,6 +478,15 @@ func (s *Scheduler) executeAction(ctx context.Context, stored *store.StoredActio
 		"type", action.Type.String(),
 	)
 
+	// Advance the due cursor BEFORE executing. If the agent crashes between
+	// here and RecordExecution, the action is no longer due on the next boot,
+	// so a non-idempotent action is not silently applied twice. RecordExecution
+	// writes the authoritative cursor on success; this is the in-flight guard.
+	if err := s.store.MarkActionStarted(action.Id.Value); err != nil {
+		s.logger.Warn("failed to mark action started; proceeding without crash-replay guard",
+			"action_id", action.Id.Value, "error", err)
+	}
+
 	// Verify the stored signed envelope and execute THOSE bytes.
 	result := s.verifyAndExecute(ctx, action)
 

--- a/internal/scheduler/scheduler_failclosed_test.go
+++ b/internal/scheduler/scheduler_failclosed_test.go
@@ -1,0 +1,113 @@
+package scheduler
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/manchtools/power-manage/agent/internal/store"
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// WS15 #1 — fail-CLOSED on a corrupt persisted maintenance window.
+//
+// scheduler.New logs a Warn and leaves s.window nil when loadMaintenanceWindow
+// returns a decode error, so maintenance.IsAllowed(nil, t) == true and dispatch
+// is unconstrained — a tampered/corrupt persisted window UNGATES the agent
+// instead of denying it. Design intent: a window that EXISTS but cannot be
+// proto-decoded must fail closed (deny-until-next-sync), cleared only by the
+// next successful SetMaintenanceWindow. A truly-absent row stays unconstrained
+// (the same default a fresh device gets before its first sync).
+
+func TestNew_CorruptPersistedWindow_FailsClosed(t *testing.T) {
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+
+	t.Run("correct: no persisted row boots unconstrained (allowed)", func(t *testing.T) {
+		st := newStore(t)
+		s := New(st, &mockExecutor{}, slog.Default())
+		s.now = func() time.Time { return now }
+		if s.activeWindow() != nil {
+			t.Fatalf("fresh store should have a nil window, got %v", s.activeWindow())
+		}
+		if !s.dispatchAllowed(now) {
+			t.Fatal("a never-synced device must allow dispatch (unconstrained default)")
+		}
+	})
+
+	t.Run("correct: a valid persisted window round-trips and gates", func(t *testing.T) {
+		st := newStore(t)
+		seed := New(st, &mockExecutor{}, slog.Default())
+		// Allow only Saturdays 22:00-06:00 — closed at a Sunday noon.
+		w := &pb.MaintenanceWindow{Schedule: []*pb.MaintenanceWindowEntry{
+			{Days: []string{"sat"}, Allow: "22:00-06:00"},
+		}}
+		seed.SetMaintenanceWindow(w)
+
+		restored := New(st, &mockExecutor{}, slog.Default())
+		if restored.activeWindow() == nil {
+			t.Fatal("valid persisted window must restore")
+		}
+		// now (2026-06-14) is a Sunday noon → outside the Saturday-night window.
+		if restored.dispatchAllowed(now) {
+			t.Fatal("valid window must gate dispatch outside its allowed range")
+		}
+	})
+
+	t.Run("the bug: byte-tampered persisted window fails CLOSED (deny-until-sync)", func(t *testing.T) {
+		st := newStore(t)
+		// Garbage that proto.Unmarshal rejects — tamper the BYTES so a no-op
+		// decode cannot pass. (A trailing 0xff group-end with junk is invalid
+		// wire format for MaintenanceWindow.)
+		if err := st.SetSetting(maintenanceWindowSettingKey, string([]byte{0xff, 0x00, 0x13, 0x37})); err != nil {
+			t.Fatalf("seed corrupt setting: %v", err)
+		}
+		// Sanity: confirm the bytes really are undecodable, so this test pins
+		// the decode-error path and not an empty/no-op decode.
+		if err := proto.Unmarshal([]byte{0xff, 0x00, 0x13, 0x37}, &pb.MaintenanceWindow{}); err == nil {
+			t.Fatal("test setup invalid: tampered bytes unexpectedly decoded cleanly")
+		}
+
+		s := New(st, &mockExecutor{}, slog.Default())
+		s.now = func() time.Time { return now }
+		// RED today: New leaves s.window nil and dispatchAllowed == true
+		// (fail-open). The deny-until-sync sentinel must make this false at
+		// EVERY moment until the next sync overwrites the window.
+		if s.dispatchAllowed(now) {
+			t.Fatal("corrupt persisted window must fail CLOSED (deny dispatch), got allowed")
+		}
+		if s.dispatchAllowed(now.Add(48 * time.Hour)) {
+			t.Fatal("corrupt persisted window must deny at every moment until next sync")
+		}
+	})
+
+	t.Run("recovery: next sync clears the deny sentinel and restores gating", func(t *testing.T) {
+		st := newStore(t)
+		if err := st.SetSetting(maintenanceWindowSettingKey, string([]byte{0xff, 0x00, 0x13, 0x37})); err != nil {
+			t.Fatalf("seed corrupt setting: %v", err)
+		}
+		s := New(st, &mockExecutor{}, slog.Default())
+		s.now = func() time.Time { return now }
+		if s.dispatchAllowed(now) {
+			t.Fatal("precondition: corrupt boot must deny")
+		}
+
+		// The next successful sync (an empty/cleared window) lifts the deny
+		// sentinel — fail-closed is "until next sync", not a permanent brick.
+		s.SetMaintenanceWindow(nil)
+		if !s.dispatchAllowed(now) {
+			t.Fatal("after a clearing sync, dispatch must be allowed again (deny sentinel not cleared)")
+		}
+	})
+}
+
+func newStore(t *testing.T) *store.Store {
+	t.Helper()
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+	return st
+}

--- a/internal/store/clock_clamp_test.go
+++ b/internal/store/clock_clamp_test.go
@@ -1,0 +1,101 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// WS15 #5 — forward clock-jump must not suppress drift-prevention beyond one
+// interval.
+//
+// calculateNextExecute / calculateNextExecuteFromSchedule (interval path)
+// compute lastExecuted+interval. A future-dated lastExecuted — persisted while
+// the wall clock was transiently jumped forward, then corrected back — yields a
+// next_execute_at arbitrarily far ahead, so the action silently stops running.
+// Intent: the computed cursor must be clamped to min(computed, now+interval) so
+// a single forward excursion can delay drift-prevention by at most one
+// interval, never indefinitely.
+
+func TestCalculateNextExecute_ForwardClockJump_ClampedToOneInterval(t *testing.T) {
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	const intervalHours = 8
+	interval := time.Duration(intervalHours) * time.Hour
+
+	newStoreAt := func(t *testing.T) *Store {
+		t.Helper()
+		st, err := New(t.TempDir())
+		if err != nil {
+			t.Fatalf("new store: %v", err)
+		}
+		t.Cleanup(func() { st.Close() })
+		st.now = func() time.Time { return now }
+		return st
+	}
+
+	t.Run("ABSENT/normal: monotonic progression is unchanged", func(t *testing.T) {
+		st := newStoreAt(t)
+		action := &pb.Action{
+			Id:       &pb.ActionId{Value: "01HCLOCKNORMAL00000000000"},
+			Type:     pb.ActionType_ACTION_TYPE_SHELL,
+			Schedule: &pb.ActionSchedule{IntervalHours: intervalHours},
+		}
+		last := now.Add(-2 * time.Hour) // executed 2h ago, in the past
+		got := st.calculateNextExecute(action, &last, false)
+		want := last.UTC().Add(interval)
+		if !got.Equal(want) {
+			t.Fatalf("normal interval cursor = %v, want %v (unchanged progression)", got, want)
+		}
+		// And it is at or before now+interval (the clamp ceiling).
+		if got.After(now.Add(interval)) {
+			t.Fatalf("normal cursor %v exceeds now+interval ceiling %v", got, now.Add(interval))
+		}
+	})
+
+	t.Run("the bug: future-dated lastExecuted is clamped to now+interval (action)", func(t *testing.T) {
+		st := newStoreAt(t)
+		action := &pb.Action{
+			Id:       &pb.ActionId{Value: "01HCLOCKJUMP000000000000A"},
+			Type:     pb.ActionType_ACTION_TYPE_SHELL,
+			Schedule: &pb.ActionSchedule{IntervalHours: intervalHours},
+		}
+		// lastExecuted is 10 days in the FUTURE (a forward clock excursion that
+		// has since been corrected back to `now`).
+		last := now.Add(240 * time.Hour)
+		got := st.calculateNextExecute(action, &last, false)
+
+		ceiling := now.Add(interval)
+		// RED today: got == last+interval == now+250h, far past the ceiling.
+		if got.After(ceiling) {
+			t.Fatalf("future-dated cursor = %v exceeds clamp ceiling now+interval = %v; "+
+				"a forward clock jump suppressed drift-prevention beyond one interval", got, ceiling)
+		}
+	})
+
+	t.Run("the bug: future-dated lastExecuted is clamped (group variant)", func(t *testing.T) {
+		schedule := &pb.ActionSchedule{IntervalHours: intervalHours}
+		last := now.Add(240 * time.Hour)
+		got := calculateNextExecuteFromSchedule(schedule, &last, false, now)
+
+		ceiling := now.Add(interval)
+		if got.After(ceiling) {
+			t.Fatalf("group future-dated cursor = %v exceeds ceiling %v", got, ceiling)
+		}
+	})
+
+	t.Run("nil-schedule drift default is also clamped", func(t *testing.T) {
+		st := newStoreAt(t)
+		action := &pb.Action{
+			Id:   &pb.ActionId{Value: "01HCLOCKJUMPNILSCHED00000"},
+			Type: pb.ActionType_ACTION_TYPE_SHELL,
+			// no Schedule → 8h drift default
+		}
+		last := now.Add(240 * time.Hour)
+		got := st.calculateNextExecute(action, &last, false)
+		ceiling := now.Add(8 * time.Hour)
+		if got.After(ceiling) {
+			t.Fatalf("nil-schedule future-dated cursor = %v exceeds 8h ceiling %v", got, ceiling)
+		}
+	})
+}

--- a/internal/store/crash_marker_test.go
+++ b/internal/store/crash_marker_test.go
@@ -1,0 +1,89 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// WS15 #4 — in-flight marker before execute, so a crash between Execute and
+// RecordExecution does not re-run a non-idempotent action on the next boot.
+//
+// Today next_execute_at only advances inside RecordExecution, which runs AFTER
+// executor.Execute. A crash in between leaves the action due, so the offline
+// scheduler re-dispatches it on restart. Intent: persist a started marker that
+// advances the due cursor by one interval BEFORE execution, so a crashed
+// in-flight action is not blindly re-dispatched within the same interval.
+// (Best-effort for non-idempotent actions; idempotent actions are unaffected.)
+
+func TestExecuteAction_InFlightMarker_NoDoubleApplyAcrossRestart(t *testing.T) {
+	const intervalHours = 8
+	interval := time.Duration(intervalHours) * time.Hour
+
+	// t0 is when the action was first scheduled; tDue is a later "now" at which
+	// the action has become due and the scheduler picks it up.
+	t0 := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
+	tDue := t0.Add(interval + time.Minute) // just past the first cursor → due
+
+	clock := t0
+	st, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	defer st.Close()
+	st.now = func() time.Time { return clock }
+
+	action := &pb.Action{
+		Id:       &pb.ActionId{Value: "01HCRASHMARKER0000000000A"},
+		Type:     pb.ActionType_ACTION_TYPE_SHELL,
+		Schedule: &pb.ActionSchedule{IntervalHours: intervalHours},
+	}
+	if err := st.SaveAction(action); err != nil {
+		t.Fatalf("save action: %v", err)
+	}
+
+	// Advance the clock so the action is now due.
+	clock = tDue
+	due, err := st.GetDueActions(context.Background())
+	if err != nil {
+		t.Fatalf("get due: %v", err)
+	}
+	if len(due) != 1 {
+		t.Fatalf("precondition: expected exactly 1 due action, got %d", len(due))
+	}
+
+	// The scheduler marks the action started BEFORE invoking the executor.
+	if err := st.MarkActionStarted(action.Id.Value); err != nil {
+		t.Fatalf("mark started: %v", err)
+	}
+
+	// Simulate a CRASH between Execute and RecordExecution: nothing else runs.
+	// On the next boot, the scheduler scans for due actions. The in-flight
+	// marker must have advanced the cursor so the crashed action is NOT
+	// immediately re-dispatched within the same interval.
+	dueAfter, err := st.GetDueActions(context.Background())
+	if err != nil {
+		t.Fatalf("get due after marker: %v", err)
+	}
+	for _, a := range dueAfter {
+		if a.ID == action.Id.Value {
+			t.Fatalf("crashed in-flight action is still due after the started marker "+
+				"(cursor not advanced) — it would be re-dispatched on restart; next_execute_at=%v now=%v",
+				a.NextExecuteAt, clock)
+		}
+	}
+
+	// The advanced cursor must be bounded to one interval ahead (not arbitrarily
+	// far): at most now+interval, so a recovered action resumes its cadence.
+	got, err := st.GetAction(action.Id.Value)
+	if err != nil {
+		t.Fatalf("get action: %v", err)
+	}
+	ceiling := clock.Add(interval)
+	if got.NextExecuteAt.After(ceiling) {
+		t.Fatalf("started marker advanced cursor to %v, beyond one interval ceiling %v",
+			got.NextExecuteAt, ceiling)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -226,11 +226,42 @@ func (s *Store) SaveAction(action *pb.Action) error {
 }
 
 // MarkActionStarted advances an action's next_execute_at by one interval
-// BEFORE the executor runs, so a crash between execute and RecordExecution
-// does not leave the action due and re-dispatch it on the next boot. RecordExecution
-// later writes the authoritative cursor. RED-PHASE STUB (no-op).
+// BEFORE the executor runs, so a crash between executor.Execute and
+// RecordExecution does not leave the action due and re-dispatch it on the next
+// boot (a second apply of a non-idempotent action). RecordExecution later
+// writes the authoritative cursor (computed from the same schedule), so the
+// marker is a best-effort in-flight guard, not the source of truth. It does
+// NOT touch last_executed_at — only the due cursor — so change-detection and
+// result recording are unaffected. A missing action is a no-op (it may have
+// been removed by a concurrent sync).
 func (s *Store) MarkActionStarted(actionID string) error {
-	return nil
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var actionJSON string
+	err := s.db.QueryRow("SELECT action_json FROM actions WHERE id = ?", actionID).Scan(&actionJSON)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get action: %w", err)
+	}
+
+	action := &pb.Action{}
+	if err := protojson.Unmarshal([]byte(actionJSON), action); err != nil {
+		return fmt.Errorf("unmarshal action: %w", err)
+	}
+
+	// Compute the cursor as if the action just executed now — one interval
+	// ahead, clamped — so a crash mid-execute does not re-run it this interval.
+	now := s.now().UTC()
+	nextExecute := s.calculateNextExecute(action, &now, false)
+
+	_, err = s.db.Exec(
+		"UPDATE actions SET next_execute_at = ? WHERE id = ?",
+		nextExecute, actionID,
+	)
+	return err
 }
 
 // RemoveAction removes an action from the store.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -225,6 +225,14 @@ func (s *Store) SaveAction(action *pb.Action) error {
 	return err
 }
 
+// MarkActionStarted advances an action's next_execute_at by one interval
+// BEFORE the executor runs, so a crash between execute and RecordExecution
+// does not leave the action due and re-dispatch it on the next boot. RecordExecution
+// later writes the authoritative cursor. RED-PHASE STUB (no-op).
+func (s *Store) MarkActionStarted(actionID string) error {
+	return nil
+}
+
 // RemoveAction removes an action from the store.
 func (s *Store) RemoveAction(actionID string) error {
 	s.mu.Lock()
@@ -1123,7 +1131,7 @@ func calculateNextExecuteFromSchedule(schedule *pb.ActionSchedule, lastExecuted 
 		if lastExecuted == nil {
 			return now
 		}
-		return lastExecuted.UTC().Add(8 * time.Hour)
+		return clampInterval(lastExecuted.UTC().Add(8*time.Hour), now, 8*time.Hour)
 	}
 	if schedule.RunOnAssign && lastExecuted == nil {
 		return now
@@ -1142,7 +1150,22 @@ func calculateNextExecuteFromSchedule(schedule *pb.ActionSchedule, lastExecuted 
 	if lastExecuted == nil {
 		return now
 	}
-	return lastExecuted.UTC().Add(time.Duration(interval) * time.Hour)
+	d := time.Duration(interval) * time.Hour
+	return clampInterval(lastExecuted.UTC().Add(d), now, d)
+}
+
+// clampInterval bounds an interval-derived next-execute cursor to at most
+// now+interval. A future-dated lastExecuted (from a transient forward clock
+// excursion that was later corrected back) would otherwise push the cursor
+// arbitrarily far ahead and silently suppress drift-prevention indefinitely.
+// Clamping caps the suppression at one interval. Cron cursors are derived from
+// now and so are already bounded; only the interval path needs the clamp.
+func clampInterval(computed, now time.Time, interval time.Duration) time.Time {
+	ceiling := now.UTC().Add(interval)
+	if computed.After(ceiling) {
+		return ceiling
+	}
+	return computed
 }
 
 // GetAllActionIDs returns the IDs of all stored actions.
@@ -1185,7 +1208,7 @@ func (s *Store) calculateNextExecute(action *pb.Action, lastExecuted *time.Time,
 		if lastExecuted == nil {
 			return now
 		}
-		return lastExecuted.UTC().Add(8 * time.Hour)
+		return clampInterval(lastExecuted.UTC().Add(8*time.Hour), now, 8*time.Hour)
 	}
 
 	// Check for run_on_assign
@@ -1213,7 +1236,8 @@ func (s *Store) calculateNextExecute(action *pb.Action, lastExecuted *time.Time,
 	if lastExecuted == nil {
 		return now
 	}
-	return lastExecuted.UTC().Add(time.Duration(interval) * time.Hour)
+	d := time.Duration(interval) * time.Hour
+	return clampInterval(lastExecuted.UTC().Add(d), now, d)
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes manchtools/power-manage-agent#117

## What

WS15 agent stream-loop robustness, agent leg. Builds on the SDK leg (manchtools/power-manage-sdk#109, merged — bumped in here).

### Changes

1. **Terminal Cols/Rows bounds** (`fix(handler)`). `OnTerminalStart`/`OnTerminalResize` narrowed `req.Cols`/`req.Rows` (`uint32`) to `uint16` unchecked, so `65536` wrapped to `0` and `65537` to `1` — a degenerate PTY. New `validateDims` enforces `0 < dim <= 65535`: start rejects with a `STATE_ERROR` before any PTY allocation; resize logs and no-ops before the narrowing.
2. **Fail-closed maintenance window** (`fix(scheduler)`). `New` left `s.window` nil on a `loadMaintenanceWindow` decode error, so `IsAllowed(nil, t)` returned true and a corrupt/tampered persisted window unconstrained dispatch. A `windowDecodeFailed` deny-until-sync sentinel now denies every moment until the next `SetMaintenanceWindow`; a truly-absent row still boots unconstrained.
3. **Clock clamp** (`fix(scheduler)`). The interval cursor `lastExecuted+interval` is clamped to `min(computed, now+interval)`, so a future-dated cursor from a forward clock excursion cannot suppress drift-prevention beyond one interval. Cron cursors are already bounded; `SaveAction` (lastExecuted==now) is a no-op under the clamp.
4. **Crash-replay guard** (`fix(scheduler)`). `Store.MarkActionStarted` advances the due cursor one interval **before** `executor.Execute`, so a crash before `RecordExecution` does not re-dispatch a non-idempotent action on the next boot.
5. **Consolidated gateway-URL guard** (`fix(agent)`). `runtime.go`'s `strings.HasPrefix(addr, "http://")` let `HTTP://`, `Https://` corner cases, `https:foo` (opaque), `https:` (no host), `ftp://`, `h2c://`, empty, and leading-whitespace values reach `WithMTLSFromPEM`. Extracted the `cmd_selftest.go` `url.Parse` predicate into one shared `requireHTTPSGateway` used at both gateway dial sites.

### Tests

Five charter test files, each RED-confirmed for the intended reason before its fix (truncation accepted, fail-open allow, future cursor unclamped, crashed action re-due, non-https accepted). Correct / absent / present-but-wrong coverage throughout; the gateway-URL and `validateDims` tables source "wrong" from intent, not the artifact. Scheduler + store suites pass under `-race`.

### Charter notes

- The original charter's handler `action.Id.Value` nil-deref was already closed by the action-signing-envelope refactor (`OnActionWithStreaming` routes raw envelope bytes through fail-closed `VerifyEnvelope` + nil-safe proto getters). A regression test (`TestOnActionWithStreaming_MalformedEnvelopeNoPanic`) pins it so it cannot silently regress.
- `cmd_luks.go` has no remote gateway dial (it uses a local unix socket), so it is not one of the gateway dial sites; the consolidated guard covers `runtime.go` and `cmd_selftest.go`.
- ADR (server/docs/adr) is intentionally out of scope here and tracked as pending.