### PR TITLE
fix(handler): propagate nested-group state in ReDoS grep-guard (close bypass)

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -419,6 +419,20 @@ func isPathologicalGrepPattern(p string) string {
 			top := stack[len(stack)-1]
 			stack = stack[:len(stack)-1]
 			depth--
+			// Propagate the closed group's quantifier/alternation state up to its
+			// parent, so an outer quantifier still sees an unbounded quantifier or
+			// alternation nested one level deeper — `((a+))+`, `((a|ab))+`,
+			// `((.*a)){2}` would otherwise bypass the guard. (`((a)*)*` is caught
+			// without this because the `*` after the inner `)` re-attaches to the
+			// still-open outer group; these shapes have no such trailing quantifier.)
+			if len(stack) > 0 {
+				if top.hasInnerQuant {
+					stack[len(stack)-1].hasInnerQuant = true
+				}
+				if top.hasAlt {
+					stack[len(stack)-1].hasAlt = true
+				}
+			}
 			// Is the closing paren followed by an unbounded quantifier?
 			if i+1 < len(p) {
 				next := p[i+1]

--- a/internal/handler/log_filter_test.go
+++ b/internal/handler/log_filter_test.go
@@ -136,6 +136,15 @@ func TestIsPathologicalGrepPattern_IndependentReDoSCorpus(t *testing.T) {
 		`((a)*)*`,       // nested-star nesting
 		`a*b*c*d*e*f*`,  // 6 unbounded quantifiers, NO nesting — trips the counter alone
 		`(ab+)+`,        // nesting with <=5 total quantifiers — trips nesting alone
+		// Quantifier/alternation buried one level DEEPER than the outer
+		// quantifier — the flag must propagate from the inner group to its
+		// parent on close, or these bypass the guard. (`((a)*)*` above is
+		// already caught because the `*` after the inner `)` re-attaches to the
+		// still-open outer group; these are different — the inner quantifier
+		// lives INSIDE the inner group with no trailing quantifier of its own.)
+		`((a+))+`,    // nested unbounded quantifier, two groups deep
+		`((a|ab))+`,  // ambiguous alternation, two groups deep
+		`((.*a)){2}`, // bounded repetition of an unbounded group, two deep
 	}
 	for _, p := range corpus {
 		t.Run(p, func(t *testing.T) {


### PR DESCRIPTION
Closes #146

`isPathologicalGrepPattern` walked a group stack but, on closing a group, never propagated that group's `hasInnerQuant`/`hasAlt` flags to its parent. A quantifier or alternation nested one level deeper than the outer quantifier bypassed the guard and reached `journalctl --grep` (PCRE, backtracking) — a defense-in-depth DoS hole (log queries are CA-signed, so this guards against an authorized-but-malicious or compromised signer):

| Pattern | Before | After |
|---|---|---|
| `((a+))+` | accepted ✗ | rejected ✓ |
| `((a\|ab))+` | accepted ✗ | rejected ✓ |
| `((.*a)){2}` | accepted ✗ | rejected ✓ |

`((a)*)*` was already caught (the `*` after the inner `)` re-attaches to the still-open outer group); the bypass is specifically a quantifier/alternation **inside** the inner group with no trailing quantifier of its own.

### Fix
Port the parent-propagation block already present in the SDK's verbatim copy (`sdk/go/sys/log/grepguard.go`, where this was fixed). The agent's copy is deleted when the agent migrates onto `sdk/go/sys/log` (tracked separately).

### Tests (test-first)
The three bypass shapes were added to `TestIsPathologicalGrepPattern_IndependentReDoSCorpus` and confirmed RED against the buggy guard before the fix; full handler suite green with `-race`.