### PR TITLE
Exhaustive rejection-path test hardening for executor/scheduler/store/handler/cmd (WS17a)

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,20 @@ power-manage-agent tty status
 
 Exit code 0 = enabled, 1 = disabled. Combined with `is_compliance=true` + `compliance_expected_output=enabled` (or `disabled`), admins can report on fleet-wide TTY state without a new action type.
 
+### Inbound-message & action-input validation (WS17a)
+
+The agent treats every server/gateway-supplied field that reaches a filesystem path, a shell, or a privileged call as untrusted and validates it before use. These device-side rejection guards are exercised by dedicated rejection-path tests:
+
+- **TTY `session_id` is validated as a ULID.** `TerminalStart.session_id` is spliced into the per-session `/tmp/<tty-user>.<session-id>` directory that is created and `chown`-ed as root, so it must parse as a ULID. Path-meaningful values (`../../etc`, `a/b`), embedded NULs, and the empty string are refused before any filesystem use; together with the validated `pm-tty-*` username this makes the joined path unable to escape `/tmp`.
+- **Locked/disabled TTY users are refused.** A `pm-tty-*` account that is shadow-locked cannot open a session.
+- **`FILE` actions refuse to overwrite a directory.** Writing a file to a path that already exists as a directory reports `FAILED` and leaves the directory untouched, rather than moving a temp file inside it (WS6).
+- **`WIFI` action IDs are filesystem-validated.** The action ID is run through the same `validateActionIDForFilesystem` guard the sudo/ssh/sshd executors use before it is spliced into the EAP-TLS cert directory or the `pm-wifi-<id>` connection name.
+- **`SHELL` env vars go through the SDK hijack allow-list.** Caller-supplied `LD_PRELOAD` / `PATH` / `LD_LIBRARY_PATH` and friends are refused before the interpreter is launched.
+- **The gateway URL must be `https://host`.** Cleartext / h2c / opaque / hostless gateway URLs are refused before the mTLS dial (WS15).
+- **osquery refuses credential-bearing tables.** The SDK's convenience table path denies `shadow` / `process_envs` / `crontab` / `shell_history` / `sudoers` (the signed `RawSql` escape hatch is unaffected) — see the SDK README.
+
+CI runs the agent unit/arch suite (`go test -race ./...`, no build tags) separately from the per-distro `-tags=integration` executor suite, so these pure-function and handler-level guards are covered without requiring root or a real device.
+
 ## Logging
 
 Logs are written to stdout/stderr and can be collected by systemd journal:

--- a/cmd/power-manage-agent/backend.go
+++ b/cmd/power-manage-agent/backend.go
@@ -14,6 +14,11 @@ import (
 	sysservice "github.com/manchtools/power-manage/sdk/go/sys/service"
 )
 
+// geteuidFn is a seam over os.Geteuid so the empty-default privilege branch
+// (root vs sudo) can be exercised deterministically in a normal non-root test
+// run instead of depending on the runner's real uid.
+var geteuidFn = os.Geteuid
+
 // randomBackoff returns a random duration between minInitialBackoff and maxInitialBackoff.
 func randomBackoff() time.Duration {
 	jitter := rand.Int64N(int64(maxInitialBackoff - minInitialBackoff))
@@ -101,7 +106,7 @@ func setPrivilegeBackend(backend string, logger *slog.Logger) error {
 		sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendSudo)
 		privilegeTool = "sudo"
 	case "":
-		if os.Geteuid() == 0 {
+		if geteuidFn() == 0 {
 			sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendRoot)
 			privilegeTool = ""
 		} else {

--- a/cmd/power-manage-agent/backend_test.go
+++ b/cmd/power-manage-agent/backend_test.go
@@ -35,6 +35,13 @@ func TestApplyBackendOverrides_PrivilegeBackend(t *testing.T) {
 	defer sysservice.SetServiceBackend(sysservice.ServiceBackendSystemd)
 	defer sysenc.SetBackend(sysenc.BackendLUKS)
 
+	// Force a non-root euid so "empty defaults to sudo" is deterministic even
+	// when this runs under root (e.g. the privileged CI job) — the empty
+	// default is euid-coupled and would otherwise resolve to the root backend.
+	origEuid := geteuidFn
+	t.Cleanup(func() { geteuidFn = origEuid })
+	geteuidFn = func() int { return 1000 }
+
 	// Build a PATH where every backend binary we care about exists
 	// as an empty executable, so LookPath succeeds without actually
 	// running any of them.
@@ -111,6 +118,97 @@ func TestApplyBackendOverrides_MissingPrivilegeBinaryIsFatal(t *testing.T) {
 	if !strings.Contains(err.Error(), "doas") {
 		t.Errorf("error should mention doas, got: %v", err)
 	}
+}
+
+// The empty-string privilege default is security-relevant: it must pick the
+// no-escalation root backend when the agent runs as root (uid 0) and sudo
+// otherwise. Drive both branches deterministically via the geteuidFn seam so a
+// normal non-root CI run still proves the root default, instead of the silent
+// euid-coupled "want=sudo" the previous test baked in.
+func TestSetPrivilegeBackend_EmptyDefault_BranchesOnEuid(t *testing.T) {
+	defer sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendSudo)
+	origEuid := geteuidFn
+	t.Cleanup(func() { geteuidFn = origEuid })
+
+	// fake sudo so the non-root branch's LookPath("sudo") succeeds regardless
+	// of the host PATH.
+	t.Setenv("PATH", fakePathWith(t, "sudo"))
+
+	t.Run("euid 0 selects the root backend (no escalation tool)", func(t *testing.T) {
+		geteuidFn = func() int { return 0 }
+		if err := setPrivilegeBackend("", discardLogger()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := sysexec.CurrentPrivilegeBackend(); got != sysexec.PrivilegeBackendRoot {
+			t.Errorf("empty default at euid 0 = %v, want Root", got)
+		}
+	})
+
+	t.Run("euid 1000 selects the sudo backend", func(t *testing.T) {
+		geteuidFn = func() int { return 1000 }
+		if err := setPrivilegeBackend("", discardLogger()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := sysexec.CurrentPrivilegeBackend(); got != sysexec.PrivilegeBackendSudo {
+			t.Errorf("empty default at euid 1000 = %v, want Sudo", got)
+		}
+	})
+}
+
+// The service backend mirrors the privilege backend's three behaviours:
+// a known value whose binary is missing is fatal; a known scaffold value with
+// its binary present is selected (and warns); an unknown value falls back to
+// systemd WITHOUT erroring (fail-safe, not fail-open to the bogus name).
+func TestApplyBackendOverrides_ServiceBackend(t *testing.T) {
+	defer sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendSudo)
+	defer sysservice.SetServiceBackend(sysservice.ServiceBackendSystemd)
+	defer sysenc.SetBackend(sysenc.BackendLUKS)
+
+	// Non-root so the empty privilege default lands on sudo (present in PATH).
+	origEuid := geteuidFn
+	t.Cleanup(func() { geteuidFn = origEuid })
+	geteuidFn = func() int { return 1000 }
+
+	t.Run("openrc with rc-service missing is fatal", func(t *testing.T) {
+		t.Setenv("PATH", fakePathWith(t, "sudo", "cryptsetup")) // no rc-service
+		err := applyBackendOverrides(&Config{ServiceBackend: "openrc"}, discardLogger())
+		if err == nil {
+			t.Fatal("expected a fatal error when rc-service is missing")
+		}
+		if !strings.Contains(err.Error(), "rc-service") {
+			t.Errorf("error should mention rc-service, got: %v", err)
+		}
+	})
+
+	t.Run("openrc with rc-service present selects OpenRC", func(t *testing.T) {
+		t.Setenv("PATH", fakePathWith(t, "sudo", "cryptsetup", "rc-service"))
+		if err := applyBackendOverrides(&Config{ServiceBackend: "openrc"}, discardLogger()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := sysservice.CurrentServiceBackend(); got != sysservice.ServiceBackendOpenRC {
+			t.Errorf("service backend = %v, want OpenRC", got)
+		}
+	})
+
+	t.Run("unknown value falls back to systemd, no error", func(t *testing.T) {
+		t.Setenv("PATH", fakePathWith(t, "sudo", "cryptsetup", "systemctl"))
+		if err := applyBackendOverrides(&Config{ServiceBackend: "bogus"}, discardLogger()); err != nil {
+			t.Fatalf("unknown service backend must not error: %v", err)
+		}
+		if got := sysservice.CurrentServiceBackend(); got != sysservice.ServiceBackendSystemd {
+			t.Errorf("service backend = %v, want Systemd (fail-safe fallback)", got)
+		}
+	})
+
+	t.Run("empty defaults to systemd", func(t *testing.T) {
+		t.Setenv("PATH", fakePathWith(t, "sudo", "cryptsetup", "systemctl"))
+		if err := applyBackendOverrides(&Config{ServiceBackend: ""}, discardLogger()); err != nil {
+			t.Fatalf("empty service backend must not error: %v", err)
+		}
+		if got := sysservice.CurrentServiceBackend(); got != sysservice.ServiceBackendSystemd {
+			t.Errorf("service backend = %v, want Systemd", got)
+		}
+	})
 }
 
 // fakePathWith creates empty executables for each named tool in a

--- a/cmd/power-manage-agent/cert_reload_test.go
+++ b/cmd/power-manage-agent/cert_reload_test.go
@@ -28,6 +28,14 @@ func testCreds(cert string) *credentials.Credentials {
 // than the stale in-memory copy that would fail the handshake once
 // expired.
 func TestReloadCredsForReconnect_PicksUpRotatedCert(t *testing.T) {
+	// store.Save derives its at-rest key from the machine ID; on a host without
+	// /etc/machine-id (or /var/lib/dbus/machine-id) it cannot save. Skip cleanly
+	// rather than hard-fail via require.NoError below — matching the
+	// requireMachineID guard the internal/credentials tests use.
+	if !credentials.MachineIDAvailable() {
+		t.Skip("no machine-id on this host; credential save/load is unavailable")
+	}
+
 	dir := t.TempDir()
 	store := credentials.NewStore(dir)
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.11
 require (
 	connectrpc.com/connect v1.18.1
 	github.com/manchtools/power-manage/sdk v0.2.1
+	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pressly/goose/v3 v3.26.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.11.1
@@ -45,7 +46,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/oklog/ulid/v2 v2.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260615081409-a1beb65c5258 h1:9uRZbSw49MYLFgWso3q4oeXXm99cev+etin/pKqe9+I=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260615081409-a1beb65c5258/go.mod h1:4YgWcixbkSLTu5Ds8m/b/EfwGNRqUsOaC/nMgTyAwxo=
 github.com/manchtools/power-manage-sdk v0.4.1-0.20260615140649-541787e0a9aa h1:ZecW1N21gMkOapR1XYGk9PxeQ5iANjZZUeO/wnUfm74=
 github.com/manchtools/power-manage-sdk v0.4.1-0.20260615140649-541787e0a9aa/go.mod h1:4YgWcixbkSLTu5Ds8m/b/EfwGNRqUsOaC/nMgTyAwxo=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -310,6 +310,15 @@ var getMachineID = func() ([]byte, error) {
 	return nil, errors.New("machine ID not found")
 }
 
+// MachineIDAvailable reports whether a machine ID can be read on this host.
+// Credential save/load (and cert rotation, which round-trips through the
+// credential store) need it for the KDF binding, so cmd-level tests use this to
+// skip cleanly on machine-id-less hosts rather than hard-failing.
+func MachineIDAvailable() bool {
+	_, err := getMachineID()
+	return err == nil
+}
+
 // encrypt encrypts plaintext using AES-256-GCM.
 func encrypt(key, plaintext []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)

--- a/internal/executor/action_update.go
+++ b/internal/executor/action_update.go
@@ -15,43 +15,73 @@ import (
 	sysnotify "github.com/manchtools/power-manage/sdk/go/sys/notify"
 )
 
-// hasUpdatesAvailable checks if there are pending package updates.
-// Uses exit codes and structured queries — language-agnostic.
-func (e *Executor) hasUpdatesAvailable(ctx context.Context, securityOnly bool) bool {
-	if pkg.IsDnf() {
-		// dnf check-update: exit 100 = updates available, 0 = none (language-agnostic)
-		args := []string{"check-update"}
-		if securityOnly {
-			args = append(args, "--security")
-		}
-		_, exitCode, _ := queryCmdOutput("dnf", args...)
+// Seams so the security-only-upgrade and reboot-scheduling paths can be
+// exercised with fixtures instead of a live host. Production binds them to the
+// real implementations; tests stub them.
+var (
+	execLookPath = exec.LookPath
+	notifyAll    = sysnotify.NotifyAll
+)
+
+// interpretUpdateCheck maps a package manager's update-check result (its
+// stdout and exit code) onto "are updates available?". It is the pure,
+// language-agnostic decision extracted from hasUpdatesAvailable so it can be
+// exercised with fixtures rather than a live host — giving every manager
+// (notably zypper) a real assertion instead of a logged smoke value.
+//
+//   - dnf:    check-update exit 100 = updates, 0 = none
+//   - apt:    `-s upgrade` simulate; any "Inst " line = updates
+//   - pacman: -Qu exit 0 = updates, 1 = none
+//   - zypper: list-updates exit 100 = updates, 0 = none
+//   - unknown manager: assume updates (fail safe toward running the update)
+func interpretUpdateCheck(manager, stdout string, exitCode int) bool {
+	switch manager {
+	case "dnf":
 		return exitCode == 100
-	}
-	if pkg.IsApt() {
-		// apt/apt-get -s upgrade: simulate and count lines with "Inst " prefix (language-agnostic)
-		aptCmd := "apt-get"
-		if _, err := exec.LookPath("apt"); err == nil {
-			aptCmd = "apt"
-		}
-		out, _, _ := queryCmdOutput(aptCmd, "-s", "upgrade")
-		for _, line := range strings.Split(out, "\n") {
+	case "apt":
+		for _, line := range strings.Split(stdout, "\n") {
 			if strings.HasPrefix(line, "Inst ") {
 				return true
 			}
 		}
 		return false
+	case "pacman":
+		return exitCode == 0
+	case "zypper":
+		return exitCode == 100
+	default:
+		return true
+	}
+}
+
+// hasUpdatesAvailable checks if there are pending package updates.
+// Uses exit codes and structured queries — language-agnostic.
+func (e *Executor) hasUpdatesAvailable(ctx context.Context, securityOnly bool) bool {
+	if pkg.IsDnf() {
+		args := []string{"check-update"}
+		if securityOnly {
+			args = append(args, "--security")
+		}
+		out, exitCode, _ := queryCmdOutput("dnf", args...)
+		return interpretUpdateCheck("dnf", out, exitCode)
+	}
+	if pkg.IsApt() {
+		aptCmd := "apt-get"
+		if _, err := exec.LookPath("apt"); err == nil {
+			aptCmd = "apt"
+		}
+		out, exitCode, _ := queryCmdOutput(aptCmd, "-s", "upgrade")
+		return interpretUpdateCheck("apt", out, exitCode)
 	}
 	if pkg.IsPacman() {
-		// pacman -Qu: exit 0 = updates available, 1 = none (language-agnostic)
-		_, exitCode, _ := queryCmdOutput("pacman", "-Qu")
-		return exitCode == 0
+		out, exitCode, _ := queryCmdOutput("pacman", "-Qu")
+		return interpretUpdateCheck("pacman", out, exitCode)
 	}
 	if pkg.IsZypper() {
-		// zypper: exit 100 = updates available, 0 = none
-		_, exitCode, _ := queryCmdOutput("zypper", "--non-interactive", "list-updates")
-		return exitCode == 100
+		out, exitCode, _ := queryCmdOutput("zypper", "--non-interactive", "list-updates")
+		return interpretUpdateCheck("zypper", out, exitCode)
 	}
-	return true // assume updates for unknown package managers
+	return interpretUpdateCheck("", "", 0) // unknown manager → assume updates
 }
 
 // installedPackageCount returns the number of installed packages (language-agnostic).
@@ -554,33 +584,11 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 	if rebootRequiredAfter {
 		allOutput.WriteString("\n*** REBOOT REQUIRED ***\n")
 		if newRebootRequired && params != nil && params.RebootIfRequired {
-			// Issue the shutdown FIRST and only report success if
-			// it actually went out — the prior shape printed
-			// "Scheduling reboot..." regardless of whether
-			// shutdown(8) accepted the request, so an operator
-			// would see "scheduled" in the action result while
-			// the host stayed up. Failure to schedule a reboot
-			// the operator explicitly asked for is a real action
-			// failure, not a logged warning. The desktop
-			// notification is also gated on success so we don't
-			// tell users "your system will reboot" when it won't.
-			if out, err := runSudoCmd(ctx, "shutdown", "-r", "+1", "System update requires reboot"); err != nil {
-				if out != nil {
-					allOutput.WriteString(out.Stdout)
-					allOutput.WriteString(out.Stderr)
-				}
-				allOutput.WriteString(fmt.Sprintf("FAILED to schedule reboot: %v\n", err))
-				// Always join the reboot failure into lastErr — the
-				// preceding comment claims this is a real action
-				// failure, but a first-error-wins guard would silently
-				// demote it whenever an earlier upgrade error already
-				// occupied lastErr. errors.Join keeps both visible to
-				// the caller.
-				lastErr = errors.Join(lastErr, fmt.Errorf("schedule reboot: %w", err))
-			} else {
-				sysnotify.NotifyAll(ctx, "System Reboot", "A system update requires a reboot. This system will reboot in 1 minute.")
-				allOutput.WriteString("Scheduled reboot in 1 minute.\n")
-			}
+			// errors.Join keeps the reboot failure visible even when an
+			// earlier upgrade error already occupied lastErr — a
+			// first-error-wins guard would silently demote a reboot the
+			// operator explicitly asked for.
+			lastErr = errors.Join(lastErr, e.scheduleRebootAfterUpdate(ctx, &allOutput))
 		}
 	}
 
@@ -596,11 +604,32 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 	}, changed, lastErr
 }
 
+// scheduleRebootAfterUpdate issues the reboot the operator requested via
+// RebootIfRequired and notifies signed-in users ONLY if the shutdown actually
+// went out. A failure to schedule a reboot the operator explicitly asked for
+// is a real action failure (returned, not a logged warning); the desktop
+// notification is gated on success so users are never told "your system will
+// reboot" when it won't. Returns nil when the reboot was scheduled.
+func (e *Executor) scheduleRebootAfterUpdate(ctx context.Context, output *strings.Builder) error {
+	out, err := runSudoCmd(ctx, "shutdown", "-r", "+1", "System update requires reboot")
+	if err != nil {
+		if out != nil {
+			output.WriteString(out.Stdout)
+			output.WriteString(out.Stderr)
+		}
+		output.WriteString(fmt.Sprintf("FAILED to schedule reboot: %v\n", err))
+		return fmt.Errorf("schedule reboot: %w", err)
+	}
+	notifyAll(ctx, "System Reboot", "A system update requires a reboot. This system will reboot in 1 minute.")
+	output.WriteString("Scheduled reboot in 1 minute.\n")
+	return nil
+}
+
 // executeAptUpgrade performs apt-specific upgrade.
 func (e *Executor) executeAptUpgrade(ctx context.Context, params *pb.UpdateParams, output *strings.Builder) error {
 	if params != nil && params.SecurityOnly {
 		// Use unattended-upgrades for security-only updates if available.
-		if _, err := exec.LookPath("unattended-upgrade"); err == nil {
+		if _, err := execLookPath("unattended-upgrade"); err == nil {
 			cmdOutput, err := runSudoCmd(ctx, "unattended-upgrade", "-v")
 			if cmdOutput != nil {
 				output.WriteString(cmdOutput.Stdout)

--- a/internal/executor/action_user.go
+++ b/internal/executor/action_user.go
@@ -237,7 +237,7 @@ func (e *Executor) createUser(ctx context.Context, params *pb.UserParams, output
 	// are good to have for any account that might ever need a
 	// PAM-protected login path. See sdk proto comment on no_password.
 	var metadata map[string]string
-	if !params.NoPassword && !params.SystemUser && !params.Disabled {
+	if createUserSetsPassword(params) {
 		tempPassword, err := sysuser.GeneratePassword(16, false)
 		if err != nil {
 			output.WriteString(fmt.Sprintf("warning: failed to generate temporary password: %v\n", err))
@@ -303,16 +303,26 @@ func (e *Executor) createUser(ctx context.Context, params *pb.UserParams, output
 	return &pb.CommandOutput{ExitCode: 0, Stdout: output.String()}, metadata, nil
 }
 
+// createUserSetsPassword reports whether createUser will set a temporary
+// password for this account. createUser sets one only when none of
+// no_password / system_user / disabled is requested; in every other case the
+// account is left at the useradd '!' (locked, hash-less) default. This is the
+// single source of truth that createUser and desiredAccountLocked both consult
+// so the two can never drift — see desiredAccountLocked.
+func createUserSetsPassword(params *pb.UserParams) bool {
+	return !params.NoPassword && !params.SystemUser && !params.Disabled
+}
+
 // desiredAccountLocked reports whether the account described by params
 // must remain shadow-locked (no PAM login path). It is the single
-// source of truth shared between createUser and updateUser, and MUST
-// mirror createUser's password-skip condition: createUser sets a temp
-// password only when none of no_password / system_user / disabled is
-// set, leaving the account at the useradd '!' default otherwise. An
-// account with no password must never be unlocked — unlocking a
-// hash-less account yields a passwordless login path.
+// source of truth shared between createUser and updateUser, and is bound
+// to createUser's password-skip condition via createUserSetsPassword:
+// createUser sets a temp password only when none of no_password /
+// system_user / disabled is set, leaving the account at the useradd '!'
+// default otherwise. An account with no password must never be unlocked —
+// unlocking a hash-less account yields a passwordless login path.
 func desiredAccountLocked(params *pb.UserParams) bool {
-	return params.Disabled || params.NoPassword || params.SystemUser
+	return !createUserSetsPassword(params)
 }
 
 // updateUser modifies an existing user account.

--- a/internal/executor/action_user_ssh_test.go
+++ b/internal/executor/action_user_ssh_test.go
@@ -1,0 +1,68 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// setupSSHKeys must refuse an authorized_keys entry that carries an embedded
+// newline (or carriage return) BEFORE it writes anything to disk. Without the
+// guard, a single signed action could smuggle extra authorized_keys lines —
+// additional principals, a command="…" override, a restrict= bypass — by
+// embedding "\nssh-rsa ATTACKER…" in one key value: the prefix check passes on
+// the first line and the appended lines land in the file unfiltered.
+//
+// The malicious payload is sourced from intent (a forged second key line), not
+// from the guard's own ContainsAny rule. The rejection happens in the
+// key-building loop, before the .ssh mkdir / SafeReplaceFile, so no
+// authorized_keys file is created — pointed at a temp HOME we assert exactly
+// that.
+func TestSetupSSHKeys_RejectsEmbeddedNewline(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+	}{
+		{
+			name: "embedded LF splices a second key",
+			key:  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5legit\nssh-rsa AAAAB3NzaC1ATTACKER command=\"/bin/sh\"",
+		},
+		{
+			name: "embedded CR splices a second key",
+			key:  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5legit\rssh-rsa AAAAB3NzaC1ATTACKER",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := NewExecutor(nil)
+			home := t.TempDir()
+			params := &pb.UserParams{
+				Username:          "alice",
+				HomeDir:           home,
+				SshAuthorizedKeys: []string{tc.key},
+			}
+
+			var out strings.Builder
+			changed, err := e.setupSSHKeys(context.Background(), params, &out)
+			if err == nil {
+				t.Fatal("expected setupSSHKeys to refuse the embedded-newline key")
+			}
+			if !strings.Contains(err.Error(), "embedded newline") && !strings.Contains(err.Error(), "refusing to splice") {
+				t.Errorf("error = %q, want it to name the embedded newline / refusal to splice", err)
+			}
+			if changed {
+				t.Error("changed must be false when the key is refused")
+			}
+			// The splice must not have reached the filesystem.
+			authKeys := filepath.Join(home, ".ssh", "authorized_keys")
+			if _, statErr := os.Stat(authKeys); !os.IsNotExist(statErr) {
+				t.Errorf("authorized_keys must not be written on a refused key (stat err = %v)", statErr)
+			}
+		})
+	}
+}

--- a/internal/executor/action_user_test.go
+++ b/internal/executor/action_user_test.go
@@ -95,23 +95,31 @@ func TestDesiredAccountLocked(t *testing.T) {
 	}
 }
 
-// Pin the cross-function invariant directly: for every combination of
-// the three password-skip flags, "createUser left it passwordless" must
-// equal "desiredAccountLocked wants it locked". If they ever diverge,
-// updateUser will fight createUser and either churn forever or unlock a
-// passwordless account.
+// Pin the cross-function invariant by binding to the SHARED predicate, not a
+// hand-copy of it: for every combination of the three password-skip flags,
+// "desiredAccountLocked wants it locked" must equal "createUser did NOT set a
+// password". Both callers consult createUserSetsPassword, so this drives the
+// real function on both sides — a future edit to one cannot diverge from the
+// other without this test (and createUser's call site) catching it. The prior
+// version re-derived the rule inline in the test, which only proved
+// desiredAccountLocked matched a COPY of the rule, not createUser's actual code.
 func TestDesiredAccountLocked_MatchesCreateUserPasswordSkip(t *testing.T) {
 	for _, noPass := range []bool{false, true} {
 		for _, sysUser := range []bool{false, true} {
 			for _, disabled := range []bool{false, true} {
 				p := &pb.UserParams{NoPassword: noPass, SystemUser: sysUser, Disabled: disabled}
-				// createUser sets a password (and thus leaves the
-				// account unlockable) ONLY in the all-false case.
-				createUserSetsPassword := !noPass && !sysUser && !disabled
-				wantLocked := !createUserSetsPassword
-				assert.Equal(t, wantLocked, desiredAccountLocked(p),
+				assert.Equal(t, !createUserSetsPassword(p), desiredAccountLocked(p),
 					"no_password=%v system_user=%v disabled=%v", noPass, sysUser, disabled)
 			}
 		}
 	}
+
+	// Pin the password-skip contract itself so the binding above can't be
+	// satisfied by a vacuous "both wrong the same way". createUser sets a
+	// temporary password ONLY when none of the three opt-outs is requested.
+	assert.True(t, createUserSetsPassword(&pb.UserParams{}),
+		"a plain account (no opt-outs) must get a password")
+	assert.False(t, createUserSetsPassword(&pb.UserParams{NoPassword: true}), "no_password skips the password")
+	assert.False(t, createUserSetsPassword(&pb.UserParams{SystemUser: true}), "system_user skips the password")
+	assert.False(t, createUserSetsPassword(&pb.UserParams{Disabled: true}), "disabled skips the password")
 }

--- a/internal/executor/cmd.go
+++ b/internal/executor/cmd.go
@@ -32,8 +32,11 @@ func runCmdWithStdin(ctx context.Context, stdin io.Reader, name string, args ...
 	return toOutput(r), err
 }
 
-// runSudoCmd wraps a command with sudo for privileged operations.
-func runSudoCmd(ctx context.Context, name string, args ...string) (*pb.CommandOutput, error) {
+// runSudoCmd wraps a command with sudo for privileged operations. It is a
+// package var (not a plain func) so update/reboot tests can stub the
+// privileged shell-out without a live host; production always uses the
+// sysexec.Privileged dispatch below.
+var runSudoCmd = func(ctx context.Context, name string, args ...string) (*pb.CommandOutput, error) {
 	r, err := sysexec.Privileged(ctx, name, args...)
 	return toOutput(r), err
 }

--- a/internal/executor/executor_env_test.go
+++ b/internal/executor/executor_env_test.go
@@ -1,0 +1,63 @@
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// runShellScript builds the child environment from a curated baseline plus
+// only the caller-supplied entries that pass the SDK hijack allow-list. A
+// blocklisted variable (LD_PRELOAD, PATH, LD_LIBRARY_PATH, …) must be refused
+// BEFORE the interpreter is ever launched, so a compromised gateway cannot
+// inject an ambient-library hijack through a SHELL action.
+//
+// The wrong inputs are sourced from intent (the classic LD_* / PATH hijack
+// names), not from the allow-list's own table. A deliberately non-existent
+// interpreter is used so that if the guard ever regressed to run *after*
+// exec, the failure would surface as an interpreter error rather than the
+// allow-list message — and this test would catch it.
+func TestRunShellScript_RejectsBlocklistedEnvVar(t *testing.T) {
+	e := NewExecutor(nil)
+	ctx := context.Background()
+
+	const bogusInterp = "/nonexistent/pm-ws17a-interp"
+
+	for _, name := range []string{"LD_PRELOAD", "PATH", "LD_LIBRARY_PATH"} {
+		t.Run("rejects "+name, func(t *testing.T) {
+			params := &pb.ShellParams{
+				Interpreter: bogusInterp,
+				RunAsRoot:   true,
+				Environment: map[string]string{name: "/tmp/evil"},
+			}
+			out, err := e.runShellScript(ctx, params, "echo hi", nil)
+			if err == nil {
+				t.Fatalf("runShellScript with %s = nil error, want rejection before exec", name)
+			}
+			if !strings.Contains(err.Error(), "is not allowed") {
+				t.Errorf("error = %q, want the env allow-list rejection (%q) — a different error means exec ran first", err, name)
+			}
+			if out != nil {
+				t.Errorf("output must be nil on a rejected env var, got %v", out)
+			}
+		})
+	}
+
+	// correct: an allow-listed application variable passes the gate and the
+	// function proceeds to launch the interpreter. With a non-existent
+	// interpreter the launch fails, but the error is NOT the allow-list
+	// rejection — proving MYAPP_FLAG was accepted into the child env.
+	t.Run("allows MYAPP_FLAG past the gate", func(t *testing.T) {
+		params := &pb.ShellParams{
+			Interpreter: bogusInterp,
+			RunAsRoot:   true,
+			Environment: map[string]string{"MYAPP_FLAG": "1"},
+		}
+		_, err := e.runShellScript(ctx, params, "echo hi", nil)
+		if err != nil && strings.Contains(err.Error(), "is not allowed") {
+			t.Errorf("MYAPP_FLAG was rejected by the env gate (%v); an application variable must pass", err)
+		}
+	})
+}

--- a/internal/executor/update_seams_test.go
+++ b/internal/executor/update_seams_test.go
@@ -1,0 +1,170 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// interpretUpdateCheck is the pure exit-code/stdout → "updates available?"
+// mapping extracted from hasUpdatesAvailable. Driving it with fixtures gives
+// every manager — including zypper, which previously only had a logged smoke
+// value — a real assertion in both directions. The "wrong" rows (e.g. dnf exit
+// 0, apt with no Inst line) are the rejection cases that matter.
+func TestInterpretUpdateCheck(t *testing.T) {
+	cases := []struct {
+		manager  string
+		stdout   string
+		exitCode int
+		want     bool
+	}{
+		{"dnf", "", 100, true},
+		{"dnf", "", 0, false},
+		{"apt", "Inst libfoo [1.0] (1.1 stable)\n", 0, true},
+		{"apt", "Reading package lists...\nBuilding dependency tree...\n", 0, false},
+		{"pacman", "", 0, true},
+		{"pacman", "", 1, false},
+		{"zypper", "", 100, true},
+		{"zypper", "", 0, false},
+		{"", "", 0, true},        // unknown manager → assume updates (fail safe)
+		{"weirdpm", "", 0, true}, // unknown manager → assume updates (fail safe)
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%s/exit=%d", tc.manager, tc.exitCode), func(t *testing.T) {
+			got := interpretUpdateCheck(tc.manager, tc.stdout, tc.exitCode)
+			if got != tc.want {
+				t.Errorf("interpretUpdateCheck(%q, %q, %d) = %v, want %v",
+					tc.manager, tc.stdout, tc.exitCode, got, tc.want)
+			}
+		})
+	}
+}
+
+// executeAptUpgrade must fail CLOSED when a security-only update is requested
+// but no security-only path exists on the host: the operator asked for
+// security-only because their compliance posture forbids the broader upgrade,
+// so silently delivering a full apt.Upgrade() is a compliance violation.
+func TestExecuteAptUpgrade_SecurityOnly_FailsClosedWhenUnattendedAbsent(t *testing.T) {
+	origLook := execLookPath
+	origSudo := runSudoCmd
+	t.Cleanup(func() { execLookPath = origLook; runSudoCmd = origSudo })
+
+	e := NewExecutor(nil)
+
+	t.Run("absent unattended-upgrade fails closed, no broad upgrade", func(t *testing.T) {
+		execLookPath = func(name string) (string, error) {
+			return "", fmt.Errorf("exec: %q: executable file not found in $PATH", name)
+		}
+		var out strings.Builder
+		err := e.executeAptUpgrade(context.Background(), &pb.UpdateParams{SecurityOnly: true}, &out)
+		if err == nil {
+			t.Fatal("security-only upgrade must fail closed when unattended-upgrade is absent")
+		}
+		if !strings.Contains(err.Error(), "unattended-upgrade") {
+			t.Errorf("error = %q, want it to name the missing unattended-upgrade", err)
+		}
+		if !strings.Contains(out.String(), "ERROR: security-only") {
+			t.Errorf("output = %q, want the security-only ERROR line", out.String())
+		}
+		// The broad upgrade path writes a "Dist-Upgrade" banner — it must NOT
+		// have been reached (the function returns at the fail-closed branch).
+		if strings.Contains(out.String(), "Dist-Upgrade") {
+			t.Error("broad upgrade path was taken; security-only must not fall through to a full upgrade")
+		}
+	})
+
+	t.Run("present unattended-upgrade runs the security path", func(t *testing.T) {
+		execLookPath = func(name string) (string, error) { return "/usr/bin/unattended-upgrade", nil }
+		ran := ""
+		runSudoCmd = func(ctx context.Context, name string, args ...string) (*pb.CommandOutput, error) {
+			ran = name
+			return &pb.CommandOutput{Stdout: "0 upgraded, 0 newly installed"}, nil
+		}
+		var out strings.Builder
+		err := e.executeAptUpgrade(context.Background(), &pb.UpdateParams{SecurityOnly: true}, &out)
+		if err != nil {
+			t.Fatalf("present security path returned error: %v", err)
+		}
+		if ran != "unattended-upgrade" {
+			t.Errorf("expected the security path to run unattended-upgrade, ran %q", ran)
+		}
+		if strings.Contains(out.String(), "Dist-Upgrade") {
+			t.Error("security path must not run the broad dist-upgrade")
+		}
+	})
+}
+
+// scheduleRebootAfterUpdate must treat a failed `shutdown` as a real action
+// error (the operator asked for the reboot), and must NOT notify users that
+// their system will reboot when it won't. On success it notifies exactly once.
+func TestScheduleRebootAfterUpdate(t *testing.T) {
+	origSudo := runSudoCmd
+	origNotify := notifyAll
+	t.Cleanup(func() { runSudoCmd = origSudo; notifyAll = origNotify })
+
+	e := NewExecutor(nil)
+
+	t.Run("shutdown failure returns an error and suppresses notify", func(t *testing.T) {
+		runSudoCmd = func(ctx context.Context, name string, args ...string) (*pb.CommandOutput, error) {
+			return &pb.CommandOutput{Stderr: "Failed to set wall message"}, fmt.Errorf("exit status 1")
+		}
+		notified := 0
+		notifyAll = func(ctx context.Context, title, body string) { notified++ }
+
+		var out strings.Builder
+		err := e.scheduleRebootAfterUpdate(context.Background(), &out)
+		if err == nil {
+			t.Fatal("a failed reboot schedule must return an error, not a clean success")
+		}
+		if !strings.Contains(err.Error(), "schedule reboot") {
+			t.Errorf("error = %q, want it to name the reboot scheduling failure", err)
+		}
+		if !strings.Contains(out.String(), "FAILED to schedule reboot") {
+			t.Errorf("output = %q, want the FAILED line", out.String())
+		}
+		if notified != 0 {
+			t.Errorf("users must NOT be notified when the reboot did not go out, got %d notifications", notified)
+		}
+	})
+
+	t.Run("success notifies exactly once", func(t *testing.T) {
+		runSudoCmd = func(ctx context.Context, name string, args ...string) (*pb.CommandOutput, error) {
+			return &pb.CommandOutput{Stdout: "Shutdown scheduled"}, nil
+		}
+		notified := 0
+		notifyAll = func(ctx context.Context, title, body string) { notified++ }
+
+		var out strings.Builder
+		if err := e.scheduleRebootAfterUpdate(context.Background(), &out); err != nil {
+			t.Fatalf("successful reboot scheduling returned error: %v", err)
+		}
+		if notified != 1 {
+			t.Errorf("want exactly one notification on success, got %d", notified)
+		}
+		if !strings.Contains(out.String(), "Scheduled reboot") {
+			t.Errorf("output = %q, want the scheduled-reboot line", out.String())
+		}
+	})
+
+	t.Run("reboot failure joins with a prior error rather than demoting it", func(t *testing.T) {
+		runSudoCmd = func(ctx context.Context, name string, args ...string) (*pb.CommandOutput, error) {
+			return nil, fmt.Errorf("exit status 1")
+		}
+		notifyAll = func(ctx context.Context, title, body string) {}
+
+		var out strings.Builder
+		// Mirror executeUpdate's call site: lastErr = errors.Join(lastErr, ...).
+		prior := errors.New("apt upgrade failed")
+		joined := errors.Join(prior, e.scheduleRebootAfterUpdate(context.Background(), &out))
+		if !errors.Is(joined, prior) {
+			t.Error("a prior upgrade error must stay visible alongside the reboot failure")
+		}
+		if !strings.Contains(joined.Error(), "schedule reboot") {
+			t.Error("the reboot failure must not be demoted by a first-error-wins guard")
+		}
+	})
+}

--- a/internal/executor/wifi.go
+++ b/internal/executor/wifi.go
@@ -28,8 +28,14 @@ func (e *Executor) executeWifi(ctx context.Context, params *pb.WifiParams, state
 	if params == nil {
 		return nil, false, fmt.Errorf("wifi params required")
 	}
-	if actionID == "" {
-		return nil, false, fmt.Errorf("action ID required for wifi")
+	// The action ID is spliced into a filesystem path
+	// (network.CertBaseDir/<id> for EAP-TLS certificates) and the
+	// pm-wifi-<id> NetworkManager connection name. Validate it the same
+	// way the sudo/ssh/sshd executors do — empty was the only case
+	// checked before, leaving traversal/separator characters
+	// ("../../etc", "a/b") free to escape CertBaseDir.
+	if err := validateActionIDForFilesystem(actionID); err != nil {
+		return nil, false, err
 	}
 
 	conName := wifiConnectionName(actionID)

--- a/internal/executor/wifi_test.go
+++ b/internal/executor/wifi_test.go
@@ -1,0 +1,62 @@
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// executeWifi splices the action ID into a filesystem path
+// (network.CertBaseDir/<id> for EAP-TLS certificates) and into the
+// pm-wifi-<id> NetworkManager connection name. Like the sudo/ssh/sshd
+// executors it must run the action ID through validateActionIDForFilesystem
+// BEFORE building any path, not merely reject the empty string.
+//
+// The "wrong" inputs are sourced from intent (path-meaningful characters and
+// the 64-char ceiling), NOT from the validator's regex. Each must be refused
+// before any NetworkManager call — the function returns at the validation
+// check, before conName/certDir are computed, so no connection is created and
+// no cert directory is written.
+func TestExecuteWifi_RejectsUnsafeActionID(t *testing.T) {
+	e := NewExecutor(nil)
+	ctx := context.Background()
+	// Non-nil params so the nil-params guard isn't what trips; the action-ID
+	// gate must reject before params are ever read.
+	params := &pb.WifiParams{Ssid: "corp-net"}
+
+	unsafe := []struct {
+		name string
+		id   string
+	}{
+		{"parent traversal", "../../etc"},
+		{"embedded slash", "a/b"},
+		{"shell separator", "a;b"},
+		{"over 64 chars", strings.Repeat("a", 65)},
+		{"empty", ""},
+	}
+	for _, tc := range unsafe {
+		t.Run(tc.name, func(t *testing.T) {
+			out, changed, err := e.executeWifi(ctx, params, pb.DesiredState_DESIRED_STATE_PRESENT, tc.id)
+			if err == nil {
+				t.Fatalf("executeWifi(id=%q) = nil error, want rejection", tc.id)
+			}
+			if !strings.Contains(err.Error(), "action ID") {
+				t.Errorf("error = %q, want a validateActionIDForFilesystem message naming the action ID", err)
+			}
+			if changed {
+				t.Error("changed must be false on a rejected action ID")
+			}
+			if out != nil {
+				t.Errorf("output must be nil on rejection, got %v", out)
+			}
+		})
+	}
+
+	// correct: a valid alphanumeric ULID passes the same gate executeWifi
+	// consults, so legitimate WiFi actions are not broken by the new check.
+	if err := validateActionIDForFilesystem("01ARZ3NDEKTSV4RRFFQ69G5FAV"); err != nil {
+		t.Errorf("valid ULID action ID rejected by the gate: %v", err)
+	}
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -264,12 +264,15 @@ func (h *Handler) OnActionWithStreaming(ctx context.Context, envelope []byte, si
 	}
 
 	// Log output for debugging — but truncate + redact (audit F-32).
-	// Shell scripts and configuration content may embed secrets
-	// (LUKS passphrases, API tokens, the AES-GCM `enc:v1:` prefix
-	// the server uses for secrets-at-rest). Truncating to a tail
-	// preview keeps debugging useful for short-output checks
-	// without dumping multi-KB payloads into journald + downstream
-	// log shippers (Loki, journald-to-syslog forwarders, etc.).
+	// The exact contract (see sanitizeForLog): the AES-GCM `enc:v1:`
+	// ciphertext token the server uses for secrets-at-rest is redacted,
+	// and the whole preview is length-bounded. A PLAINTEXT secret (a LUKS
+	// passphrase or API token printed without the enc:v1: prefix) is NOT
+	// redacted — only length-bounded — so this is a payload-size guard plus
+	// ciphertext redaction, not a plaintext-secret scrubber. Truncating to a
+	// tail preview keeps debugging useful for short-output checks without
+	// dumping multi-KB payloads into journald + downstream log shippers
+	// (Loki, journald-to-syslog forwarders, etc.).
 	if result.Output != nil {
 		if result.Output.Stdout != "" {
 			h.logger.Debug("action stdout", "action_id", actionID, "stdout", sanitizeForLog(result.Output.Stdout))

--- a/internal/handler/log_filter_test.go
+++ b/internal/handler/log_filter_test.go
@@ -67,6 +67,23 @@ func TestSanitizeForLog(t *testing.T) {
 	}
 }
 
+// Pin the ACTUAL contract at the boundary, not the comment's overclaim:
+// sanitizeForLog redacts the AES-GCM enc:v1: ciphertext token and truncates;
+// it does NOT redact a PLAINTEXT secret printed without that prefix — such a
+// value is only length-bounded. Documenting this prevents a future reader from
+// trusting a protection the filter does not provide (plaintext-secret redaction
+// would be a separate security feature, not part of this filter).
+func TestSanitizeForLog_PlaintextSecretBoundary(t *testing.T) {
+	// A LUKS-passphrase-shaped plaintext, short enough to avoid truncation and
+	// carrying no enc:v1: prefix.
+	plaintext := "hunter2-luks-pass"
+	out := sanitizeForLog("recovered key: " + plaintext)
+	assert.Contains(t, out, plaintext,
+		"a plaintext secret with no enc:v1: prefix is length-bounded only — the filter does not redact it")
+	assert.NotContains(t, out, "[REDACTED-ENC]",
+		"there is no enc:v1: token here, so nothing is redacted")
+}
+
 func TestIsPathologicalGrepPattern(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/internal/handler/terminal.go
+++ b/internal/handler/terminal.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/oklog/ulid/v2"
+
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	sdk "github.com/manchtools/power-manage/sdk/go"
 	"github.com/manchtools/power-manage/sdk/go/sys/terminal"
@@ -287,6 +289,21 @@ func (h *Handler) OnTerminalStart(ctx context.Context, req *pb.TerminalStart) er
 	if err := validateDims(req.Cols, req.Rows); err != nil {
 		logger.Warn("terminal start rejected: bad dimensions", "cols", req.Cols, "rows", req.Rows)
 		h.failTerminalStart(ctx, sender, req.SessionId, err.Error())
+		return nil
+	}
+
+	// The session id is spliced into a /tmp path (tempHome below) that is then
+	// created and chowned as root, so it must be a well-formed ULID — the proto
+	// declares session_id as validate:"required,ulid", and the agent enforces
+	// that on inbound stream messages rather than trusting a possibly-compromised
+	// gateway. ulid.Parse rejects path-meaningful values ("../../etc", "a/b",
+	// embedded NULs) and the empty string before any filesystem use; together
+	// with the validated pm-tty-* username this makes the joined path unable to
+	// escape /tmp. Placed after the TTY/dims gates so those keep their existing
+	// rejection precedence, but before the user lookup so an invalid id costs no
+	// syscall.
+	if _, err := ulid.Parse(req.SessionId); err != nil {
+		h.failTerminalStart(ctx, sender, req.SessionId, "invalid session id")
 		return nil
 	}
 

--- a/internal/handler/terminal_ws17a_test.go
+++ b/internal/handler/terminal_ws17a_test.go
@@ -1,0 +1,235 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+	sysuser "github.com/manchtools/power-manage/sdk/go/sys/user"
+)
+
+func ws17aULID() string { return ulid.Make().String() }
+
+// The IsValidName conjunct of the username guard is exercised independently of
+// the HasPrefix conjunct the existing test covers: usernames that HAVE the
+// pm-tty- prefix but FAIL IsValidName (uppercase, separators, control chars,
+// over length) must be refused with STATE_ERROR before any system call, and no
+// session may be registered. The wrong inputs are sourced from the IsValidName
+// contract (lowercase letters/digits/_/-, ≤32 chars), not from the regex.
+func TestTerminal_Start_RejectsPrefixedButInvalidUsername(t *testing.T) {
+	cases := map[string]string{
+		"uppercase":  "pm-tty-Abc",
+		"slash":      "pm-tty-a/b",
+		"newline":    "pm-tty-a\nb",
+		"colon":      "pm-tty-a:b",
+		"over-32":    "pm-tty-" + strings.Repeat("a", 40),
+		"whitespace": "pm-tty-a b",
+	}
+	for name, user := range cases {
+		t.Run(name, func(t *testing.T) {
+			h, sender := newTestHandler(t)
+			err := h.OnTerminalStart(context.Background(), &pb.TerminalStart{
+				SessionId: ws17aULID(), // valid ULID so the failure is the username, not the id
+				TtyUser:   user,
+				Cols:      80,
+				Rows:      24,
+			})
+			if err != nil {
+				t.Fatalf("OnTerminalStart returned %v", err)
+			}
+			last := sender.lastState()
+			if last == nil || last.State != pb.TerminalSessionState_TERMINAL_SESSION_STATE_ERROR {
+				t.Fatalf("expected STATE_ERROR, got %v", last)
+			}
+			if !strings.Contains(last.Error, "invalid tty username") {
+				t.Errorf("error = %q, want 'invalid tty username'", last.Error)
+			}
+			if got := len(h.terminals); got != 0 {
+				t.Errorf("registry must stay empty, got %d entries", got)
+			}
+		})
+	}
+}
+
+// session_id flows into filepath.Join("/tmp", ttyUser+"."+session_id) and is
+// then created + chowned as root. It must be a valid ULID (the proto declares
+// validate:"required,ulid"); the agent must enforce that on inbound stream
+// messages. Cases are sourced from ULID intent (path-meaningful values, the
+// empty string, wrong length), not from ulid.Parse's own rules.
+func TestTerminal_Start_RejectsNonUlidSessionId(t *testing.T) {
+	bad := map[string]string{
+		"parent-traversal": "../../etc",
+		"embedded-slash":   "a/b",
+		"dotted":           "a.b",
+		"empty":            "",
+		"too-long":         strings.Repeat("Z", 40),
+		"embedded-nul":     "01ARZ3NDEKTSV4RRFFQ69G5F\x00",
+	}
+	for name, sid := range bad {
+		t.Run(name, func(t *testing.T) {
+			h, sender := newTestHandler(t)
+			err := h.OnTerminalStart(context.Background(), &pb.TerminalStart{
+				SessionId: sid,
+				TtyUser:   "pm-tty-test",
+				Cols:      80,
+				Rows:      24,
+			})
+			if err != nil {
+				t.Fatalf("OnTerminalStart returned %v", err)
+			}
+			last := sender.lastState()
+			if last == nil || last.State != pb.TerminalSessionState_TERMINAL_SESSION_STATE_ERROR {
+				t.Fatalf("expected STATE_ERROR for session id %q, got %v", sid, last)
+			}
+			if !strings.Contains(last.Error, "invalid session id") {
+				t.Errorf("error = %q, want 'invalid session id'", last.Error)
+			}
+			if got := len(h.terminals); got != 0 {
+				t.Errorf("registry must stay empty, got %d entries", got)
+			}
+		})
+	}
+
+	// correct: a real ULID passes the session-id gate (it then fails later for
+	// other reasons, but NOT with the session-id message).
+	t.Run("valid ULID passes the session-id gate", func(t *testing.T) {
+		origGet := sysuserGet
+		origModify := sysuserModify
+		t.Cleanup(func() { sysuserGet = origGet; sysuserModify = origModify })
+		sysuserGet = func(string) (*sysuser.Info, error) { return &sysuser.Info{Locked: false}, nil }
+		sysuserModify = func(context.Context, string, ...string) (*sysexec.Result, error) {
+			return nil, fmt.Errorf("usermod unavailable in test")
+		}
+		h, sender := newTestHandler(t)
+		err := h.OnTerminalStart(context.Background(), &pb.TerminalStart{
+			SessionId: ws17aULID(), TtyUser: "pm-tty-test", Cols: 80, Rows: 24,
+		})
+		if err != nil {
+			t.Fatalf("OnTerminalStart returned %v", err)
+		}
+		if last := sender.lastState(); last != nil && strings.Contains(last.Error, "invalid session id") {
+			t.Errorf("a valid ULID must pass the session-id gate, got %q", last.Error)
+		}
+	})
+}
+
+// The session-limit and duplicate-session guards sit AFTER the real user lookup
+// (which shells out), so they are driven through the sysuserGet seam returning a
+// healthy account.
+func TestTerminal_Start_RejectsAtSessionLimit(t *testing.T) {
+	origGet := sysuserGet
+	t.Cleanup(func() { sysuserGet = origGet })
+	sysuserGet = func(string) (*sysuser.Info, error) { return &sysuser.Info{Locked: false}, nil }
+
+	h, sender := newTestHandler(t)
+	h.terminalLimit = 2
+	addTestSession(h, ws17aULID(), "pm-tty-test", time.Now())
+	addTestSession(h, ws17aULID(), "pm-tty-test", time.Now())
+
+	err := h.OnTerminalStart(context.Background(), &pb.TerminalStart{
+		SessionId: ws17aULID(), TtyUser: "pm-tty-test", Cols: 80, Rows: 24,
+	})
+	if err != nil {
+		t.Fatalf("OnTerminalStart returned %v", err)
+	}
+	last := sender.lastState()
+	if last == nil || last.State != pb.TerminalSessionState_TERMINAL_SESSION_STATE_ERROR {
+		t.Fatalf("expected STATE_ERROR at the session limit, got %v", last)
+	}
+	if !strings.Contains(last.Error, "session limit reached") {
+		t.Errorf("error = %q, want 'session limit reached'", last.Error)
+	}
+	if got := len(h.terminals); got != 2 {
+		t.Errorf("a rejected over-limit start must not be registered; registry size = %d, want 2", got)
+	}
+}
+
+func TestTerminal_Start_RejectsDuplicateSession(t *testing.T) {
+	origGet := sysuserGet
+	t.Cleanup(func() { sysuserGet = origGet })
+	sysuserGet = func(string) (*sysuser.Info, error) { return &sysuser.Info{Locked: false}, nil }
+
+	h, sender := newTestHandler(t)
+	dup := ws17aULID()
+	addTestSession(h, dup, "pm-tty-test", time.Now())
+
+	err := h.OnTerminalStart(context.Background(), &pb.TerminalStart{
+		SessionId: dup, TtyUser: "pm-tty-test", Cols: 80, Rows: 24,
+	})
+	if err != nil {
+		t.Fatalf("OnTerminalStart returned %v", err)
+	}
+	last := sender.lastState()
+	if last == nil || last.State != pb.TerminalSessionState_TERMINAL_SESSION_STATE_ERROR {
+		t.Fatalf("expected STATE_ERROR for a duplicate session, got %v", last)
+	}
+	if !strings.Contains(last.Error, "session already exists") {
+		t.Errorf("error = %q, want 'session already exists'", last.Error)
+	}
+	if got := len(h.terminals); got != 1 {
+		t.Errorf("the duplicate must not add a second entry; registry size = %d, want 1", got)
+	}
+}
+
+// A locked/disabled pm-tty-* user must be refused; an unlocked user is the
+// distinguishing factor — it gets PAST the locked gate (and then fails at shell
+// activation, a different error), proving info.Locked is what gates here.
+func TestTerminal_Start_RejectsLockedTtyUser(t *testing.T) {
+	origGet := sysuserGet
+	origModify := sysuserModify
+	t.Cleanup(func() { sysuserGet = origGet; sysuserModify = origModify })
+
+	t.Run("locked user is rejected, nothing reserved", func(t *testing.T) {
+		sysuserGet = func(string) (*sysuser.Info, error) { return &sysuser.Info{Locked: true}, nil }
+		h, sender := newTestHandler(t)
+		err := h.OnTerminalStart(context.Background(), &pb.TerminalStart{
+			SessionId: ws17aULID(), TtyUser: "pm-tty-test", Cols: 80, Rows: 24,
+		})
+		if err != nil {
+			t.Fatalf("OnTerminalStart returned %v", err)
+		}
+		last := sender.lastState()
+		if last == nil || last.State != pb.TerminalSessionState_TERMINAL_SESSION_STATE_ERROR {
+			t.Fatalf("expected STATE_ERROR for a locked user, got %v", last)
+		}
+		if !strings.Contains(last.Error, "is disabled") {
+			t.Errorf("error = %q, want 'is disabled'", last.Error)
+		}
+		if got := len(h.terminals); got != 0 {
+			t.Errorf("a locked-user rejection must reserve no slot, got %d", got)
+		}
+	})
+
+	t.Run("unlocked user passes the locked gate (fails later at shell activation)", func(t *testing.T) {
+		sysuserGet = func(string) (*sysuser.Info, error) { return &sysuser.Info{Locked: false}, nil }
+		sysuserModify = func(context.Context, string, ...string) (*sysexec.Result, error) {
+			return nil, fmt.Errorf("usermod boom")
+		}
+		h, sender := newTestHandler(t)
+		err := h.OnTerminalStart(context.Background(), &pb.TerminalStart{
+			SessionId: ws17aULID(), TtyUser: "pm-tty-test", Cols: 80, Rows: 24,
+		})
+		if err != nil {
+			t.Fatalf("OnTerminalStart returned %v", err)
+		}
+		last := sender.lastState()
+		if last == nil || last.State != pb.TerminalSessionState_TERMINAL_SESSION_STATE_ERROR {
+			t.Fatalf("expected STATE_ERROR at shell activation, got %v", last)
+		}
+		if strings.Contains(last.Error, "is disabled") {
+			t.Errorf("an unlocked user must pass the locked gate, got %q", last.Error)
+		}
+		if !strings.Contains(last.Error, "activate shell") {
+			t.Errorf("error = %q, want it to fail at shell activation (proving the locked gate was passed)", last.Error)
+		}
+		if got := len(h.terminals); got != 0 {
+			t.Errorf("a failed start must unwind its reserved slot, got %d", got)
+		}
+	})
+}

--- a/internal/scheduler/scheduler_changedexec_test.go
+++ b/internal/scheduler/scheduler_changedexec_test.go
@@ -1,0 +1,44 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// A non-first SyncActions must re-execute exactly the NEW and CHANGED
+// standalone actions and leave an UNCHANGED action alone — the positive
+// direction of the store's change detection, driven through the real
+// Scheduler.SyncActions rather than asserted at the store layer. A regression
+// that re-ran unchanged actions (e.g. whitespace drift mistaken for a change)
+// would surface here as a spurious execution.
+func TestSyncActions_ExecutesNewAndChanged_NotUnchanged(t *testing.T) {
+	sched, mock := newTestScheduler(t)
+	ctx := context.Background()
+
+	// Seed two actions on the first sync (firstSync=true runs them immediately).
+	// `unchanged` is reused by-reference below so its stored bytes are identical
+	// on the re-sync (no re-signing, which would look like a change).
+	unchanged := makeTestAction("a-unchanged", pb.ActionType_ACTION_TYPE_PACKAGE, pb.DesiredState_DESIRED_STATE_PRESENT)
+	changedSeed := makeTestAction("a-changed", pb.ActionType_ACTION_TYPE_PACKAGE, pb.DesiredState_DESIRED_STATE_PRESENT)
+	require.NoError(t, sched.SyncActions(ctx, []*pb.Action{unchanged, changedSeed}, nil, true))
+	mock.reset()
+
+	// Re-sync: flip the changed action's desired state, add a brand-new
+	// standalone, and re-send the unchanged action byte-identical.
+	changed := makeTestAction("a-changed", pb.ActionType_ACTION_TYPE_PACKAGE, pb.DesiredState_DESIRED_STATE_ABSENT)
+	added := makeTestAction("a-new", pb.ActionType_ACTION_TYPE_PACKAGE, pb.DesiredState_DESIRED_STATE_PRESENT)
+	require.NoError(t, sched.SyncActions(ctx, []*pb.Action{unchanged, changed, added}, nil, false))
+
+	executed := map[string]int{}
+	for _, c := range mock.getCalls() {
+		executed[c.GetActionId().GetValue()]++
+	}
+	assert.Equal(t, 1, executed["a-changed"], "the changed (desired-state-flipped) action re-executes exactly once")
+	assert.Equal(t, 1, executed["a-new"], "the new standalone action executes exactly once")
+	assert.Equal(t, 0, executed["a-unchanged"], "the byte-identical unchanged action must NOT re-execute")
+}

--- a/internal/store/change_detection_test.go
+++ b/internal/store/change_detection_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -108,4 +109,80 @@ func TestSyncStandaloneAndGrouped_IgnoresScheduleWhitespaceDrift(t *testing.T) {
 	require.NoError(t, st.db.QueryRow("SELECT next_execute_at FROM action_groups WHERE id = ?", group.SourceLabel).Scan(&after))
 	assert.Equal(t, before, after,
 		"whitespace-only schedule drift must preserve the group's cadence, not reset next_execute_at")
+}
+
+// The companion guarantee for STANDALONE actions: the existing drift test only
+// proved the action is absent from ChangedActionIDs. The upsert's next_execute_at
+// CASE used a raw byte compare of the stored vs incoming action_json — which
+// disagreed with the Go compacted compare — so insignificant whitespace drift
+// reset the action's cadence even though it was reported unchanged. The clock is
+// advanced between syncs so a spurious reset would be observable (the recomputed
+// next_execute_at differs); the test pins that it is NOT reset.
+func TestSyncActions_WhitespaceDrift_PreservesStandaloneCadence(t *testing.T) {
+	st, err := New(t.TempDir())
+	require.NoError(t, err)
+	defer st.Close()
+
+	now1 := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	st.now = func() time.Time { return now1 }
+
+	a := &pb.Action{
+		Id:           &pb.ActionId{Value: "pkg-cadence"},
+		Type:         pb.ActionType_ACTION_TYPE_PACKAGE,
+		DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
+	}
+	if _, err := st.SyncActions([]*pb.Action{a}); err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+
+	var before string
+	require.NoError(t, st.db.QueryRow("SELECT next_execute_at FROM actions WHERE id = ?", a.Id.Value).Scan(&before))
+
+	// Drift the STORED json with insignificant whitespace and advance the clock
+	// so a reset would move next_execute_at forward (now+8h recomputed).
+	raw, err := protojson.Marshal(a)
+	require.NoError(t, err)
+	drifted := insignificantWhitespaceDrift(t, raw)
+	_, err = st.db.Exec("UPDATE actions SET action_json = ? WHERE id = ?", drifted, a.Id.Value)
+	require.NoError(t, err)
+	st.now = func() time.Time { return now1.Add(time.Hour) }
+
+	res, err := st.SyncActions([]*pb.Action{a})
+	require.NoError(t, err)
+	assert.NotContains(t, res.ChangedActionIDs, a.Id.Value,
+		"whitespace-only drift must not flag the standalone action as changed")
+
+	var after string
+	require.NoError(t, st.db.QueryRow("SELECT next_execute_at FROM actions WHERE id = ?", a.Id.Value).Scan(&after))
+	assert.Equal(t, before, after,
+		"whitespace-only drift must PRESERVE the standalone action's cadence (next_execute_at), not reset it")
+}
+
+// Positive direction for change detection: a desired-state flip and a params
+// change must both land in ChangedActionIDs, a byte-identical re-sync must land
+// in NEITHER list, and nothing is mis-reported as New on a re-sync.
+func TestSyncActions_ChangedActionIDs_PositiveDirection(t *testing.T) {
+	st, err := New(t.TempDir())
+	require.NoError(t, err)
+	defer st.Close()
+
+	flip := &pb.Action{Id: &pb.ActionId{Value: "a-flip"}, Type: pb.ActionType_ACTION_TYPE_PACKAGE, DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT}
+	param := &pb.Action{Id: &pb.ActionId{Value: "a-param"}, Type: pb.ActionType_ACTION_TYPE_PACKAGE, DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT, Schedule: &pb.ActionSchedule{IntervalHours: 8}}
+	same := &pb.Action{Id: &pb.ActionId{Value: "a-same"}, Type: pb.ActionType_ACTION_TYPE_PACKAGE, DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT}
+
+	if _, err := st.SyncActions([]*pb.Action{flip, param, same}); err != nil {
+		t.Fatalf("seed sync: %v", err)
+	}
+
+	// (a) desired_state flip; (b) params change (interval); (c) untouched.
+	flip.DesiredState = pb.DesiredState_DESIRED_STATE_ABSENT
+	param.Schedule = &pb.ActionSchedule{IntervalHours: 12}
+
+	res, err := st.SyncActions([]*pb.Action{flip, param, same})
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{"a-flip", "a-param"}, res.ChangedActionIDs,
+		"exactly the flipped and re-parameterised actions are changed")
+	assert.Empty(t, res.NewActionIDs, "a re-sync of existing actions reports none as new")
+	assert.NotContains(t, res.ChangedActionIDs, "a-same", "an unchanged action must not be reported as changed")
 }

--- a/internal/store/pragma_test.go
+++ b/internal/store/pragma_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,6 +34,36 @@ func TestStore_ForeignKeysOnEveryConnection(t *testing.T) {
 		var fk int
 		require.NoError(t, c.QueryRowContext(context.Background(), "PRAGMA foreign_keys").Scan(&fk))
 		assert.Equal(t, 1, fk, "connection %d must have foreign_keys ON", i)
+		require.NoError(t, c.Close())
+	}
+}
+
+// busy_timeout and journal_mode=WAL are DSN pragmas (so they apply to every
+// pooled connection). busy_timeout is what lets the CLI subcommands (tty/luks)
+// wait for the daemon's writer instead of failing immediately with
+// SQLITE_BUSY; WAL keeps readers and the writer from blocking each other. Pin
+// both per-connection so dropping either from the DSN is caught.
+func TestStore_BusyTimeoutAndWalOnEveryConnection(t *testing.T) {
+	st, err := New(t.TempDir())
+	require.NoError(t, err)
+	defer st.Close()
+
+	const n = 5
+	conns := make([]*sql.Conn, 0, n)
+	for i := 0; i < n; i++ {
+		c, err := st.db.Conn(context.Background())
+		require.NoError(t, err)
+		conns = append(conns, c)
+	}
+	for i, c := range conns {
+		var busy int
+		require.NoError(t, c.QueryRowContext(context.Background(), "PRAGMA busy_timeout").Scan(&busy))
+		assert.Equal(t, 5000, busy, "connection %d must carry busy_timeout=5000", i)
+
+		var journal string
+		require.NoError(t, c.QueryRowContext(context.Background(), "PRAGMA journal_mode").Scan(&journal))
+		assert.Equal(t, "wal", strings.ToLower(journal), "connection %d must be in WAL journal mode", i)
+
 		require.NoError(t, c.Close())
 	}
 }

--- a/internal/store/results_test.go
+++ b/internal/store/results_test.go
@@ -2,12 +2,92 @@ package store
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 )
+
+// GetUnsyncedResults must return ONLY unsynced rows, ordered by executed_at
+// ascending, with the proto Output round-tripped. The reconnect sender relies
+// on this order to deliver results oldest-first and on the synced filter to
+// not re-send already-delivered results.
+func TestGetUnsyncedResults_FiltersOrdersRoundtrips(t *testing.T) {
+	st, err := New(t.TempDir())
+	require.NoError(t, err)
+	defer st.Close()
+
+	clock := time.Date(2026, 6, 15, 8, 0, 0, 0, time.UTC)
+	st.now = func() time.Time { return clock }
+
+	a := &pb.Action{
+		Id:           &pb.ActionId{Value: "act-unsynced"},
+		Type:         pb.ActionType_ACTION_TYPE_SHELL,
+		DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
+	}
+	require.NoError(t, st.SaveAction(a))
+
+	rec := func(stdout string) string {
+		clock = clock.Add(time.Minute) // distinct executed_at + result id
+		id, err := st.RecordExecution(a.Id.Value, &pb.ActionResult{
+			ActionId: a.Id,
+			Status:   pb.ExecutionStatus_EXECUTION_STATUS_SUCCESS,
+			Output:   &pb.CommandOutput{Stdout: stdout},
+		}, true)
+		require.NoError(t, err)
+		return id
+	}
+	r1 := rec("first")
+	r2 := rec("second")
+	r3 := rec("third")
+
+	// Sync the MIDDLE one — it must drop out of the unsynced set.
+	require.NoError(t, st.MarkResultSynced(r2))
+
+	got, err := st.GetUnsyncedResults()
+	require.NoError(t, err)
+	require.Len(t, got, 2, "only the two unsynced results are returned")
+	assert.Equal(t, r1, got[0].ID, "ordered by executed_at ASC: oldest first")
+	assert.Equal(t, r3, got[1].ID)
+	assert.True(t, got[0].ExecutedAt.Before(got[1].ExecutedAt), "executed_at strictly ascending")
+	assert.Equal(t, "first", got[0].Output.GetStdout(), "Output round-trips through protojson")
+	assert.Equal(t, "third", got[1].Output.GetStdout())
+}
+
+// MarkResultSynced on an unknown id is a clean no-op (returns nil, changes
+// nothing) — a cleaned-up or never-recorded id must not error nor disturb the
+// real unsynced rows.
+func TestMarkResultSynced_UnknownId_NoOp(t *testing.T) {
+	st, err := New(t.TempDir())
+	require.NoError(t, err)
+	defer st.Close()
+
+	clock := time.Date(2026, 6, 15, 8, 0, 0, 0, time.UTC)
+	st.now = func() time.Time { return clock }
+
+	a := &pb.Action{
+		Id:           &pb.ActionId{Value: "act-noop"},
+		Type:         pb.ActionType_ACTION_TYPE_SHELL,
+		DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
+	}
+	require.NoError(t, st.SaveAction(a))
+	clock = clock.Add(time.Minute)
+	r1, err := st.RecordExecution(a.Id.Value, &pb.ActionResult{
+		ActionId: a.Id,
+		Status:   pb.ExecutionStatus_EXECUTION_STATUS_SUCCESS,
+		Output:   &pb.CommandOutput{Stdout: "only"},
+	}, true)
+	require.NoError(t, err)
+
+	require.NoError(t, st.MarkResultSynced("does-not-exist"), "unknown id must be a no-op, not an error")
+
+	got, err := st.GetUnsyncedResults()
+	require.NoError(t, err)
+	require.Len(t, got, 1, "the real unsynced result is untouched by a no-op mark")
+	assert.Equal(t, r1, got[0].ID)
+}
 
 // IsResultSynced drives the reconnect dedup that stops sendScheduledResults
 // from re-sending a result syncPendingResults already delivered.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -210,6 +210,14 @@ func (s *Store) SaveAction(action *pb.Action) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// A nil Id would panic at action.Id.Value below. The sibling sync paths
+	// (SyncActions, SyncStandaloneAndGrouped) already skip nil-Id actions
+	// rather than crash on a malformed envelope; SaveAction must be just as
+	// defensive and return an error instead of panicking.
+	if action.Id == nil {
+		return fmt.Errorf("save action: nil id")
+	}
+
 	actionJSON, err := canonicalProtoJSON(action)
 	if err != nil {
 		return fmt.Errorf("marshal action: %w", err)
@@ -764,9 +772,13 @@ func (s *Store) SyncActions(actions []*pb.Action) (*SyncResult, error) {
 			return nil, fmt.Errorf("marshal action %s: %w", actionID, err)
 		}
 
+		// Decide "changed" once, in Go, on the COMPACTED JSON so that
+		// insignificant protojson whitespace drift (e.g. after a self-update to
+		// a binary with a different marshal seed) is not mistaken for a change.
+		changed := exists && (local.desiredState != newDesiredState || compactJSON([]byte(local.actionJSON)) != actionJSON)
 		if !exists {
 			result.NewActionIDs = append(result.NewActionIDs, actionID)
-		} else if local.desiredState != newDesiredState || compactJSON([]byte(local.actionJSON)) != actionJSON {
+		} else if changed {
 			result.ChangedActionIDs = append(result.ChangedActionIDs, actionID)
 		}
 
@@ -777,7 +789,14 @@ func (s *Store) SyncActions(actions []*pb.Action) (*SyncResult, error) {
 		now := s.now().UTC()
 		nextExecute := s.calculateNextExecute(action, &now, false)
 
-		// Upsert: insert new or update existing (but preserve execution history)
+		// Upsert: insert new or update existing (but preserve execution history).
+		// next_execute_at is reset ONLY when the action actually changed — driven
+		// by the Go `changed` decision above, NOT by a raw byte compare of the
+		// stored vs incoming JSON. The byte compare disagreed with the compacted
+		// Go compare, so whitespace-only drift reset a standalone action's cadence
+		// even though it was reported unchanged (it never appeared in
+		// ChangedActionIDs). Passing the precomputed decision keeps the two in
+		// lockstep.
 		_, err = tx.Exec(`
 			INSERT INTO actions (id, action_json, assigned_at, next_execute_at, desired_state)
 			VALUES (?, ?, CURRENT_TIMESTAMP, ?, ?)
@@ -785,12 +804,10 @@ func (s *Store) SyncActions(actions []*pb.Action) (*SyncResult, error) {
 				action_json = excluded.action_json,
 				desired_state = excluded.desired_state,
 				next_execute_at = CASE
-					WHEN excluded.desired_state != actions.desired_state
-						OR excluded.action_json != actions.action_json
-					THEN excluded.next_execute_at
+					WHEN ? THEN excluded.next_execute_at
 					ELSE actions.next_execute_at
 				END
-		`, actionID, actionJSON, nextExecute, newDesiredState)
+		`, actionID, actionJSON, nextExecute, newDesiredState, changed)
 		if err != nil {
 			return nil, fmt.Errorf("upsert action %s: %w", actionID, err)
 		}
@@ -918,10 +935,16 @@ func (s *Store) SyncStandaloneAndGrouped(standalone []*pb.Action, groups []*pb.A
 			return nil, fmt.Errorf("marshal action %s: %w", actionID, err)
 		}
 
+		// Same lockstep decision as SyncActions: compare the COMPACTED JSON in
+		// Go (whitespace drift is not a change) and also treat a grouped→
+		// standalone transition as changed. The SQL CASE consumes this single
+		// decision instead of raw-byte-comparing the JSON, which would reset a
+		// standalone action's cadence on insignificant drift.
 		local, exists := localActions[actionID]
+		changed := exists && (local.desiredState != newDesiredState || compactJSON([]byte(local.actionJSON)) != actionJSON || local.isGrouped != 0)
 		if !exists {
 			result.NewActionIDs = append(result.NewActionIDs, actionID)
-		} else if local.desiredState != newDesiredState || compactJSON([]byte(local.actionJSON)) != actionJSON || local.isGrouped != 0 {
+		} else if changed {
 			result.ChangedActionIDs = append(result.ChangedActionIDs, actionID)
 		}
 
@@ -935,13 +958,10 @@ func (s *Store) SyncStandaloneAndGrouped(standalone []*pb.Action, groups []*pb.A
 				desired_state = excluded.desired_state,
 				is_grouped = 0,
 				next_execute_at = CASE
-					WHEN excluded.desired_state != actions.desired_state
-						OR excluded.action_json != actions.action_json
-						OR actions.is_grouped != 0
-					THEN excluded.next_execute_at
+					WHEN ? THEN excluded.next_execute_at
 					ELSE actions.next_execute_at
 				END
-		`, actionID, actionJSON, nextExecute, newDesiredState)
+		`, actionID, actionJSON, nextExecute, newDesiredState, changed)
 		if err != nil {
 			return nil, fmt.Errorf("upsert action %s: %w", actionID, err)
 		}

--- a/internal/store/store_retention_test.go
+++ b/internal/store/store_retention_test.go
@@ -41,6 +41,32 @@ func resultExists(t *testing.T, st *Store, id string) bool {
 	return n == 1
 }
 
+// The rejection case is the point: a result that is OLD (past the soft
+// retention) but still UNSYNCED and under the hard age ceiling must SURVIVE —
+// the soft retention only evicts DELIVERED (synced) results; undelivered ones
+// are kept until the 30-day hard ceiling so they are not silently lost.
+func TestCleanupOldResults_KeepsOldUnsyncedUnderHardAge(t *testing.T) {
+	st, err := New(t.TempDir())
+	require.NoError(t, err)
+	defer st.Close()
+
+	base := time.Now()
+	clock := base
+	st.now = func() time.Time { return clock }
+
+	// 8 days old: past the 7-day soft retention, under the 30-day hard ceiling.
+	syncedOld := recordResultAt(t, st, &clock, base, "old-synced", 8*24*time.Hour, true)
+	unsyncedOld := recordResultAt(t, st, &clock, base, "old-unsynced", 8*24*time.Hour, false)
+
+	clock = base
+	_, err = st.CleanupOldResults(7 * 24 * time.Hour)
+	require.NoError(t, err)
+
+	assert.False(t, resultExists(t, st, syncedOld), "an old DELIVERED result is evicted at the soft retention")
+	assert.True(t, resultExists(t, st, unsyncedOld),
+		"an old UNDELIVERED result under the hard ceiling must survive the soft retention")
+}
+
 // TestCleanupOldResults_PrunesUnsyncedBeyondCeiling pins WS13 #6: the results
 // table is bounded INDEPENDENTLY of sync state. Ceilings are sourced from intent
 // (named constants), not from whatever the impl happens to do.

--- a/internal/store/store_saveaction_test.go
+++ b/internal/store/store_saveaction_test.go
@@ -1,0 +1,33 @@
+package store
+
+import (
+	"strings"
+	"testing"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// SaveAction dereferences action.Id.Value to build the upsert key. A nil Id
+// from a malformed envelope must be rejected with an error, NOT panic — the
+// sibling sync paths (SyncActions, SyncStandaloneAndGrouped) already skip
+// nil-Id actions, so SaveAction must be equally defensive rather than crash
+// the agent. (If the guard were absent this test would panic, not fail.)
+func TestSaveAction_NilId_ReturnsErrorNotPanic(t *testing.T) {
+	st, err := New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	err = st.SaveAction(&pb.Action{
+		Id:           nil,
+		Type:         pb.ActionType_ACTION_TYPE_PACKAGE,
+		DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
+	})
+	if err == nil {
+		t.Fatal("SaveAction with a nil Id must return an error, not succeed")
+	}
+	if !strings.Contains(err.Error(), "nil id") {
+		t.Errorf("error = %q, want it to name the nil id", err)
+	}
+}

--- a/internal/store/tty_test.go
+++ b/internal/store/tty_test.go
@@ -4,6 +4,57 @@ import (
 	"testing"
 )
 
+// IsTTYEnabled's accept-list is exercised DIRECTLY via SetSetting (not via
+// SetTTYEnabled, which only ever writes the canonical "1"/"0") so the test
+// isn't circular: it pins the exact set of truthy spellings a manual sqlite
+// edit might use. The disable set is sourced from intent (wrong-but-plausible
+// values), not from the switch under test, so an under-specified accept-list
+// would be caught.
+func TestIsTTYEnabled_AcceptListExactBothDirections(t *testing.T) {
+	enable := []string{"1", "true", "TRUE", " enabled ", "yes", "On"}
+	disable := []string{"0", "", "garbage", "2", "disabled", "tru", "enabled!"}
+
+	for _, v := range enable {
+		t.Run("enable/"+v, func(t *testing.T) {
+			st, err := New(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer st.Close()
+			if err := st.SetSetting(TTYSettingKey, v); err != nil {
+				t.Fatal(err)
+			}
+			enabled, err := st.IsTTYEnabled()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !enabled {
+				t.Errorf("IsTTYEnabled() with stored %q = false, want true", v)
+			}
+		})
+	}
+
+	for _, v := range disable {
+		t.Run("disable/"+v, func(t *testing.T) {
+			st, err := New(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer st.Close()
+			if err := st.SetSetting(TTYSettingKey, v); err != nil {
+				t.Fatal(err)
+			}
+			enabled, err := st.IsTTYEnabled()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if enabled {
+				t.Errorf("IsTTYEnabled() with stored %q = true, want false", v)
+			}
+		})
+	}
+}
+
 func TestTTYDefault_Disabled(t *testing.T) {
 	st, err := New(t.TempDir())
 	if err != nil {


### PR DESCRIPTION
WS17a — turn the remaining weak/missing agent rejection-path coverage into real, intent-asserting tests, and close the small agent-local guards the feature streams left open. Every code-fix finding was verified **RED-before-green**.

## Ground-truth note (verified before starting)
Several original WS17a findings were already closed by earlier streams — cross-referenced, not re-done:
- #4 file-over-directory refusal → **WS6** (fd-based safe writer + `assertFailed` integration test).
- #8 h2c/cleartext gateway refusal → **WS15** (`requireHTTPSGateway` + table-driven rejection test).
- #20 corrupt-maintenance-window fail-closed → **WS15** (`windowDecodeFailed` + `scheduler_failclosed_test.go`).
- #24 `enc:v1:` redaction → already covered by `TestSanitizeForLog`; only a plaintext-boundary assertion + comment tightening added.
- #28 status-cache trio, #30 unit-vs-integration CI split → already present.

## Code fixes (+ pinning test, each RED-verified)
- **#17** `SyncActions` / `SyncStandaloneAndGrouped` reset `next_execute_at` via a raw byte compare that disagreed with the Go compacted change decision, so insignificant protojson whitespace drift reset a standalone action's cadence. Pass the precomputed `changed` decision into the CASE. *(RED: drift reset 20:00→21:00.)*
- **#18** `SaveAction` panicked on a nil `action.Id`; now returns an error like the sync paths. *(RED: nil-pointer panic.)*
- **#11** `TerminalStart.session_id` is now validated as a ULID before it is spliced into the root-`chown`-ed `/tmp` tempHome path. *(RED: traversal/empty/NUL ids slipped to the user lookup.)*
- **#27** `executeWifi` runs the action ID through `validateActionIDForFilesystem` (was empty-string only).
- **#15/#16** extract shared `createUserSetsPassword`; bind `createUser` + `desiredAccountLocked`; rebind the test to the real function (was an inline hand-copy).
- **#29** export `credentials.MachineIDAvailable` + skip-guard the cert-reload test on machine-id-less hosts.

## Seam + rejection tests (guard already correct)
#12 apt security-only fail-closed · #13 reboot-failure-is-an-action-error (+ notify gated on success, joins not demotes) · #14 `interpretUpdateCheck` extraction (gives zypper a real assertion) · #7/#22 euid-deterministic root/sudo default · #23 service-backend overrides.

## Test-only against existing guards
#3 ssh authorized_keys embedded-newline · #5 changed/new execute, unchanged does not (store + scheduler) · #6 tty accept-list exact both directions · #9 prefixed-but-invalid tty username · #10 session-limit + duplicate-session via the real handler · #19 busy_timeout/WAL per pooled connection · #21 `GetUnsyncedResults` filter/order/round-trip + `MarkResultSynced` no-op + old-unsynced survival · #25 shell env-var allow-list · #26 locked tty user.

## Cross-referenced / out of this PR
- **#1** osquery sensitive-table deny-list → manchtools/power-manage-sdk#119 (gate was nominally WS4's; WS4 shipped signing, not a table policy).
- **#2** signed-action replay/freshness → **blocked**: the WS1 signing envelope shipped with no freshness/nonce field, so there is nothing to pin without a cross-repo protocol change (WS1 scope). Tracked, no fabricated always-skip test.

## Verification
`gofmt` clean · `go vet ./...` (incl. `-tags=integration`) clean · full `go test -race ./...` green · local CodeRabbit review: **No findings**.

Closes #133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added input validation for terminal sessions, WiFi actions, and SSH keys to prevent unsafe operations
  * Improved environment variable validation for shell execution
  
* **Bug Fixes**
  * Enhanced error handling for package updates and reboot scheduling
  * Fixed action execution schedule preservation for unchanged actions
  
* **Tests**
  * Expanded test coverage for input validation, database configuration, and sync behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->