### PR TITLE
chore(deps): adopt SDK exec Runner foundation enum rename (Root→Direct)

### DIFF
--- a/cmd/power-manage-agent/backend.go
+++ b/cmd/power-manage-agent/backend.go
@@ -40,7 +40,6 @@ func applyBackendOverrides(cfg *Config, logger *slog.Logger) error {
 	if err := setPrivilegeBackend(cfg.PrivilegeBackend, logger); err != nil {
 		return err
 	}
-
 	// Service manager. Only systemd has a concrete implementation
 	// today; the other backends are scaffolded in the SDK so the
 	// proto enum + agent wiring stay stable, but WriteUnit / Enable /
@@ -97,25 +96,25 @@ func setPrivilegeBackend(backend string, logger *slog.Logger) error {
 	var privilegeTool string
 	switch backend {
 	case "root":
-		sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendRoot)
+		sysexec.SetPrivilegeBackend(sysexec.Direct)
 		privilegeTool = ""
 	case "doas":
-		sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendDoas)
+		sysexec.SetPrivilegeBackend(sysexec.Doas)
 		privilegeTool = "doas"
 	case "sudo":
-		sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendSudo)
+		sysexec.SetPrivilegeBackend(sysexec.Sudo)
 		privilegeTool = "sudo"
 	case "":
 		if geteuidFn() == 0 {
-			sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendRoot)
+			sysexec.SetPrivilegeBackend(sysexec.Direct)
 			privilegeTool = ""
 		} else {
-			sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendSudo)
+			sysexec.SetPrivilegeBackend(sysexec.Sudo)
 			privilegeTool = "sudo"
 		}
 	default:
 		logger.Warn("unknown POWER_MANAGE_PRIVILEGE_BACKEND, staying on sudo", "value", backend)
-		sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendSudo)
+		sysexec.SetPrivilegeBackend(sysexec.Sudo)
 		privilegeTool = "sudo"
 	}
 	if privilegeTool == "" {

--- a/cmd/power-manage-agent/backend_test.go
+++ b/cmd/power-manage-agent/backend_test.go
@@ -31,7 +31,7 @@ import (
 func TestApplyBackendOverrides_PrivilegeBackend(t *testing.T) {
 	// Restore the SDK's global state after each case so parallel
 	// test packages can't see stale backend selections.
-	defer sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendSudo)
+	defer sysexec.SetPrivilegeBackend(sysexec.Sudo)
 	defer sysservice.SetServiceBackend(sysservice.ServiceBackendSystemd)
 	defer sysenc.SetBackend(sysenc.BackendLUKS)
 
@@ -56,25 +56,25 @@ func TestApplyBackendOverrides_PrivilegeBackend(t *testing.T) {
 		{
 			name:    "empty defaults to sudo",
 			cfg:     &Config{},
-			want:    sysexec.PrivilegeBackendSudo,
+			want:    sysexec.Sudo,
 			wantErr: false,
 		},
 		{
 			name:    "explicit sudo",
 			cfg:     &Config{PrivilegeBackend: "sudo"},
-			want:    sysexec.PrivilegeBackendSudo,
+			want:    sysexec.Sudo,
 			wantErr: false,
 		},
 		{
 			name:    "explicit doas",
 			cfg:     &Config{PrivilegeBackend: "doas"},
-			want:    sysexec.PrivilegeBackendDoas,
+			want:    sysexec.Doas,
 			wantErr: false,
 		},
 		{
 			name:    "unknown value warns and falls back to sudo",
 			cfg:     &Config{PrivilegeBackend: "typo"},
-			want:    sysexec.PrivilegeBackendSudo,
+			want:    sysexec.Sudo,
 			wantErr: false,
 		},
 	}
@@ -103,7 +103,7 @@ func TestApplyBackendOverrides_PrivilegeBackend(t *testing.T) {
 // as a cryptic "command not found" on the first privileged call,
 // long after the cause.
 func TestApplyBackendOverrides_MissingPrivilegeBinaryIsFatal(t *testing.T) {
-	defer sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendSudo)
+	defer sysexec.SetPrivilegeBackend(sysexec.Sudo)
 
 	// PATH that contains everything EXCEPT doas. systemctl is present
 	// so the service-backend check passes; we're isolating the
@@ -126,7 +126,7 @@ func TestApplyBackendOverrides_MissingPrivilegeBinaryIsFatal(t *testing.T) {
 // normal non-root CI run still proves the root default, instead of the silent
 // euid-coupled "want=sudo" the previous test baked in.
 func TestSetPrivilegeBackend_EmptyDefault_BranchesOnEuid(t *testing.T) {
-	defer sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendSudo)
+	defer sysexec.SetPrivilegeBackend(sysexec.Sudo)
 	origEuid := geteuidFn
 	t.Cleanup(func() { geteuidFn = origEuid })
 
@@ -139,7 +139,7 @@ func TestSetPrivilegeBackend_EmptyDefault_BranchesOnEuid(t *testing.T) {
 		if err := setPrivilegeBackend("", discardLogger()); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got := sysexec.CurrentPrivilegeBackend(); got != sysexec.PrivilegeBackendRoot {
+		if got := sysexec.CurrentPrivilegeBackend(); got != sysexec.Direct {
 			t.Errorf("empty default at euid 0 = %v, want Root", got)
 		}
 	})
@@ -149,7 +149,7 @@ func TestSetPrivilegeBackend_EmptyDefault_BranchesOnEuid(t *testing.T) {
 		if err := setPrivilegeBackend("", discardLogger()); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got := sysexec.CurrentPrivilegeBackend(); got != sysexec.PrivilegeBackendSudo {
+		if got := sysexec.CurrentPrivilegeBackend(); got != sysexec.Sudo {
 			t.Errorf("empty default at euid 1000 = %v, want Sudo", got)
 		}
 	})
@@ -160,7 +160,7 @@ func TestSetPrivilegeBackend_EmptyDefault_BranchesOnEuid(t *testing.T) {
 // its binary present is selected (and warns); an unknown value falls back to
 // systemd WITHOUT erroring (fail-safe, not fail-open to the bogus name).
 func TestApplyBackendOverrides_ServiceBackend(t *testing.T) {
-	defer sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendSudo)
+	defer sysexec.SetPrivilegeBackend(sysexec.Sudo)
 	defer sysservice.SetServiceBackend(sysservice.ServiceBackendSystemd)
 	defer sysenc.SetBackend(sysenc.BackendLUKS)
 

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 // it. There is no automatic floating tag — that's intentional, because
 // SDK proto/Go API drifts between commits should be reviewable in the
 // same PR as the agent change that consumes them.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260615140649-541787e0a9aa
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260616163503-979ab22c4a6b
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260615140649-541787e0a9aa h1:ZecW1N21gMkOapR1XYGk9PxeQ5iANjZZUeO/wnUfm74=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260615140649-541787e0a9aa/go.mod h1:4YgWcixbkSLTu5Ds8m/b/EfwGNRqUsOaC/nMgTyAwxo=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260616163503-979ab22c4a6b h1:0HRoD1+kmr7sj3KraF6Uqc01/OS8Oim1geTZb/H91Q0=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260616163503-979ab22c4a6b/go.mod h1:4YgWcixbkSLTu5Ds8m/b/EfwGNRqUsOaC/nMgTyAwxo=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/executor/action_directory_test.go
+++ b/internal/executor/action_directory_test.go
@@ -21,7 +21,7 @@ import (
 func withRootBackend(t *testing.T) {
 	t.Helper()
 	prev := sysexec.CurrentPrivilegeBackend()
-	sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendRoot)
+	sysexec.SetPrivilegeBackend(sysexec.Direct)
 	t.Cleanup(func() { sysexec.SetPrivilegeBackend(prev) })
 }
 

--- a/internal/executor/integration_test.go
+++ b/internal/executor/integration_test.go
@@ -36,7 +36,7 @@ import (
 // root, breaking every `sudo -n cmd` invocation).
 func init() {
 	if os.Geteuid() == 0 {
-		sysexec.SetPrivilegeBackend(sysexec.PrivilegeBackendRoot)
+		sysexec.SetPrivilegeBackend(sysexec.Direct)
 	}
 }
 


### PR DESCRIPTION
Paired agent change for the merged SDK rework PR 1 (`manchtools/power-manage-sdk#125`, closes sdk#124). The SDK redefined `exec.PrivilegeBackend` to the ratified fail-closed enum (`Sudo=iota+1, Doas, Direct`; zero invalid; `Direct` replaces `Root`), which broke the workspace agent build against the in-tree SDK.

Closes #144.

## Changes (Layer 1 — mechanical, keep the legacy global)
- Bump the SDK replace pin to include sdk PR 1 (`v0.4.1-0.20260616163503-979ab22c4a6b`).
- Rename const references `PrivilegeBackendRoot`→`Direct`, `PrivilegeBackendDoas`→`Doas`, `PrivilegeBackendSudo`→`Sudo` in `cmd/power-manage-agent/backend.go` + the affected tests (`backend_test.go`, `internal/executor/action_directory_test.go`, `internal/executor/integration_test.go`). The rename preserves every test assertion's meaning; the `defer SetPrivilegeBackend(Sudo)` restores remain valid.
- The agent **keeps using the legacy `SetPrivilegeBackend` global**. The DI-`Runner` transformation lands incrementally with the capability PRs (`user`, `service`, …), not here.

## Verification
Workspace build, standalone build (GOWORK=off), `go test -race ./...`, `go vet`, `gofmt`, `staticcheck -checks='inherit,-SA1019,-U1000'` (the CI filter), and `govulncheck` all clean. No new staticcheck findings.