### PR TITLE
fix(executor,store): checksum well-formedness (WS16) + fail-closed data-dir mode (WS14)

### DIFF
--- a/internal/executor/action_rpm.go
+++ b/internal/executor/action_rpm.go
@@ -170,8 +170,32 @@ func requireVerifiedArtifact(rawURL, checksum string) error {
 	if err := validateHTTPS(rawURL); err != nil {
 		return fmt.Errorf("artifact rejected: %w", err)
 	}
-	if strings.TrimSpace(checksum) == "" {
+	checksum = strings.TrimSpace(checksum)
+	if checksum == "" {
 		return fmt.Errorf("artifact rejected: checksum_sha256 is required (refusing to install an unverified binary)")
 	}
+	// Validate the FORM, not just presence: a sha256 is exactly 64 hex chars.
+	// A malformed checksum can never match the downloaded artifact, so reject it
+	// up front with a clear message rather than failing late at the post-download
+	// compare (WS16 #2 well-formedness).
+	if !isHex64(checksum) {
+		return fmt.Errorf("artifact rejected: checksum_sha256 must be 64 hexadecimal characters")
+	}
 	return nil
+}
+
+// isHex64 reports whether s is exactly 64 hexadecimal characters (a sha256
+// digest), case-insensitively — operators routinely paste uppercase digests.
+func isHex64(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for _, c := range s {
+		switch {
+		case c >= '0' && c <= '9', c >= 'a' && c <= 'f', c >= 'A' && c <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/internal/executor/action_rpm_test.go
+++ b/internal/executor/action_rpm_test.go
@@ -67,11 +67,18 @@ func TestRequireVerifiedArtifact(t *testing.T) {
 	if err := requireVerifiedArtifact("https://x/x.rpm", validHex); err != nil {
 		t.Errorf("valid https+checksum rejected: %v", err)
 	}
+	// Uppercase / surrounding whitespace is a valid sha256 (operators paste it).
+	if err := requireVerifiedArtifact("https://x/x.rpm", "  "+strings.Repeat("A", 64)+"  "); err != nil {
+		t.Errorf("valid uppercase checksum rejected: %v", err)
+	}
 	bad := []struct{ url, sum string }{
 		{"http://x/x.rpm", validHex}, // non-https → MITM
 		{"ftp://x/x.rpm", validHex},
-		{"https://x/x.rpm", ""},    // empty checksum → unverified
-		{"https://x/x.rpm", "   "}, // whitespace-only checksum
+		{"https://x/x.rpm", ""},                      // empty checksum → unverified
+		{"https://x/x.rpm", "   "},                   // whitespace-only checksum
+		{"https://x/x.rpm", "abc123"},                // too short → malformed
+		{"https://x/x.rpm", strings.Repeat("a", 63)}, // wrong length → malformed
+		{"https://x/x.rpm", strings.Repeat("z", 64)}, // non-hex chars → malformed
 	}
 	for _, tc := range bad {
 		if err := requireVerifiedArtifact(tc.url, tc.sum); err == nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -141,6 +141,14 @@ func New(dataDir string) (*Store, error) {
 		db.Close()
 		return nil, fmt.Errorf("restrict data dir mode: %w", err)
 	}
+	// Re-stat to confirm the chmod actually tightened the mode: os.Chmod can
+	// silently no-op on some filesystems (9p, certain network/vfat mounts),
+	// which would leave the secrets dir group/world-accessible while Chmod
+	// reported success. Fail closed — "couldn't tighten → error", not "tried".
+	if err := verifyRestrictiveDirMode(dataDir); err != nil {
+		db.Close()
+		return nil, err
+	}
 	for _, p := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
 		if err := os.Chmod(p, 0o600); err != nil && !os.IsNotExist(err) {
 			db.Close()
@@ -149,6 +157,21 @@ func New(dataDir string) (*Store, error) {
 	}
 
 	return &Store{db: db, now: time.Now}, nil
+}
+
+// verifyRestrictiveDirMode fails closed unless dir has NO group/world permission
+// bits, i.e. the chmod to 0700 actually took effect. os.Chmod's success return
+// is not enough: on filesystems that don't honour Unix modes it silently no-ops,
+// which would leave the secrets data dir readable by other local users.
+func verifyRestrictiveDirMode(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("stat data dir after chmod: %w", err)
+	}
+	if perm := info.Mode().Perm(); perm&0o077 != 0 {
+		return fmt.Errorf("data dir %s is %#o after tightening; refusing to store secrets in a group/world-accessible directory", dir, perm)
+	}
+	return nil
 }
 
 // SetClockForTest overrides the store's clock seam. Test-only: the scheduler's

--- a/internal/store/store_perms_test.go
+++ b/internal/store/store_perms_test.go
@@ -10,6 +10,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestVerifyRestrictiveDirMode_FailsClosedOnWideDir pins WS14 #6's "couldn't
+// tighten → error" contract: the post-chmod re-stat must REJECT a data dir that
+// still carries group/world bits (the case where os.Chmod silently no-ops on a
+// mount that ignores modes), and accept a 0700 dir.
+func TestVerifyRestrictiveDirMode_FailsClosedOnWideDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not meaningful on Windows")
+	}
+	dir := t.TempDir()
+
+	require.NoError(t, os.Chmod(dir, 0o777)) // simulate a chmod that did not tighten
+	require.Error(t, verifyRestrictiveDirMode(dir),
+		"a group/world-accessible data dir must be rejected, not accepted")
+
+	require.NoError(t, os.Chmod(dir, 0o750)) // group still has access
+	require.Error(t, verifyRestrictiveDirMode(dir),
+		"any group/world permission bit must be rejected")
+
+	require.NoError(t, os.Chmod(dir, 0o700))
+	require.NoError(t, verifyRestrictiveDirMode(dir), "a 0700 dir must be accepted")
+}
+
 // TestStoreNew_TightensDataDirAndDBFileModes pins WS14 #6: store.New re-asserts
 // 0700 on the data dir and 0600 on the DB + its WAL/SHM sidecars, even when the
 // dir pre-existed with a wider mode (distro package, prior umask) — the DB holds


### PR DESCRIPTION
Closes #137.

- **WS16**: `requireVerifiedArtifact` now rejects a checksum that isn't a well-formed 64-hex sha256 (case-insensitive), not just empty — a malformed checksum can never match the artifact, so fail up front rather than late at the post-download compare.
- **WS14 #6**: `store.New` re-stats the secrets data dir after `chmod 0700` and fails closed if any group/world bit remains (`os.Chmod` silently no-ops on mounts that ignore Unix modes), enforcing the 'couldn't tighten → error' contract. New `verifyRestrictiveDirMode` helper + wide-dir rejection test.

Unit + (checksum-using) integration tests green locally.