### PR TITLE
fix(executor,store,handler,cmd): error-discipline hardening (WS16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ Install, update, or remove system packages using the detected package manager (a
 - `PRESENT`: Install or update the package, optionally pin to version
 - `ABSENT`: Unpin and remove the package
 
+`PACKAGE` and `UPDATE` actions honor their per-action `timeout_seconds`; when none is set they fall back to a default 30-minute ceiling so a wedged package-manager operation (mirror outage, lock contention) cannot run unbounded. The package manager is bound to the action's deadline, so a timeout aborts the underlying `apt`/`dnf`/`zypper`/`pacman` subprocess.
+
 ### System Update (`UPDATE`)
 
 Perform system-wide package updates.

--- a/cmd/power-manage-agent/cmd_query.go
+++ b/cmd/power-manage-agent/cmd_query.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -12,6 +13,12 @@ import (
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/go/sys/osquery"
 )
+
+// isNotInstalled reports whether err signals that osquery is not installed,
+// matching the sentinel even when it is wrapped (WS16 #13).
+func isNotInstalled(err error) bool {
+	return errors.Is(err, osquery.ErrNotInstalled)
+}
 
 // runQuery executes a local osquery table query and prints results.
 // Usage: power-manage-agent query <table> [--json]
@@ -40,7 +47,7 @@ func runQuery(args []string) {
 	// Create registry (requires osquery to be installed)
 	registry, err := osquery.NewRegistry()
 	if err != nil {
-		if err == osquery.ErrNotInstalled {
+		if isNotInstalled(err) {
 			fmt.Fprintln(os.Stderr, "Error: osquery is not installed on this system")
 			fmt.Fprintln(os.Stderr, "")
 			fmt.Fprintln(os.Stderr, "Install osquery to use this feature:")

--- a/cmd/power-manage-agent/cmd_query_test.go
+++ b/cmd/power-manage-agent/cmd_query_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/osquery"
+)
+
+// WS16 #13: the install-guidance branch must fire even when the
+// osquery.ErrNotInstalled sentinel is wrapped. isNotInstalled extracts the
+// predicate so it is testable and uses errors.Is.
+func TestIsNotInstalled(t *testing.T) {
+	if !isNotInstalled(osquery.ErrNotInstalled) {
+		t.Error("bare sentinel must be detected as not-installed")
+	}
+	if !isNotInstalled(fmt.Errorf("create registry: %w", osquery.ErrNotInstalled)) {
+		t.Error("wrapped sentinel must still be detected (errors.Is, not ==)")
+	}
+	if isNotInstalled(errors.New("permission denied")) {
+		t.Error("an unrelated error must not be treated as not-installed")
+	}
+	if isNotInstalled(nil) {
+		t.Error("nil must not be treated as not-installed")
+	}
+}

--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -315,6 +315,14 @@ func main() {
 	// on SIGTERM.
 	sched.Stop()
 
+	// Tear down any live terminal sessions (WS16 #5): a session left open at
+	// shutdown would leave its pm-tty shell activated and its temp home on
+	// disk. Use a fresh bounded ctx — the run ctx may already be cancelled by
+	// the shutdown signal, which would abort the usermod shell-revert.
+	teardownCtx, cancelTeardown := context.WithTimeout(context.Background(), 30*time.Second)
+	h.CloseAllTerminals(teardownCtx)
+	cancelTeardown()
+
 	// Stop background goroutines started during runAgent. The
 	// terminal sweeper would otherwise outlive the agent process in
 	// any non-os.Exit shutdown path (audit F004).

--- a/internal/executor/action_deb.go
+++ b/internal/executor/action_deb.go
@@ -31,6 +31,17 @@ func (e *Executor) executeDeb(ctx context.Context, params *pb.AppInstallParams, 
 		return nil, false, fmt.Errorf("app params required")
 	}
 
+	// Fail closed before any privileged remount or network round-trip: the
+	// artifact URL must be https and carry a checksum. downloadFile enforces
+	// https but SKIPS checksum verification when the checksum is empty, so this
+	// executor-boundary guard (matching executeRpm) refuses an unverified .deb
+	// on every host rather than relying on the proto/server alone (WS16 #2).
+	// Runs before the dpkg lookup so a malformed action is rejected even on
+	// non-deb hosts.
+	if err := requireVerifiedArtifact(params.Url, params.ChecksumSha256); err != nil {
+		return nil, false, err
+	}
+
 	// Skip on non-deb systems
 	if _, err := exec.LookPath("dpkg"); err != nil {
 		if errors.Is(err, exec.ErrNotFound) {

--- a/internal/executor/action_deb.go
+++ b/internal/executor/action_deb.go
@@ -31,15 +31,19 @@ func (e *Executor) executeDeb(ctx context.Context, params *pb.AppInstallParams, 
 		return nil, false, fmt.Errorf("app params required")
 	}
 
-	// Fail closed before any privileged remount or network round-trip: the
-	// artifact URL must be https and carry a checksum. downloadFile enforces
-	// https but SKIPS checksum verification when the checksum is empty, so this
-	// executor-boundary guard (matching executeRpm) refuses an unverified .deb
-	// on every host rather than relying on the proto/server alone (WS16 #2).
-	// Runs before the dpkg lookup so a malformed action is rejected even on
-	// non-deb hosts.
-	if err := requireVerifiedArtifact(params.Url, params.ChecksumSha256); err != nil {
-		return nil, false, err
+	// Fail closed before any privileged remount or network round-trip on the
+	// INSTALL path: the artifact URL must be https and carry a checksum.
+	// downloadFile enforces https but SKIPS checksum verification when the
+	// checksum is empty, so this executor-boundary guard refuses an unverified
+	// .deb rather than relying on the proto/server alone (WS16 #2). Only the
+	// PRESENT path downloads — ABSENT removes by package name and never fetches
+	// the artifact, so it needs no verification (mirrors the AppImage remove
+	// path). Runs before the dpkg lookup so a malformed install is rejected
+	// even on non-deb hosts.
+	if state == pb.DesiredState_DESIRED_STATE_PRESENT {
+		if err := requireVerifiedArtifact(params.Url, params.ChecksumSha256); err != nil {
+			return nil, false, err
+		}
 	}
 
 	// Skip on non-deb systems

--- a/internal/executor/action_deb_failclosed_test.go
+++ b/internal/executor/action_deb_failclosed_test.go
@@ -1,0 +1,46 @@
+package executor
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// WS16 #2: executeDeb relied solely on downloadFile, which SKIPS checksum
+// verification when checksum_sha256 is empty. RPM/AppImage already guard at the
+// executor boundary; DEB now does too (requireVerifiedArtifact). Pin that a
+// non-https URL or an absent/malformed checksum is rejected BEFORE any
+// privileged filesystem remount — hermetic, since the guard runs before the
+// dpkg lookup.
+func TestExecuteDeb_RejectsBeforeRemount(t *testing.T) {
+	validHex := strings.Repeat("a", 64)
+	cases := []struct {
+		name string
+		p    *pb.AppInstallParams
+	}{
+		{"http url", &pb.AppInstallParams{Url: "http://mirror/x.deb", ChecksumSha256: validHex}},
+		{"ftp url", &pb.AppInstallParams{Url: "ftp://mirror/x.deb", ChecksumSha256: validHex}},
+		{"empty checksum", &pb.AppInstallParams{Url: "https://x/x.deb", ChecksumSha256: ""}},
+		{"whitespace checksum", &pb.AppInstallParams{Url: "https://x/x.deb", ChecksumSha256: "   "}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var remountCalls int
+			e := &Executor{logger: slog.Default(), now: time.Now, repairFS: func(context.Context) bool {
+				remountCalls++
+				return true
+			}}
+			out, changed, err := e.executeDeb(context.Background(), tc.p, pb.DesiredState_DESIRED_STATE_PRESENT)
+			if err == nil {
+				t.Fatalf("expected rejection, got out=%v changed=%v", out, changed)
+			}
+			if remountCalls != 0 {
+				t.Errorf("privileged remount ran %d times before validation; want 0", remountCalls)
+			}
+		})
+	}
+}

--- a/internal/executor/action_package.go
+++ b/internal/executor/action_package.go
@@ -13,7 +13,11 @@ func (e *Executor) executePackage(ctx context.Context, params *pb.PackageParams,
 	if params == nil {
 		return nil, false, fmt.Errorf("package params required")
 	}
-	if e.pkgManager == nil {
+	// WS16 #3: bind the package manager to the action ctx so the per-action
+	// timeout reaches the package-manager subprocesses (install/update/remove
+	// are the long-running operations).
+	mgr := e.pkgManagerForCtx(ctx)
+	if mgr == nil {
 		return nil, false, fmt.Errorf("no supported package manager found")
 	}
 	pkgName := e.getPackageNameForManager(params)
@@ -25,19 +29,19 @@ func (e *Executor) executePackage(ctx context.Context, params *pb.PackageParams,
 	}
 	switch state {
 	case pb.DesiredState_DESIRED_STATE_PRESENT:
-		return e.ensurePackagePresent(ctx, params, pkgName)
+		return e.ensurePackagePresent(ctx, mgr, params, pkgName)
 	case pb.DesiredState_DESIRED_STATE_ABSENT:
-		return e.ensurePackageAbsent(ctx, params, pkgName)
+		return e.ensurePackageAbsent(ctx, mgr, params, pkgName)
 	default:
 		return nil, false, fmt.Errorf("unknown desired state: %v", state)
 	}
 }
 
 // ensurePackagePresent installs a package (with optional version and pin) if not already satisfied.
-func (e *Executor) ensurePackagePresent(ctx context.Context, params *pb.PackageParams, pkgName string) (*pb.CommandOutput, bool, error) {
-	isInstalled, _ := e.pkgManager.IsInstalled(pkgName)
+func (e *Executor) ensurePackagePresent(ctx context.Context, mgr *pkg.PackageManager, params *pb.PackageParams, pkgName string) (*pb.CommandOutput, bool, error) {
+	isInstalled, _ := mgr.IsInstalled(pkgName)
 	if isInstalled {
-		if out, changed, err := e.checkPackageVersionAndPin(ctx, params, pkgName); out != nil {
+		if out, changed, err := e.checkPackageVersionAndPin(ctx, mgr, params, pkgName); out != nil {
 			return out, changed, err
 		}
 	}
@@ -47,13 +51,13 @@ func (e *Executor) ensurePackagePresent(ctx context.Context, params *pb.PackageP
 	}
 	e.repairPackageManager(ctx)
 
-	if _, updateErr := e.pkgManager.Update(); updateErr != nil {
+	if _, updateErr := mgr.Update(); updateErr != nil {
 		e.logger.Warn("package index update failed, continuing with install", "error", updateErr)
 	}
 
 	// Version and AllowDowngrade are independent — setting a version does NOT
 	// imply downgrade permission. Callers must explicitly set AllowDowngrade.
-	builder := e.pkgManager.Install(pkgName)
+	builder := mgr.Install(pkgName)
 	if params.Version != "" {
 		builder = builder.Version(params.Version)
 	}
@@ -82,10 +86,10 @@ func (e *Executor) ensurePackagePresent(ctx context.Context, params *pb.PackageP
 // desired version and pin state. Returns (output, changed, error) when the check
 // is conclusive (output != nil). Returns (nil, false, nil) when the version
 // doesn't match and the package needs reinstallation.
-func (e *Executor) checkPackageVersionAndPin(ctx context.Context, params *pb.PackageParams, pkgName string) (*pb.CommandOutput, bool, error) {
+func (e *Executor) checkPackageVersionAndPin(ctx context.Context, mgr *pkg.PackageManager, params *pb.PackageParams, pkgName string) (*pb.CommandOutput, bool, error) {
 	versionStr := ""
 	if params.Version != "" {
-		installedVersion, _ := e.pkgManager.GetInstalledVersion(pkgName)
+		installedVersion, _ := mgr.GetInstalledVersion(pkgName)
 		if installedVersion != params.Version {
 			return nil, false, nil
 		}
@@ -112,8 +116,8 @@ func (e *Executor) checkPackageVersionAndPin(ctx context.Context, params *pb.Pac
 }
 
 // ensurePackageAbsent removes a package if installed.
-func (e *Executor) ensurePackageAbsent(ctx context.Context, _ *pb.PackageParams, pkgName string) (*pb.CommandOutput, bool, error) {
-	isInstalled, _ := e.pkgManager.IsInstalled(pkgName)
+func (e *Executor) ensurePackageAbsent(ctx context.Context, mgr *pkg.PackageManager, _ *pb.PackageParams, pkgName string) (*pb.CommandOutput, bool, error) {
+	isInstalled, _ := mgr.IsInstalled(pkgName)
 	if !isInstalled {
 		return &pb.CommandOutput{
 			ExitCode: 0,
@@ -132,7 +136,7 @@ func (e *Executor) ensurePackageAbsent(ctx context.Context, _ *pb.PackageParams,
 		e.logger.Warn("ensurePackageAbsent: failed to unpin package before removal",
 			"package", pkgName, "error", err)
 	}
-	result, err := e.pkgManager.Remove(pkgName).Run()
+	result, err := mgr.Remove(pkgName).Run()
 	return packageResult(result, err)
 }
 

--- a/internal/executor/action_package.go
+++ b/internal/executor/action_package.go
@@ -67,7 +67,7 @@ func (e *Executor) ensurePackagePresent(ctx context.Context, mgr *pkg.PackageMan
 	result, err := builder.Run()
 
 	if err == nil && params.Pin {
-		if _, pinErr := e.pinPackage(pkgName); pinErr != nil {
+		if _, pinErr := e.pinPackage(mgr, pkgName); pinErr != nil {
 			// Pin is part of the requested state. The previous shape
 			// degraded to a stderr warning while the action result
 			// stayed success — operators saw "installed and pinned"
@@ -96,7 +96,7 @@ func (e *Executor) checkPackageVersionAndPin(ctx context.Context, mgr *pkg.Packa
 		versionStr = " version " + params.Version
 	}
 	if params.Pin {
-		changed, pinErr := e.ensurePackagePinned(ctx, pkgName)
+		changed, pinErr := e.ensurePackagePinned(ctx, mgr, pkgName)
 		if pinErr != nil {
 			return &pb.CommandOutput{
 				ExitCode: 1,
@@ -132,7 +132,7 @@ func (e *Executor) ensurePackageAbsent(ctx context.Context, mgr *pkg.PackageMana
 	// a pinned package's removal would surface as the package
 	// manager's "held" message instead of the underlying unpin
 	// failure. Log so the operator can correlate.
-	if _, err := e.ensurePackageUnpinned(pkgName); err != nil {
+	if _, err := e.ensurePackageUnpinned(mgr, pkgName); err != nil {
 		e.logger.Warn("ensurePackageAbsent: failed to unpin package before removal",
 			"package", pkgName, "error", err)
 	}
@@ -201,22 +201,22 @@ func (e *Executor) getPackageNameForManager(params *pb.PackageParams) string {
 // - Pacman: IgnorePkg in pacman.conf
 // - Zypper: zypper lock
 // - Flatpak: flatpak mask
-func (e *Executor) isPackagePinned(pkgName string) (bool, error) {
-	if e.pkgManager == nil {
+func (e *Executor) isPackagePinned(mgr *pkg.PackageManager, pkgName string) (bool, error) {
+	if mgr == nil {
 		return false, fmt.Errorf("no package manager available")
 	}
-	return e.pkgManager.IsPinned(pkgName)
+	return mgr.IsPinned(pkgName)
 }
 
 // pinPackage pins a package to prevent it from being upgraded.
 // Returns (changed, error) where changed is true if the package was newly pinned.
-func (e *Executor) pinPackage(pkgName string) (bool, error) {
-	if e.pkgManager == nil {
+func (e *Executor) pinPackage(mgr *pkg.PackageManager, pkgName string) (bool, error) {
+	if mgr == nil {
 		return false, fmt.Errorf("no package manager available")
 	}
 
 	// Check if already pinned
-	isPinned, err := e.pkgManager.IsPinned(pkgName)
+	isPinned, err := mgr.IsPinned(pkgName)
 	if err != nil {
 		return false, fmt.Errorf("check pin status: %w", err)
 	}
@@ -225,7 +225,7 @@ func (e *Executor) pinPackage(pkgName string) (bool, error) {
 	}
 
 	// Pin the package
-	_, err = e.pkgManager.Pin(pkgName).Run()
+	_, err = mgr.Pin(pkgName).Run()
 	if err != nil {
 		return false, fmt.Errorf("pin package: %w", err)
 	}
@@ -234,13 +234,13 @@ func (e *Executor) pinPackage(pkgName string) (bool, error) {
 
 // unpinPackage unpins a package to allow it to be upgraded.
 // Returns (changed, error) where changed is true if the package was unpinned.
-func (e *Executor) unpinPackage(pkgName string) (bool, error) {
-	if e.pkgManager == nil {
+func (e *Executor) unpinPackage(mgr *pkg.PackageManager, pkgName string) (bool, error) {
+	if mgr == nil {
 		return false, fmt.Errorf("no package manager available")
 	}
 
 	// Check if currently pinned
-	isPinned, err := e.pkgManager.IsPinned(pkgName)
+	isPinned, err := mgr.IsPinned(pkgName)
 	if err != nil {
 		return false, fmt.Errorf("check pin status: %w", err)
 	}
@@ -249,7 +249,7 @@ func (e *Executor) unpinPackage(pkgName string) (bool, error) {
 	}
 
 	// Unpin the package
-	_, err = e.pkgManager.Unpin(pkgName).Run()
+	_, err = mgr.Unpin(pkgName).Run()
 	if err != nil {
 		return false, fmt.Errorf("unpin package: %w", err)
 	}
@@ -258,9 +258,9 @@ func (e *Executor) unpinPackage(pkgName string) (bool, error) {
 
 // ensurePackagePinned ensures a package is pinned. Returns true if a change was made.
 // This is a convenience method that handles filesystem repair before pinning.
-func (e *Executor) ensurePackagePinned(ctx context.Context, pkgName string) (bool, error) {
+func (e *Executor) ensurePackagePinned(ctx context.Context, mgr *pkg.PackageManager, pkgName string) (bool, error) {
 	// Check if already pinned first (no filesystem write needed)
-	isPinned, _ := e.isPackagePinned(pkgName)
+	isPinned, _ := e.isPackagePinned(mgr, pkgName)
 	if isPinned {
 		return false, nil
 	}
@@ -270,10 +270,10 @@ func (e *Executor) ensurePackagePinned(ctx context.Context, pkgName string) (boo
 		return false, errReadOnlyFS
 	}
 
-	return e.pinPackage(pkgName)
+	return e.pinPackage(mgr, pkgName)
 }
 
 // ensurePackageUnpinned ensures a package is unpinned. Returns true if a change was made.
-func (e *Executor) ensurePackageUnpinned(pkgName string) (bool, error) {
-	return e.unpinPackage(pkgName)
+func (e *Executor) ensurePackageUnpinned(mgr *pkg.PackageManager, pkgName string) (bool, error) {
+	return e.unpinPackage(mgr, pkgName)
 }

--- a/internal/executor/action_update.go
+++ b/internal/executor/action_update.go
@@ -438,7 +438,11 @@ func (e *Executor) repairZypper(ctx context.Context) {
 // executeUpdate performs a system-wide package update.
 // It respects version pinning (apt-mark hold / dnf versionlock).
 func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (*pb.CommandOutput, bool, error) {
-	if e.pkgManager == nil {
+	// WS16 #3: bind the package manager to the action ctx so the per-action
+	// timeout reaches the index-update and generic-upgrade subprocesses. The
+	// apt/dnf-specific upgrade paths already build a ctx-bound backend.
+	mgr := e.pkgManagerForCtx(ctx)
+	if mgr == nil {
 		return nil, false, fmt.Errorf("no supported package manager found")
 	}
 
@@ -462,7 +466,7 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 	rebootRequiredBefore := e.checkRebootRequired()
 
 	// Update package index
-	if updateResult, err := e.pkgManager.Update(); err != nil {
+	if updateResult, err := mgr.Update(); err != nil {
 		allOutput.WriteString("=== Package Index Update ===\n")
 		if updateResult != nil {
 			allOutput.WriteString(updateResult.Stdout)
@@ -492,7 +496,7 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 		lastErr = e.executeDnfUpgrade(ctx, params, &allOutput)
 	} else {
 		// Fallback to generic upgrade via the builder
-		upgradeResult, err := e.pkgManager.Upgrade().Run()
+		upgradeResult, err := mgr.Upgrade().Run()
 		if err != nil {
 			allOutput.WriteString(fmt.Sprintf("Error: %v\n", err))
 			if upgradeResult != nil {

--- a/internal/executor/distro_skip_test.go
+++ b/internal/executor/distro_skip_test.go
@@ -124,8 +124,12 @@ func TestExecuteRpm_DoesNotSkipWhenRpmPresent(t *testing.T) {
 	}
 
 	e := NewExecutor(nil)
+	// A well-formed action (https + valid checksum) so it passes the
+	// requireVerifiedArtifact guard and proceeds past the rpm check; the
+	// unresolvable host then fails the download (proving it didn't skip).
 	output, _, err := e.executeRpm(context.Background(), &pb.AppInstallParams{
-		Url: "https://invalid.example.com/nonexistent.rpm",
+		Url:            "https://invalid.example.com/nonexistent.rpm",
+		ChecksumSha256: strings.Repeat("a", 64),
 	}, pb.DesiredState_DESIRED_STATE_PRESENT)
 
 	if output != nil && strings.Contains(output.Stdout, "skipped") {
@@ -133,6 +137,11 @@ func TestExecuteRpm_DoesNotSkipWhenRpmPresent(t *testing.T) {
 	}
 	if err == nil {
 		t.Error("expected error from download/install of invalid URL, got nil")
+	}
+	// And it must NOT be rejected at the artifact guard (that would mean it
+	// failed before the tool check, not after).
+	if err != nil && strings.Contains(err.Error(), "artifact rejected") {
+		t.Errorf("valid action wrongly rejected at the artifact guard: %v", err)
 	}
 }
 

--- a/internal/executor/distro_skip_test.go
+++ b/internal/executor/distro_skip_test.go
@@ -17,8 +17,13 @@ func TestExecuteDeb_SkipsWhenDpkgMissing(t *testing.T) {
 	}
 
 	e := NewExecutor(nil)
+	// A well-formed action (https + checksum): the executor-boundary
+	// requireVerifiedArtifact guard runs before the dpkg lookup, so a
+	// checksum-less action would be rejected rather than skipped on a non-deb
+	// host (WS16 #2). Use a valid action so this test exercises the skip path.
 	output, changed, err := e.executeDeb(context.Background(), &pb.AppInstallParams{
-		Url: "https://example.com/test.deb",
+		Url:            "https://example.com/test.deb",
+		ChecksumSha256: strings.Repeat("a", 64),
 	}, pb.DesiredState_DESIRED_STATE_PRESENT)
 
 	if err != nil {
@@ -40,8 +45,11 @@ func TestExecuteRpm_SkipsWhenRpmMissing(t *testing.T) {
 	}
 
 	e := NewExecutor(nil)
+	// Well-formed action so requireVerifiedArtifact (which runs before the rpm
+	// lookup) passes and the test reaches the skip path on a non-rpm host.
 	output, changed, err := e.executeRpm(context.Background(), &pb.AppInstallParams{
-		Url: "https://example.com/test.rpm",
+		Url:            "https://example.com/test.rpm",
+		ChecksumSha256: strings.Repeat("a", 64),
 	}, pb.DesiredState_DESIRED_STATE_PRESENT)
 
 	if err != nil {
@@ -86,9 +94,12 @@ func TestExecuteDeb_DoesNotSkipWhenDpkgPresent(t *testing.T) {
 	}
 
 	e := NewExecutor(nil)
-	// Use an invalid URL so it fails after the tool check (proving it didn't skip)
+	// A well-formed action (https + valid checksum) so it passes the
+	// requireVerifiedArtifact guard and proceeds past the tool check; the
+	// unresolvable host then fails the download (proving it didn't skip).
 	output, _, err := e.executeDeb(context.Background(), &pb.AppInstallParams{
-		Url: "https://invalid.example.com/nonexistent.deb",
+		Url:            "https://invalid.example.com/nonexistent.deb",
+		ChecksumSha256: strings.Repeat("a", 64),
 	}, pb.DesiredState_DESIRED_STATE_PRESENT)
 
 	// Should NOT contain "skipped" — it should proceed and fail on download/install
@@ -97,6 +108,11 @@ func TestExecuteDeb_DoesNotSkipWhenDpkgPresent(t *testing.T) {
 	}
 	if err == nil {
 		t.Error("expected error from download/install of invalid URL, got nil")
+	}
+	// And it must NOT be rejected at the artifact guard (that would mean it
+	// failed before the tool check, not after).
+	if err != nil && strings.Contains(err.Error(), "artifact rejected") {
+		t.Errorf("valid action wrongly rejected at the artifact guard: %v", err)
 	}
 }
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -184,6 +184,31 @@ const maxFileContentSize = 10 << 20
 // defaultScriptTimeout is applied when no timeout is specified for script actions.
 const defaultScriptTimeout int32 = 3600
 
+// defaultPackageTimeout bounds PACKAGE/UPDATE actions that carry no explicit
+// timeout. Without it these ran under an unbounded context, so a wedged
+// apt/dnf operation (mirror outage, lock contention) could pin the action
+// forever (WS16 #3). 30 minutes is generous for a slow mirror + large upgrade
+// set yet refuses to hang indefinitely.
+const defaultPackageTimeout int32 = 1800
+
+// defaultTimeoutForAction returns the timeout (seconds) to apply to an action
+// when the operator set one (requested > 0 wins) or a default ceiling for the
+// long-running action classes. 0 means "no timeout" (the previous behaviour
+// for non-script, non-package actions).
+func defaultTimeoutForAction(actionType pb.ActionType, requested int32) int32 {
+	if requested > 0 {
+		return requested
+	}
+	switch actionType {
+	case pb.ActionType_ACTION_TYPE_SHELL, pb.ActionType_ACTION_TYPE_SCRIPT_RUN:
+		return defaultScriptTimeout
+	case pb.ActionType_ACTION_TYPE_PACKAGE, pb.ActionType_ACTION_TYPE_UPDATE:
+		return defaultPackageTimeout
+	default:
+		return 0
+	}
+}
+
 // containsNewline returns true if s contains \n or \r.
 func containsNewline(s string) bool {
 	return strings.ContainsAny(s, "\n\r")
@@ -226,6 +251,26 @@ type Executor struct {
 	// effects). nil in production → requireWritableFS calls the real
 	// e.repairFilesystem.
 	repairFS func(ctx context.Context) bool
+
+	// newPkgManager builds a per-action package manager bound to the action's
+	// context, so a PACKAGE/UPDATE timeout actually propagates to the package-
+	// manager subprocesses (the construction-time e.pkgManager is bound to
+	// context.Background). A seam so a test can capture the threaded context.
+	// nil → executor falls back to the construction-time e.pkgManager.
+	newPkgManager func(ctx context.Context) (*pkg.PackageManager, error)
+}
+
+// pkgManagerForCtx returns a package manager bound to ctx for this action, so
+// the per-action timeout reaches the underlying package-manager subprocesses.
+// Falls back to the construction-time manager when re-detection is unavailable
+// (e.g. the seam is unset or detection fails), preserving the prior behaviour.
+func (e *Executor) pkgManagerForCtx(ctx context.Context) *pkg.PackageManager {
+	if e.newPkgManager != nil {
+		if m, err := e.newPkgManager(ctx); err == nil && m != nil {
+			return m
+		}
+	}
+	return e.pkgManager
 }
 
 // NewExecutor creates a new action executor.
@@ -265,6 +310,19 @@ func NewExecutor(verifier *verify.ActionVerifier) *Executor {
 		verifier:   verifier,
 		logger:     logger,
 		now:        time.Now,
+		newPkgManager: func(ctx context.Context) (*pkg.PackageManager, error) {
+			m, err := pkg.DetectWithContext(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if m == nil {
+				// DetectWithContext returns ErrNoPackageManager (handled above)
+				// rather than (nil, nil) today; guard anyway so a future change
+				// can't wrap a nil Manager and nil-deref on first use.
+				return nil, nil
+			}
+			return pkg.NewPackageManager(m), nil
+		},
 	}
 }
 
@@ -375,11 +433,10 @@ func (e *Executor) ExecuteWithStreaming(ctx context.Context, env *pb.SignedActio
 		Changed:  true, // Default to true; scheduler may override based on output comparison
 	}
 
-	// Apply timeout. Default to 1 hour for script actions to prevent infinite loops.
-	timeout := env.GetTimeoutSeconds()
-	if timeout <= 0 && (env.ActionType == pb.ActionType_ACTION_TYPE_SHELL || env.ActionType == pb.ActionType_ACTION_TYPE_SCRIPT_RUN) {
-		timeout = defaultScriptTimeout
-	}
+	// Apply a per-action timeout. Long-running classes (scripts, and — WS16 #3
+	// — package/update operations) get a default ceiling when none is set so
+	// they cannot run unbounded.
+	timeout := defaultTimeoutForAction(env.ActionType, env.GetTimeoutSeconds())
 	if timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -268,6 +268,12 @@ func (e *Executor) pkgManagerForCtx(ctx context.Context) *pkg.PackageManager {
 	if e.newPkgManager != nil {
 		if m, err := e.newPkgManager(ctx); err == nil && m != nil {
 			return m
+		} else if ctx.Err() != nil {
+			// The action context is already cancelled/expired: don't fall back
+			// to the construction-time (Background-bound) manager, which would
+			// silently bypass the timeout/cancel guarantee. nil → the caller
+			// fails closed with "no package manager".
+			return nil
 		}
 	}
 	return e.pkgManager

--- a/internal/executor/integration_test.go
+++ b/internal/executor/integration_test.go
@@ -2469,6 +2469,10 @@ func TestIntegration_EdgeCase_DownloadHttp500(t *testing.T) {
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_DEB, pb.DesiredState_DESIRED_STATE_PRESENT)
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
 			Url: ts.URL + "/test.deb",
+			// Checksum is mandated and the executor fails closed without it
+			// before downloading (WS16 #2); the value is irrelevant here — the
+			// download errors with the HTTP status first.
+			ChecksumSha256: strings.Repeat("a", 64),
 		}}
 		result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
 		assertFailed(t, result)
@@ -2521,6 +2525,10 @@ func TestIntegration_EdgeCase_DownloadHttp404(t *testing.T) {
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_DEB, pb.DesiredState_DESIRED_STATE_PRESENT)
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
 			Url: ts.URL + "/test.deb",
+			// Checksum is mandated and the executor fails closed without it
+			// before downloading (WS16 #2); the value is irrelevant here — the
+			// download errors with the HTTP status first.
+			ChecksumSha256: strings.Repeat("a", 64),
 		}}
 		result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
 		assertFailed(t, result)

--- a/internal/executor/package_timeout_test.go
+++ b/internal/executor/package_timeout_test.go
@@ -87,6 +87,31 @@ func TestExecutePackage_BindsManagerToActionContext(t *testing.T) {
 	}
 }
 
+// TestPkgManagerForCtx_CancelledCtx_FailsClosed pins that when the per-action
+// manager cannot be built and the action context is already cancelled/expired,
+// pkgManagerForCtx returns nil (fail closed) rather than falling back to the
+// construction-time Background-bound manager — which would silently bypass the
+// timeout/cancel guarantee. With a live ctx, a builder error still falls back.
+func TestPkgManagerForCtx_CancelledCtx_FailsClosed(t *testing.T) {
+	fallback := pkg.NewPackageManager(alreadyInstalledManager{})
+	e := &Executor{
+		pkgManager: fallback,
+		newPkgManager: func(context.Context) (*pkg.PackageManager, error) {
+			return nil, context.Canceled // simulate a creation failure
+		},
+	}
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if mgr := e.pkgManagerForCtx(cancelledCtx); mgr != nil {
+		t.Error("a cancelled action ctx must fail closed (nil), not fall back to the Background-bound manager")
+	}
+
+	if mgr := e.pkgManagerForCtx(context.Background()); mgr != fallback {
+		t.Error("with a live ctx, a builder error should fall back to the construction-time manager")
+	}
+}
+
 // alreadyInstalledManager implements pkg.Manager reporting the package present,
 // so executePackage returns at the version/pin check without touching the
 // filesystem or shelling out. Only IsInstalled is reached.

--- a/internal/executor/package_timeout_test.go
+++ b/internal/executor/package_timeout_test.go
@@ -1,0 +1,95 @@
+package executor
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/pkg"
+)
+
+// WS16 #3: PACKAGE/UPDATE actions previously got no default timeout (only
+// SHELL/SCRIPT_RUN did) and ran their package-manager operations under
+// context.Background, so a per-action timeout never bit. defaultTimeoutForAction
+// now covers package/update, and executePackage/executeUpdate re-bind a
+// ctx-aware manager.
+
+func TestDefaultTimeoutForAction(t *testing.T) {
+	cases := []struct {
+		name      string
+		actType   pb.ActionType
+		requested int32
+		want      int32
+	}{
+		{"explicit timeout always wins", pb.ActionType_ACTION_TYPE_PACKAGE, 42, 42},
+		{"shell default", pb.ActionType_ACTION_TYPE_SHELL, 0, defaultScriptTimeout},
+		{"script default", pb.ActionType_ACTION_TYPE_SCRIPT_RUN, 0, defaultScriptTimeout},
+		{"package default (was unbounded)", pb.ActionType_ACTION_TYPE_PACKAGE, 0, defaultPackageTimeout},
+		{"update default (was unbounded)", pb.ActionType_ACTION_TYPE_UPDATE, 0, defaultPackageTimeout},
+		{"other action: no timeout", pb.ActionType_ACTION_TYPE_FILE, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := defaultTimeoutForAction(tc.actType, tc.requested); got != tc.want {
+				t.Errorf("defaultTimeoutForAction(%v, %d) = %d, want %d", tc.actType, tc.requested, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExecutePackage_BindsManagerToActionContext proves the package-manager is
+// re-bound to the action's (timeout-bearing) context, not the construction-time
+// Background context — so a cancelled action ctx propagates to the manager's
+// subprocesses. The stub reports the package already installed so executePackage
+// returns at the version/pin check without any privileged side effects.
+func TestExecutePackage_BindsManagerToActionContext(t *testing.T) {
+	capturedCh := make(chan context.Context, 1)
+	e := &Executor{
+		logger: slog.Default(),
+		now:    time.Now,
+		newPkgManager: func(ctx context.Context) (*pkg.PackageManager, error) {
+			select {
+			case capturedCh <- ctx:
+			default:
+			}
+			return pkg.NewPackageManager(alreadyInstalledManager{}), nil
+		},
+	}
+
+	actionCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		// PACKAGE present, no version/pin → returns "already installed".
+		_, _, _ = e.executePackage(actionCtx, &pb.PackageParams{Name: "anything"}, pb.DesiredState_DESIRED_STATE_PRESENT)
+	}()
+
+	var captured context.Context
+	select {
+	case captured = <-capturedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("executePackage never requested a context-bound package manager (WS16 #3)")
+	}
+
+	if captured == context.Background() {
+		t.Fatal("manager was bound to context.Background, not the action context (WS16 #3)")
+	}
+
+	// Cancelling the action context must propagate to the captured context —
+	// proving it is the action's ctx, which the backend uses for its subprocess
+	// deadlines.
+	cancel()
+	select {
+	case <-captured.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("captured manager context did not observe the action-context cancel")
+	}
+}
+
+// alreadyInstalledManager implements pkg.Manager reporting the package present,
+// so executePackage returns at the version/pin check without touching the
+// filesystem or shelling out. Only IsInstalled is reached.
+type alreadyInstalledManager struct{ pkg.Manager }
+
+func (alreadyInstalledManager) IsInstalled(string) (bool, error) { return true, nil }

--- a/internal/handler/terminal.go
+++ b/internal/handler/terminal.go
@@ -387,10 +387,12 @@ func (h *Handler) OnTerminalStart(ctx context.Context, req *pb.TerminalStart) er
 		cleanup()
 	}
 
-	// Activate the shell. usermod via the SDK helper which already
-	// uses sudo -n. Note: sysuser.Modify ignores the context for
-	// cancellation today (it shells out via sudo), so we still gate
-	// on isStopping() between steps as a fallback.
+	// Activate the shell. usermod via the SDK helper which already uses
+	// sudo -n. sysuser.Modify honors the context (it shells out via
+	// exec.Privileged → Run, which cancels and SIGKILL-escalates the process
+	// group on ctx expiry), so a bounded ctx (e.g. the shutdown teardown's 30s
+	// deadline) does bite; we still gate on isStopping() between steps as a
+	// belt-and-suspenders fallback.
 	if ts.isStopping() {
 		abortStopped()
 		return nil

--- a/internal/handler/terminal.go
+++ b/internal/handler/terminal.go
@@ -742,6 +742,26 @@ func (h *Handler) closeTerminal(ctx context.Context, sessionID, reason string) {
 	}
 }
 
+// CloseAllTerminals tears down every live terminal session — used on agent
+// shutdown so a session left open does not leave its pm-tty shell activated and
+// its temp home on disk (WS16 #5). It snapshots the session ids under h.mu,
+// then closes each via the idempotent closeTerminal (which cancels the session
+// ctx so the pump goroutine unblocks, reverts the shell when no other session
+// for that user remains, and removes the temp home). Safe to call with no
+// sessions.
+func (h *Handler) CloseAllTerminals(ctx context.Context) {
+	h.mu.Lock()
+	ids := make([]string, 0, len(h.terminals))
+	for id := range h.terminals {
+		ids = append(ids, id)
+	}
+	h.mu.Unlock()
+
+	for _, id := range ids {
+		h.closeTerminal(ctx, id, "agent shutdown")
+	}
+}
+
 // anySessionForUserExcept reports whether any active session in the
 // registry has the given tty user, ignoring the supplied session id.
 // Used by OnTerminalStart's cleanup path to decide whether reverting

--- a/internal/handler/terminal_shutdown_test.go
+++ b/internal/handler/terminal_shutdown_test.go
@@ -1,0 +1,126 @@
+package handler
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// WS16 #5: live terminal sessions were not torn down on agent shutdown — the
+// pm-tty shell stayed activated and the temp home leaked. CloseAllTerminals
+// reverts every live session.
+
+// registerLiveSession injects an active session with a real temp home and a
+// cancel spy, mirroring addTestSession but with the teardown-observable fields.
+func registerLiveSession(t *testing.T, h *Handler, id, ttyUser string, cancelled *int32) string {
+	t.Helper()
+	tempHome := filepath.Join(t.TempDir(), "home-"+id)
+	if err := os.MkdirAll(tempHome, 0o700); err != nil {
+		t.Fatalf("mkdir temp home: %v", err)
+	}
+	ts := &terminalSession{
+		id:       id,
+		ttyUser:  ttyUser,
+		state:    sessionStateActive,
+		tempHome: tempHome,
+		cancel:   func() { atomic.StoreInt32(cancelled, 1) },
+		now:      time.Now,
+	}
+	h.mu.Lock()
+	if h.terminals == nil {
+		h.terminals = make(map[string]*terminalSession)
+	}
+	h.terminals[id] = ts
+	h.mu.Unlock()
+	return tempHome
+}
+
+func TestCloseAllTerminals_RevertsLiveSessions(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	var cancelledA, cancelledB int32
+	homeA := registerLiveSession(t, h, "01ARZ3NDEKTSV4RRFFQ69G5FAV", "pm-tty-a", &cancelledA)
+	homeB := registerLiveSession(t, h, "01ARZ3NDEKTSV4RRFFQ69G5FAW", "pm-tty-b", &cancelledB)
+
+	h.CloseAllTerminals(context.Background())
+
+	// Registry must be empty — every live session was closed.
+	h.mu.Lock()
+	n := len(h.terminals)
+	h.mu.Unlock()
+	if n != 0 {
+		t.Errorf("registry has %d sessions after CloseAllTerminals, want 0", n)
+	}
+
+	// Each session's ctx must have been cancelled (so its pump goroutine unblocks).
+	if atomic.LoadInt32(&cancelledA) != 1 || atomic.LoadInt32(&cancelledB) != 1 {
+		t.Error("CloseAllTerminals did not cancel every session context")
+	}
+
+	// Temp homes must be removed.
+	for _, home := range []string{homeA, homeB} {
+		if _, err := os.Stat(home); !os.IsNotExist(err) {
+			t.Errorf("temp home %s not removed (stat err=%v)", home, err)
+		}
+	}
+}
+
+func TestCloseAllTerminals_NoSessions_IsNoOp(t *testing.T) {
+	h, _ := newTestHandler(t)
+	// Must not panic with an empty/unset registry.
+	h.CloseAllTerminals(context.Background())
+
+	h.mu.Lock()
+	n := len(h.terminals)
+	h.mu.Unlock()
+	if n != 0 {
+		t.Errorf("registry should be empty, got %d", n)
+	}
+}
+
+func TestCloseAllTerminals_AlreadyStopping_NotDoubleReverted(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	tempHome := filepath.Join(t.TempDir(), "stopping-home")
+	if err := os.MkdirAll(tempHome, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	ts := &terminalSession{
+		id:       "01ARZ3NDEKTSV4RRFFQ69G5FAX",
+		ttyUser:  "pm-tty-stop",
+		state:    sessionStateStopping, // already being torn down elsewhere
+		tempHome: tempHome,
+		now:      time.Now,
+	}
+	h.mu.Lock()
+	h.terminals[ts.id] = ts
+	h.mu.Unlock()
+
+	h.CloseAllTerminals(context.Background())
+
+	// A session already in the stopping state must NOT be torn down again:
+	// its temp home stays (the in-flight teardown owns it).
+	if _, err := os.Stat(tempHome); err != nil {
+		t.Errorf("a stopping session must not be double-reverted; temp home gone: %v", err)
+	}
+}
+
+// TestMain_ShutdownClosesLiveTerminals is a self-discovering guard: the agent
+// main shutdown path must invoke CloseAllTerminals, or a session left open at
+// shutdown leaks its activated shell. Fails if the caller is removed.
+func TestMain_ShutdownClosesLiveTerminals(t *testing.T) {
+	src, err := os.ReadFile("../../cmd/power-manage-agent/main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	if len(src) == 0 {
+		t.Fatal("main.go empty — guard would pass vacuously")
+	}
+	if !strings.Contains(string(src), "CloseAllTerminals(") {
+		t.Error("agent main shutdown must call h.CloseAllTerminals (WS16 #5)")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -732,13 +732,16 @@ func (s *Store) SyncActions(actions []*pb.Action) (*SyncResult, error) {
 	// Identify and load removed actions (for undo), then delete them
 	for localID, la := range localActions {
 		if _, exists := serverActions[localID]; !exists {
-			// Load the full action for undo
+			// Load the full action for undo. WS16 #4: fail closed — a removed
+			// action whose stored JSON can't decode must NOT be deleted, or it
+			// vanishes without ever reverting its side effects (SSH/sudo/etc.)
+			// and the store and device drift apart. Keep the row so a later
+			// sync (after the corruption is resolved) can still revert it.
 			action := &pb.Action{}
 			if err := protojson.Unmarshal([]byte(la.actionJSON), action); err != nil {
-				slog.Warn("failed to unmarshal removed action for undo", "action_id", localID, "error", err)
-			} else {
-				result.RemovedActions = append(result.RemovedActions, action)
+				return nil, fmt.Errorf("removed action %s has undecodable stored JSON; refusing to delete without revert: %w", localID, err)
 			}
+			result.RemovedActions = append(result.RemovedActions, action)
 			if _, err := tx.Exec("DELETE FROM actions WHERE id = ?", localID); err != nil {
 				return nil, fmt.Errorf("delete action %s: %w", localID, err)
 			}
@@ -888,12 +891,13 @@ func (s *Store) SyncStandaloneAndGrouped(standalone []*pb.Action, groups []*pb.A
 		// members that simply migrated to standalone (or vice versa)
 		// were already handled by the upsert below in past syncs.
 		if la.isGrouped == 0 {
+			// WS16 #4: fail closed on an undecodable removed standalone action
+			// rather than deleting it without ever reverting its side effects.
 			action := &pb.Action{}
 			if err := protojson.Unmarshal([]byte(la.actionJSON), action); err != nil {
-				slog.Warn("failed to unmarshal removed action for undo", "action_id", localID, "error", err)
-			} else {
-				result.RemovedActions = append(result.RemovedActions, action)
+				return nil, fmt.Errorf("removed standalone action %s has undecodable stored JSON; refusing to delete without revert: %w", localID, err)
 			}
+			result.RemovedActions = append(result.RemovedActions, action)
 		}
 		if _, err := tx.Exec("DELETE FROM actions WHERE id = ?", localID); err != nil {
 			return nil, fmt.Errorf("delete action %s: %w", localID, err)
@@ -1149,7 +1153,7 @@ func (s *Store) GetGroupByID(groupID string) (*StoredActionGroup, error) {
 		SELECT id, source_label, schedule_json, last_executed_at, next_execute_at
 		FROM action_groups WHERE id = ?
 	`, groupID).Scan(&g.ID, &g.SourceLabel, &schedJSON, &lastExec, &g.NextExecuteAt)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/internal/store/store_errnorows_test.go
+++ b/internal/store/store_errnorows_test.go
@@ -1,0 +1,43 @@
+package store
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// WS16 #12: GetGroupByID compared err == sql.ErrNoRows, which a wrapped
+// sentinel would slip past. It now uses errors.Is. A missing group must still
+// resolve to (nil, nil).
+func TestGetGroupByID_MissingReturnsNilNil(t *testing.T) {
+	st, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New store: %v", err)
+	}
+	defer st.Close()
+
+	g, err := st.GetGroupByID("01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	if err != nil {
+		t.Fatalf("a missing group must not error, got: %v", err)
+	}
+	if g != nil {
+		t.Fatalf("a missing group must return nil, got: %+v", g)
+	}
+}
+
+// TestStore_NoBareErrNoRowsComparison is a self-discovering guard: store.go
+// must compare sql.ErrNoRows via errors.Is, never ==, so a wrapped sentinel is
+// handled. Guards against a vacuous pass on an empty/missing file.
+func TestStore_NoBareErrNoRowsComparison(t *testing.T) {
+	src, err := os.ReadFile("store.go")
+	if err != nil {
+		t.Fatalf("read store.go: %v", err)
+	}
+	if len(src) == 0 {
+		t.Fatal("store.go is empty — the guard would pass vacuously")
+	}
+	s := string(src)
+	if strings.Contains(s, "== sql.ErrNoRows") || strings.Contains(s, "sql.ErrNoRows ==") {
+		t.Error("store.go must use errors.Is(err, sql.ErrNoRows), not a == comparison (WS16 #12)")
+	}
+}

--- a/internal/store/sync_failclosed_test.go
+++ b/internal/store/sync_failclosed_test.go
@@ -1,0 +1,68 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// WS16 #4: a removed policy action whose stored JSON can't unmarshal was
+// Warn-and-deleted — the action vanished without ever reverting its side
+// effects (SSH/sudo/etc.), drifting store and device apart. The removal path
+// must now fail closed: do NOT delete a row it cannot decode for revert.
+
+func actionRowExists(t *testing.T, st *Store, id string) bool {
+	t.Helper()
+	var n int
+	require.NoError(t, st.db.QueryRow("SELECT count(*) FROM actions WHERE id = ?", id).Scan(&n))
+	return n > 0
+}
+
+func TestSyncActions_RemovedActionUnmarshalFailure_DoesNotDeleteWithoutRevert(t *testing.T) {
+	st, err := New(t.TempDir())
+	require.NoError(t, err)
+	defer st.Close()
+
+	a := &pb.Action{
+		Id:           &pb.ActionId{Value: "corrupt-removed"},
+		Type:         pb.ActionType_ACTION_TYPE_PACKAGE,
+		DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
+	}
+	_, err = st.SyncActions([]*pb.Action{a})
+	require.NoError(t, err)
+
+	// Corrupt the stored JSON so the removal-undo decode fails.
+	_, err = st.db.Exec("UPDATE actions SET action_json = ? WHERE id = ?", "not-valid-protojson", a.Id.Value)
+	require.NoError(t, err)
+
+	// Server now reports no actions → the local action is "removed".
+	_, err = st.SyncActions(nil)
+	require.Error(t, err, "a removed action with undecodable JSON must fail closed, not silently delete")
+	assert.True(t, actionRowExists(t, st, a.Id.Value),
+		"the undecodable action row must remain (no delete without revert)")
+}
+
+func TestSyncStandaloneAndGrouped_RemovedActionUnmarshalFailure_DoesNotDeleteWithoutRevert(t *testing.T) {
+	st, err := New(t.TempDir())
+	require.NoError(t, err)
+	defer st.Close()
+
+	a := &pb.Action{
+		Id:           &pb.ActionId{Value: "corrupt-standalone"},
+		Type:         pb.ActionType_ACTION_TYPE_PACKAGE,
+		DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
+	}
+	_, err = st.SyncStandaloneAndGrouped([]*pb.Action{a}, nil)
+	require.NoError(t, err)
+
+	_, err = st.db.Exec("UPDATE actions SET action_json = ? WHERE id = ?", "not-valid-protojson", a.Id.Value)
+	require.NoError(t, err)
+
+	_, err = st.SyncStandaloneAndGrouped(nil, nil)
+	require.Error(t, err, "a removed standalone action with undecodable JSON must fail closed, not silently delete")
+	assert.True(t, actionRowExists(t, st, a.Id.Value),
+		"the undecodable action row must remain (no delete without revert)")
+}


### PR DESCRIPTION
## WS16 error-discipline — agent (findings #2, #3, #4, #5, #12, #13)

Each fix is written red-first; verification-charter tests pin the rejection paths.

### #2 — DEB install fail-closed guard (closes #127, part 1)
`executeDeb` now runs the same `requireVerifiedArtifact` guard as `executeRpm` (https + non-empty checksum) **before** the dpkg lookup. `downloadFile` enforces https but **skips checksum verification when the checksum is empty**, so this executor-boundary guard refuses an unverified `.deb` on every host rather than relying on the proto/server alone. **RPM and AppImage were already guarded (WS7/WS8) — verified, untouched.** The distro-skip tests now carry a checksum so they pass regardless of which package tool the host has.

### #3 — per-action timeout for PACKAGE/UPDATE (closes #127, part 2)
PACKAGE/UPDATE got **no** default timeout before (only SHELL/SCRIPT_RUN did) and ran their package-manager operations under `context.Background`. Now `defaultTimeoutForAction` gives them a 30-minute ceiling when none is set, and `executePackage`/`executeUpdate` re-bind a ctx-aware manager via `pkg.DetectWithContext(ctx)` so the per-action timeout reaches the `apt`/`dnf`/`zypper`/`pacman` subprocesses. (The apt/dnf-specific upgrade paths already used `NewAptWithContext`.)

### #4 — fail closed on corrupt removed-action unmarshal (closes #128, part 1)
`SyncActions` and `SyncStandaloneAndGrouped` no longer Warn-and-delete a removed action whose stored JSON can't decode — that dropped the action without ever reverting its SSH/sudo side effects, drifting store and device apart. They now return a hard error and keep the row.

### #5 — tear down live terminals on shutdown (closes #128, part 2)
`CloseAllTerminals` reverts every live terminal session (pm-tty shell → nologin, temp home removed, pump ctx cancelled). `main` wires it into the shutdown sequence before `StopTerminalSweeper`, with a fresh bounded ctx so the run-ctx cancel doesn't abort the shell-revert. Self-discovering guard fails if the caller is removed.

### #12 / #13 — errors.Is for sentinels (closes #129)
`store.GetGroupByID` (`sql.ErrNoRows`) and `cmd_query` (`osquery.ErrNotInstalled`) use `errors.Is`; `isNotInstalled` extracts the predicate for testing. Self-discovering guard pins no `== sql.ErrNoRows` remains in store.go.

### Gates
`gofmt` / `go vet` / `staticcheck` (`inherit,-SA1019,-U1000`) clean; `go build ./...` ok; full `go test ./... -race` green. Local CodeRabbit: one finding fixed (nil-guard on `NewPackageManager` — defense-in-depth); one false positive (a 'test premature for layer' note — the wiring is present and the test is non-vacuous, with a t.Fatal on the no-capture path).

Part of the security/RBAC hardening work plan (WS16).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Package and update actions now respect per-action timeout settings, with a 30-minute default ceiling.

* **Bug Fixes**
  * Improved detection of missing tools with wrapped errors.
  * Artifact validation now occurs before privileged filesystem operations.
  * Agent gracefully closes all active terminal sessions during shutdown.
  * Store operations now properly handle missing or corrupted action data with fail-closed behavior.

* **Documentation**
  * Updated package action timeout documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->