### PR TITLE
fix(agent): refuse enrollment via URI handler (WS7) + WS14 revert/group coverage

### DIFF
--- a/cmd/power-manage-agent/cmd_enroll.go
+++ b/cmd/power-manage-agent/cmd_enroll.go
@@ -175,39 +175,14 @@ func runEnroll(args []string) {
 	fmt.Printf("Enrolled successfully. Device ID: %s\n", resp.Msg.DeviceId)
 }
 
-// trySocketEnroll attempts to enroll via the agent's enrollment socket.
-// Returns true if enrollment succeeded (caller should exit).
-func trySocketEnroll(parsed *registrationURI) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	httpClient := unixSocketHTTPClient(deviceauth.EnrollSocketPath)
-	client := pmv1connect.NewDeviceAuthServiceClient(httpClient, "http://localhost")
-
-	// Check if the enrollment socket is available
-	_, err := client.GetEnrollmentStatus(ctx, connect.NewRequest(&pm.GetEnrollmentStatusRequest{}))
-	if err != nil {
-		// Socket not available — fall back to direct registration
-		return false
-	}
-
-	resp, err := client.Enroll(ctx, connect.NewRequest(&pm.EnrollRequest{
-		ServerUrl:        parsed.ServerURL,
-		Token:            parsed.Token,
-		CaFingerprintPin: strings.ReplaceAll(strings.TrimSpace(parsed.Pin), ":", ""),
-	}))
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: socket enrollment failed: %v\n", err)
-		return false
-	}
-
-	if !resp.Msg.Success {
-		fmt.Fprintf(os.Stderr, "error: socket enrollment failed: %s\n", resp.Msg.Error)
-		return false
-	}
-
-	fmt.Printf("Enrolled successfully via agent socket. Device ID: %s\n", resp.Msg.DeviceId)
-	return true
+// registrationURIRefusedByHandler reports whether the bare-binary / desktop
+// URI-handler path must REFUSE uri. luks operation URIs (power-manage://luks/…)
+// are handled upstream; any OTHER power-manage:// URI is a registration URI
+// (server+token) and must not auto-enroll from a URI handler — a browser link
+// could otherwise silently enroll the device into an attacker-controlled
+// backend. Enrollment is only allowed via the explicit `enroll` subcommand. (WS7)
+func registrationURIRefusedByHandler(uri string) bool {
+	return strings.HasPrefix(uri, "power-manage://") && !strings.HasPrefix(uri, "power-manage://luks/")
 }
 
 type registrationURI struct {

--- a/cmd/power-manage-agent/cmd_enroll_test.go
+++ b/cmd/power-manage-agent/cmd_enroll_test.go
@@ -83,3 +83,27 @@ func TestResolveEnrollToken(t *testing.T) {
 		})
 	}
 }
+
+// TestRegistrationURIRefusedByHandler pins WS7: the bare-binary / desktop
+// URI-handler path refuses registration URIs (server+token) — only luks
+// operation URIs are allowed — so a browser-triggered power-manage:// link can
+// never silently enroll the device. Enrollment stays explicit (the `enroll`
+// subcommand).
+func TestRegistrationURIRefusedByHandler(t *testing.T) {
+	cases := []struct {
+		uri    string
+		refuse bool
+	}{
+		{"power-manage://gateway.example.com:8080?token=abc123", true}, // registration → refused
+		{"power-manage://server?token=t&pin=DEADBEEF", true},
+		{"power-manage://luks/set-passphrase?token=xxx", false}, // luks op → allowed through to runLuksURI
+		{"power-manage://luks/rotate", false},
+		{"https://example.com/?token=x", false}, // not our scheme
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := registrationURIRefusedByHandler(c.uri); got != c.refuse {
+			t.Errorf("registrationURIRefusedByHandler(%q) = %v, want %v", c.uri, got, c.refuse)
+		}
+	}
+}

--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -356,18 +356,17 @@ func parseFlags() *Config {
 		runLuksURI(uri) // runLuksURI always exits
 	}
 
-	// Parse power-manage:// URI if provided (registration URIs)
-	// Format: power-manage://server:port?token=xxx
-	if uri != "" {
-		if parsed, err := parseRegistrationURI(uri); err == nil {
-			// Try socket enrollment first (no sudo needed)
-			if trySocketEnroll(parsed) {
-				os.Exit(0)
-			}
-			// Fallback to direct registration (sudo/service mode)
-			cfg.ServerURL = parsed.ServerURL
-			cfg.Token = parsed.Token
-		}
+	// Any remaining power-manage:// URI here is a REGISTRATION URI (server+token)
+	// arriving via the bare-binary / desktop URI-handler path (luks URIs already
+	// exited above). REFUSE it (WS7): a browser-triggered
+	// power-manage://<server>?token=... must not silently enroll this device into
+	// an attacker-controlled backend. Enrollment must be an explicit,
+	// operator-initiated action via the `enroll` subcommand, which accepts the
+	// same URI.
+	if registrationURIRefusedByHandler(uri) {
+		fmt.Fprintln(os.Stderr, "refusing to enroll from a URI handler: enrollment must be explicit. Run:")
+		fmt.Fprintf(os.Stderr, "  power-manage-agent enroll '%s'\n", uri)
+		os.Exit(1)
 	}
 
 	// Allow environment variables to override

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -341,6 +341,10 @@ func TestRemoveAction_MissingActionNoError(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRemoveAction_AllPolicyTypes(t *testing.T) {
+	// All SIX revertible types per shouldRevertOnUnassign — USER and GROUP join
+	// the policy-style reverters (a user/group created by an assignment must not
+	// outlive it). This list must stay in lockstep with shouldRevertOnUnassign;
+	// the self-discovering partition test (scheduler_ws14_test.go) guards that.
 	policyTypes := []struct {
 		name       string
 		actionType pb.ActionType
@@ -349,6 +353,8 @@ func TestRemoveAction_AllPolicyTypes(t *testing.T) {
 		{"SSHD", pb.ActionType_ACTION_TYPE_SSHD},
 		{"Sudo", pb.ActionType_ACTION_TYPE_ADMIN_POLICY},
 		{"LPS", pb.ActionType_ACTION_TYPE_LPS},
+		{"User", pb.ActionType_ACTION_TYPE_USER},
+		{"Group", pb.ActionType_ACTION_TYPE_GROUP},
 	}
 
 	for _, tt := range policyTypes {
@@ -620,6 +626,54 @@ func TestRunDueActions_GroupRunOnAssign_OrdersMembers(t *testing.T) {
 		if calls[i].GetActionId().GetValue() != want {
 			t.Errorf("call %d: expected %q got %q", i, want, calls[i].GetActionId().GetValue())
 		}
+	}
+}
+
+// TestExecuteGroup_FailingMiddleMemberStillRunsLaterAndAdvancesGroup pins WS14
+// #3: a group member that FAILS must not abort the group — later members still
+// run in order — and the group cursor must still advance (MarkGroupExecuted), so
+// a failing member can't wedge the group into re-running every tick.
+func TestExecuteGroup_FailingMiddleMemberStillRunsLaterAndAdvancesGroup(t *testing.T) {
+	sched, mock := newTestScheduler(t)
+	ctx := context.Background()
+
+	a1 := makeTestAction("fm-a1", pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT)
+	a2 := makeTestAction("fm-a2", pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT)
+	a3 := makeTestAction("fm-a3", pb.ActionType_ACTION_TYPE_SHELL, pb.DesiredState_DESIRED_STATE_PRESENT)
+	group := &pb.ActionGroup{
+		SourceLabel: "action_set:fail-middle",
+		Schedule:    &pb.ActionSchedule{RunOnAssign: true, IntervalHours: 8},
+		Actions:     []*pb.Action{a1, a2, a3},
+	}
+	if err := sched.SyncActions(ctx, nil, []*pb.ActionGroup{group}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// The MIDDLE member fails. The group must not abort on it.
+	mock.setScript("fm-a2", &pb.ActionResult{
+		ActionId: &pb.ActionId{Value: "fm-a2"},
+		Status:   pb.ExecutionStatus_EXECUTION_STATUS_FAILED,
+		Error:    "boom",
+	})
+
+	sched.runDueActions(ctx)
+
+	calls := mock.getCalls()
+	if len(calls) != 3 {
+		t.Fatalf("a failing middle member must not abort the group — expected all 3 members to run, got %d", len(calls))
+	}
+	for i, want := range []string{"fm-a1", "fm-a2", "fm-a3"} {
+		if calls[i].GetActionId().GetValue() != want {
+			t.Errorf("member %d: expected %q, got %q", i, want, calls[i].GetActionId().GetValue())
+		}
+	}
+
+	// The cursor must have advanced (MarkGroupExecuted ran despite the failure):
+	// a second immediate tick does NOT re-run the group.
+	mock.reset()
+	sched.runDueActions(ctx)
+	if got := len(mock.getCalls()); got != 0 {
+		t.Fatalf("the group's next_execute_at must advance past this tick despite the middle-member failure; got %d re-runs", got)
 	}
 }
 


### PR DESCRIPTION
Closes #140.

**WS7 (impl):** the bare-binary / desktop `power-manage://` URI-handler path auto-enrolled from a registration URI (server+token) — a browser-triggered link could silently enroll the device into an attacker backend. Now refuses any non-luks `power-manage://` URI on that path and directs operators to the explicit `enroll` subcommand (which still accepts the URI). Removes the dead `trySocketEnroll`; predicate unit-tested.

**WS14 (tests):** extend `TestRemoveAction_AllPolicyTypes` to all 6 revertible types (USER/GROUP were missing); add `TestExecuteGroup_FailingMiddleMemberStillRunsLaterAndAdvancesGroup` (a failing member must not abort the group; cursor still advances).