### PR TITLE
test(deviceauth): WS9 enrollment coverage + consume shared cryptotest fixtures (WS16b)

### DIFF
--- a/internal/deviceauth/enroll_hardening_test.go
+++ b/internal/deviceauth/enroll_hardening_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"log/slog"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -64,6 +65,82 @@ func TestEnroll_RateLimitRejectsSixthInWindow(t *testing.T) {
 	assert.False(t, resp.Msg.Success)
 	assert.Contains(t, resp.Msg.Error, "rate limit")
 	assert.EqualValues(t, 5, atomic.LoadInt32(&registerCalls), "the 6th attempt must not reach the network")
+}
+
+// TestEnroll_RateLimitSlidingWindowEviction pins WS9 #6: the limiter is a
+// SLIDING window, not a permanent lockout — attempts older than the window are
+// evicted, so once the window passes enrollment is allowed again. (The
+// within-window rejection is covered by TestEnroll_RateLimitRejectsSixthInWindow;
+// this covers the eviction side, and also that FAILED attempts consume budget,
+// since all six here fail registration yet still trip the limit.)
+func TestEnroll_RateLimitSlidingWindowEviction(t *testing.T) {
+	var registerCalls int32
+	mock := &mockRegisterService{
+		registerFunc: func(_ context.Context, _ *connect.Request[pm.RegisterRequest]) (*connect.Response[pm.RegisterResponse], error) {
+			atomic.AddInt32(&registerCalls, 1)
+			return nil, connect.NewError(connect.CodePermissionDenied, nil)
+		},
+	}
+	srv := startMockControlServer(t, mock)
+	credStore := credentials.NewStore(t.TempDir())
+	h := NewEnrollHandler("test-host", "dev", credStore, slog.Default(), nil)
+	h.registerOpts = trustServer(srv)
+	now := time.Now()
+	h.now = func() time.Time { return now }
+
+	// Exhaust the window: 5 reach (and fail) registration, the 6th is rate-limited.
+	for i := 0; i < 6; i++ {
+		_, err := h.Enroll(context.Background(), connect.NewRequest(&pm.EnrollRequest{ServerUrl: srv.URL, Token: "tok"}))
+		require.NoError(t, err)
+	}
+	require.EqualValues(t, 5, atomic.LoadInt32(&registerCalls), "only 5 attempts may reach the network within one window")
+
+	// Advance past the 1-minute window: the prior attempts are evicted, so a
+	// fresh attempt is allowed through to registration again.
+	now = now.Add(61 * time.Second)
+	resp, err := h.Enroll(context.Background(), connect.NewRequest(&pm.EnrollRequest{ServerUrl: srv.URL, Token: "tok"}))
+	require.NoError(t, err)
+	assert.Contains(t, resp.Msg.Error, "registration failed", "after the window resets, enrollment is allowed through again")
+	assert.EqualValues(t, 6, atomic.LoadInt32(&registerCalls), "a fresh attempt after the window must reach registration")
+}
+
+// TestEnroll_ConcurrentSerializesToOneRegistration pins WS9 #12: enrollMu
+// serializes the enrollment body, so concurrent Enroll calls (all within the
+// rate-limit budget) cannot each pass the Exists() check and register duplicate
+// devices — the first registers and saves, and the rest short-circuit. Without
+// the lock this would race to N registrations / a corrupt Save.
+func TestEnroll_ConcurrentSerializesToOneRegistration(t *testing.T) {
+	var registerCalls int32
+	mock := &mockRegisterService{
+		registerFunc: func(_ context.Context, _ *connect.Request[pm.RegisterRequest]) (*connect.Response[pm.RegisterResponse], error) {
+			atomic.AddInt32(&registerCalls, 1)
+			return connect.NewResponse(&pm.RegisterResponse{
+				DeviceId:    &pm.DeviceId{Value: "dev-123"},
+				CaCert:      []byte("-----BEGIN CERTIFICATE-----\nfake-ca\n-----END CERTIFICATE-----\n"),
+				Certificate: []byte("-----BEGIN CERTIFICATE-----\nfake-cert\n-----END CERTIFICATE-----\n"),
+				GatewayUrl:  "https://gw.example.com:8443",
+			}), nil
+		},
+	}
+	srv := startMockControlServer(t, mock)
+	credStore := credentials.NewStore(t.TempDir())
+	h := NewEnrollHandler("test-host", "dev", credStore, slog.Default(), nil)
+	h.registerOpts = trustServer(srv)
+
+	const n = 5 // within the 5/min budget, so all reach the serialized body
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = h.Enroll(context.Background(), connect.NewRequest(&pm.EnrollRequest{ServerUrl: srv.URL, Token: "tok"}))
+		}()
+	}
+	wg.Wait()
+
+	assert.EqualValues(t, 1, atomic.LoadInt32(&registerCalls),
+		"enrollMu must serialize concurrent enrollments so exactly one device registers; the rest short-circuit on Exists()")
+	assert.True(t, credStore.Exists(), "the single enrollment must have saved credentials")
 }
 
 // TestEnroll_RejectsMissingMTLSCerts pins fail-closed when the server

--- a/internal/deviceauth/enroll_pin_test.go
+++ b/internal/deviceauth/enroll_pin_test.go
@@ -2,17 +2,9 @@ package deviceauth
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"log/slog"
-	"math/big"
 	"strings"
 	"testing"
-	"time"
 
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
@@ -22,6 +14,7 @@ import (
 
 	"github.com/manchtools/power-manage/agent/internal/credentials"
 	pmcrypto "github.com/manchtools/power-manage/sdk/go/crypto"
+	"github.com/manchtools/power-manage/sdk/go/cryptotest"
 )
 
 const fakeLeafPEM = "-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----\n"
@@ -29,20 +22,7 @@ const fakeLeafPEM = "-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE----
 // genTestCAPEM creates a self-signed CA certificate (PEM) for pin tests.
 func genTestCAPEM(t *testing.T) []byte {
 	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	tmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "test-ca"},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		IsCA:                  true,
-		KeyUsage:              x509.KeyUsageCertSign,
-		BasicConstraintsValid: true,
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	require.NoError(t, err)
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return cryptotest.CAPEM(t, "test-ca")
 }
 
 func caReturningMock(caPEM []byte) *mockRegisterService {

--- a/internal/deviceauth/status_cache_test.go
+++ b/internal/deviceauth/status_cache_test.go
@@ -2,6 +2,7 @@ package deviceauth
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -32,6 +33,41 @@ func (c *countingStore) Save(*credentials.Credentials) error { return nil }
 
 func newStatusHandler(store credentialStore) *EnrollHandler {
 	return &EnrollHandler{credStore: store, logger: slog.Default(), now: time.Now}
+}
+
+// flakyStore is a credentialStore whose Load result is controllable, so a test
+// can exercise the "credentials exist but Load fails" path.
+type flakyStore struct {
+	exists bool
+	creds  *credentials.Credentials
+	err    error
+}
+
+func (f *flakyStore) Exists() bool                            { return f.exists }
+func (f *flakyStore) Load() (*credentials.Credentials, error) { return f.creds, f.err }
+func (f *flakyStore) Save(*credentials.Credentials) error     { return nil }
+
+// TestGetEnrollmentStatus_LoadFailureNotCached pins WS9 #7: when credentials
+// EXIST but Load fails (a transient decrypt/IO error), status reports
+// not-enrolled and does NOT cache that result — so a later successful Load is
+// still observed as enrolled. A cached failure would pin "not enrolled" for the
+// whole process lifetime after one transient blip.
+func TestGetEnrollmentStatus_LoadFailureNotCached(t *testing.T) {
+	store := &flakyStore{exists: true, err: errors.New("decrypt failed")}
+	h := newStatusHandler(store)
+
+	resp, err := h.GetEnrollmentStatus(context.Background(), connect.NewRequest(&pm.GetEnrollmentStatusRequest{}))
+	require.NoError(t, err)
+	assert.False(t, resp.Msg.Enrolled, "a load failure must report not-enrolled")
+
+	// Recover: once Load succeeds the status must flip — proving the failure was
+	// not cached.
+	store.err = nil
+	store.creds = &credentials.Credentials{DeviceID: "dev-recovered"}
+	resp, err = h.GetEnrollmentStatus(context.Background(), connect.NewRequest(&pm.GetEnrollmentStatusRequest{}))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.Enrolled, "a transient load failure must not be cached as not-enrolled")
+	assert.Equal(t, "dev-recovered", resp.Msg.DeviceId)
 }
 
 // GetEnrollmentStatus must not run credStore.Load() (a 64 MiB Argon2id

--- a/internal/executor/execute_verified_envelope_test.go
+++ b/internal/executor/execute_verified_envelope_test.go
@@ -2,13 +2,6 @@ package executor
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
-	"math/big"
 	"strings"
 	"testing"
 
@@ -16,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/cryptotest"
 	"github.com/manchtools/power-manage/sdk/go/verify"
 )
 
@@ -24,19 +18,8 @@ import (
 // by this signer verifies; anything else (or nothing) is refused.
 func testVerifierAndSigner(t *testing.T) (*Executor, *verify.ActionSigner) {
 	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	tmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "test-ca"},
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	require.NoError(t, err)
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
-	verifier, err := verify.NewActionVerifier(certPEM)
+	caPEM, key, _ := cryptotest.GenCA(t, "test-ca")
+	verifier, err := verify.NewActionVerifier(caPEM)
 	require.NoError(t, err)
 	return NewExecutor(verifier), verify.NewActionSigner(key)
 }

--- a/internal/handler/sync_verify_test.go
+++ b/internal/handler/sync_verify_test.go
@@ -2,14 +2,7 @@ package handler
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"log/slog"
-	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,6 +10,7 @@ import (
 
 	"github.com/manchtools/power-manage/agent/internal/executor"
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/cryptotest"
 	"github.com/manchtools/power-manage/sdk/go/verify"
 )
 
@@ -26,19 +20,8 @@ import (
 // by any OTHER key (or no signature) is rejected.
 func testCAAndSigner(t *testing.T) ([]byte, *verify.ActionSigner) {
 	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	tmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "test-ca"},
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	require.NoError(t, err)
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
-	return certPEM, verify.NewActionSigner(key)
+	caPEM, key, _ := cryptotest.GenCA(t, "test-ca")
+	return caPEM, verify.NewActionSigner(key)
 }
 
 // signEnvelope marshals env into its deterministic wire bytes and signs

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -31,6 +31,10 @@ var (
 	testVerifier *verify.ActionVerifier
 )
 
+// init builds the package-level signer/verifier. It cannot use the shared
+// sdk/go/cryptotest fixtures because those require a *testing.TB (for t.Helper /
+// t.Fatalf) and init() has none; the other agent test packages, whose CA setup
+// runs inside a test helper, consume cryptotest.GenCA instead.
 func init() {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {


### PR DESCRIPTION
Agent test coverage backfills over already-correct code:

**WS9 enrollment (#6/#7/#12):**
- sliding-window rate-limit eviction (the limiter is a window, not a lockout; failed attempts consume budget)
- status load-failure reports not-enrolled WITHOUT caching (a transient blip recovers)
- enrollMu serializes concurrent Enroll calls → exactly one registration (race-clean)

**WS16b:** migrate the handler/executor/deviceauth test CA helpers onto the shared `cryptotest.GenCA`/`CAPEM` fixtures (scheduler's init() keeps its own — cryptotest needs a *testing.TB).