### PR TITLE
fix(executor): fail closed on unverified AppImage artifacts (parity with rpm/deb)

### DIFF
--- a/internal/executor/action_appimage.go
+++ b/internal/executor/action_appimage.go
@@ -67,6 +67,19 @@ func (e *Executor) executeAppImage(ctx context.Context, params *pb.AppInstallPar
 	if filename == "." || filename == ".." || filename == "/" || filename == "" || strings.ContainsAny(filename, `/\`) {
 		return nil, false, fmt.Errorf("appimage URL %q does not yield a usable filename", params.Url)
 	}
+
+	// Defense-in-depth (parity with rpm/deb): refuse to INSTALL an unverified
+	// artifact — require https + a non-empty checksum — before any path
+	// resolution, privileged remount, or download. The control server validator
+	// already mandates a checksum for AppInstallParams, so this is belt-and-
+	// suspenders, not a behaviour change for legitimate dispatches. ABSENT
+	// (removal) needs no checksum, so the guard is PRESENT-only.
+	if state == pb.DesiredState_DESIRED_STATE_PRESENT {
+		if err := requireVerifiedArtifact(params.Url, params.ChecksumSha256); err != nil {
+			return nil, false, err
+		}
+	}
+
 	fullPath := filepath.Join(installPath, filename)
 
 	// Resolve symlinks to prevent traversal attacks

--- a/internal/executor/action_appimage_test.go
+++ b/internal/executor/action_appimage_test.go
@@ -1,0 +1,64 @@
+package executor
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// TestExecuteAppImage_RejectsBeforeWriteAndRemount pins WS7/WS8 parity with
+// rpm/deb: installing an AppImage with a non-https URL or an empty/whitespace
+// checksum is refused BEFORE any privileged filesystem remount or download — an
+// unverified binary is never fetched. The recording repairFS seam proves no
+// remount ran. (ABSENT removal needs no checksum — see the sibling test.)
+func TestExecuteAppImage_RejectsBeforeWriteAndRemount(t *testing.T) {
+	validHex := strings.Repeat("a", 64)
+	cases := []struct {
+		name string
+		p    *pb.AppInstallParams
+	}{
+		{"http url", &pb.AppInstallParams{Url: "http://mirror/x.AppImage", ChecksumSha256: validHex}},
+		{"empty checksum", &pb.AppInstallParams{Url: "https://x/x.AppImage", ChecksumSha256: ""}},
+		{"whitespace checksum", &pb.AppInstallParams{Url: "https://x/x.AppImage", ChecksumSha256: "   "}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// A resolvable install dir so it is the verification guard — not a
+			// path-resolution failure — that rejects the install.
+			tc.p.InstallPath = t.TempDir()
+			var remountCalls int
+			e := &Executor{logger: slog.Default(), now: time.Now, repairFS: func(context.Context) bool {
+				remountCalls++
+				return true
+			}}
+			out, changed, err := e.executeAppImage(context.Background(), tc.p, pb.DesiredState_DESIRED_STATE_PRESENT)
+			if err == nil {
+				t.Fatalf("expected rejection, got out=%v changed=%v", out, changed)
+			}
+			if remountCalls != 0 {
+				t.Errorf("privileged remount ran %d times before artifact verification; want 0", remountCalls)
+			}
+		})
+	}
+}
+
+// TestExecuteAppImage_AbsentDoesNotRequireChecksum pins that the checksum guard
+// is PRESENT-only: removing an AppImage needs no checksum (parity with the
+// DEB guard, which is also install-only).
+func TestExecuteAppImage_AbsentDoesNotRequireChecksum(t *testing.T) {
+	e := &Executor{logger: slog.Default(), now: time.Now}
+	out, changed, err := e.executeAppImage(context.Background(),
+		&pb.AppInstallParams{Url: "https://x/x.AppImage", InstallPath: t.TempDir(), ChecksumSha256: ""},
+		pb.DesiredState_DESIRED_STATE_ABSENT)
+	if err != nil {
+		t.Fatalf("ABSENT removal must not require a checksum: %v", err)
+	}
+	if changed {
+		t.Errorf("removing a non-existent appimage should report no change")
+	}
+	_ = out
+}

--- a/internal/executor/integration_test.go
+++ b/internal/executor/integration_test.go
@@ -1539,11 +1539,14 @@ func TestIntegration_AppImage(t *testing.T) {
 	})
 
 	t.Run("InstallIdempotent", func(t *testing.T) {
-		// Test without checksum — file existence check should give changed=false
+		// Re-install with the SAME checksum — the file already exists with the
+		// correct hash, so the executor reports changed=false. (AppImage installs
+		// now fail closed without a checksum, parity with rpm/deb.)
 		action := makeAction(t, pb.ActionType_ACTION_TYPE_APP_IMAGE, pb.DesiredState_DESIRED_STATE_PRESENT)
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
-			Url:         ts.URL + "/" + fileName,
-			InstallPath: installDir,
+			Url:            ts.URL + "/" + fileName,
+			ChecksumSha256: checksumHex,
+			InstallPath:    installDir,
 		}}
 		result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
 		assertSuccess(t, result)
@@ -2437,6 +2440,10 @@ func TestIntegration_EdgeCase_DownloadHttp500(t *testing.T) {
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
 			Url:         ts.URL + "/test.AppImage",
 			InstallPath: t.TempDir(),
+			// Checksum is mandated and the executor fails closed without it before
+			// downloading (parity with rpm/deb); the value is irrelevant here —
+			// the download errors with the HTTP status first.
+			ChecksumSha256: strings.Repeat("a", 64),
 		}}
 		result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
 		assertFailed(t, result)
@@ -2493,6 +2500,10 @@ func TestIntegration_EdgeCase_DownloadHttp404(t *testing.T) {
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
 			Url:         ts.URL + "/test.AppImage",
 			InstallPath: t.TempDir(),
+			// Checksum is mandated and the executor fails closed without it before
+			// downloading (parity with rpm/deb); the value is irrelevant here —
+			// the download errors with the HTTP status first.
+			ChecksumSha256: strings.Repeat("a", 64),
 		}}
 		result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
 		assertFailed(t, result)
@@ -2582,6 +2593,10 @@ func TestIntegration_EdgeCase_DownloadTimeout(t *testing.T) {
 	action.Params = &pb.Action_App{App: &pb.AppInstallParams{
 		Url:         ts.URL + "/test.AppImage",
 		InstallPath: installDir,
+		// Checksum is mandated and the executor fails closed without it before
+		// downloading (parity with rpm/deb); the value is irrelevant here — the
+		// slow download trips the action timeout first.
+		ChecksumSha256: strings.Repeat("a", 64),
 	}}
 	// Set a 1-second timeout on the action
 	action.TimeoutSeconds = 1
@@ -3022,6 +3037,9 @@ func TestIntegration_EdgeCase_DNSResolutionFailure(t *testing.T) {
 		action.Params = &pb.Action_App{App: &pb.AppInstallParams{
 			Url:         "https://this-domain-does-not-exist-xyzzy.invalid/app.AppImage",
 			InstallPath: "/tmp/pm-edge-dns",
+			// Supply a checksum so the install passes the artifact-verification
+			// guard and actually reaches the DNS resolution this test exercises.
+			ChecksumSha256: strings.Repeat("a", 64),
 		}}
 		result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
 		assertFailed(t, result)
@@ -3074,6 +3092,9 @@ func TestIntegration_EdgeCase_HTTPSCertError(t *testing.T) {
 	action.Params = &pb.Action_App{App: &pb.AppInstallParams{
 		Url:         ts.URL + "/test.AppImage",
 		InstallPath: "/tmp/pm-edge-tls",
+		// Supply a checksum so the install passes the artifact-verification guard
+		// and actually reaches the TLS handshake this test exercises.
+		ChecksumSha256: strings.Repeat("a", 64),
 	}}
 	result := e.ExecuteEnvelope(ctx, actionToEnvelope(action))
 	assertFailed(t, result)


### PR DESCRIPTION
Closes #135.

executeAppImage gated the checksum behind `if ChecksumSha256 != ""`, so an empty checksum was accepted at the agent boundary while rpm/deb call `requireVerifiedArtifact` (https + non-empty checksum, fail-closed). The control validator already mandates a checksum for AppInstallParams, so this is defense-in-depth — and it makes the agent README / ADR 0012 claim ("RPM/DEB/APP_IMAGE … fail-closed before remount/download") actually true.

Adds the guard to the PRESENT path before path resolution / privileged remount / download (ABSENT removal needs no checksum → install-only). Tests pin rejection-before-remount via a recording repairFS seam + the PRESENT-only behaviour; red-checked.