### PR TITLE
refactor(store): clear-cache cutover to binary protobuf (drop the protojson fallback)

### DIFF
--- a/internal/store/change_detection_test.go
+++ b/internal/store/change_detection_test.go
@@ -1,77 +1,58 @@
 package store
 
 import (
-	"bytes"
-	"encoding/json"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/encoding/protojson"
 
 	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
 )
 
-// insignificantWhitespaceDrift returns raw with a space injected after a
-// colon — a position protojson NEVER emits (its only non-determinism is
-// an optional space after the comma separator, seeded per binary). The
-// result is therefore guaranteed byte-different from any protojson
-// output regardless of seed, yet identical after json.Compact — exactly
-// the cross-binary drift the store's change detection must ignore. It
-// fails the test if the input has no colon (nothing to drift).
-func insignificantWhitespaceDrift(t *testing.T, raw []byte) string {
-	t.Helper()
-	var compact bytes.Buffer
-	require.NoError(t, json.Compact(&compact, raw))
-	require.Contains(t, compact.String(), ":", "JSON has no colon to drift")
-	drifted := strings.Replace(compact.String(), ":", ": ", 1)
-	require.NotEqual(t, string(raw), drifted, "drift must differ from the fresh marshal or the test is vacuous")
-	return drifted
-}
-
-// protojson injects per-binary random insignificant whitespace; the
-// store's change detection byte-compares these blobs. A whitespace-only
-// difference (the shape produced when an agent self-updates to a binary
-// with a different protojson seed) MUST NOT be treated as a change, or
-// every action re-executes and every schedule resets on the next sync.
-func TestSyncActions_IgnoresProtojsonWhitespaceDrift(t *testing.T) {
+// Change detection compares the deterministic BINARY encoding of the stored vs
+// incoming action (sameStoredProto). Deterministic marshal removes the per-binary
+// whitespace non-determinism protojson had — there is nothing to "drift" — so
+// re-syncing an identical action after a self-update must land in NEITHER the
+// changed nor the new list, and must NOT reset the action's cadence (which would
+// re-execute everything on the next sync).
+func TestSyncActions_ReSyncIdenticalPreservesStandaloneCadence(t *testing.T) {
 	st, err := New(t.TempDir())
 	require.NoError(t, err)
 	defer st.Close()
 
+	now1 := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	st.now = func() time.Time { return now1 }
+
 	a := &pb.Action{
-		Id:           &pb.ActionId{Value: "pkg-drift"},
+		Id:           &pb.ActionId{Value: "pkg-cadence"},
 		Type:         pb.ActionType_ACTION_TYPE_PACKAGE,
 		DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
+		Schedule:     &pb.ActionSchedule{IntervalHours: 8},
 	}
-
-	// First sync establishes the row (desired_state + json).
 	if _, err := st.SyncActions([]*pb.Action{a}); err != nil {
 		t.Fatalf("initial sync: %v", err)
 	}
 
-	// Rewrite the stored blob with the identical action re-marshaled but
-	// carrying insignificant whitespace a different agent binary's
-	// protojson seed could have emitted.
-	raw, err := protojson.Marshal(a)
-	require.NoError(t, err)
-	drifted := insignificantWhitespaceDrift(t, raw)
-	_, err = st.db.Exec("UPDATE actions SET action_json = ? WHERE id = ?", drifted, a.Id.Value)
-	require.NoError(t, err)
+	var before string
+	require.NoError(t, st.db.QueryRow("SELECT next_execute_at FROM actions WHERE id = ?", a.Id.Value).Scan(&before))
 
-	// Re-sync the identical action.
+	// Advance the clock so a spurious reset would move next_execute_at forward, then
+	// re-sync the IDENTICAL action.
+	st.now = func() time.Time { return now1.Add(time.Hour) }
 	res, err := st.SyncActions([]*pb.Action{a})
 	require.NoError(t, err)
-	assert.NotContains(t, res.ChangedActionIDs, a.Id.Value,
-		"whitespace-only protojson drift must not flag the action as changed")
+	assert.NotContains(t, res.ChangedActionIDs, a.Id.Value, "a byte-identical re-sync must not flag the action as changed")
+
+	var after string
+	require.NoError(t, st.db.QueryRow("SELECT next_execute_at FROM actions WHERE id = ?", a.Id.Value).Scan(&after))
+	assert.Equal(t, before, after, "re-syncing an identical action must PRESERVE its cadence (next_execute_at), not reset it")
 }
 
-// Same guarantee for the group cadence-preservation compare, which
-// byte-compares the stored vs fresh schedule JSON to decide whether to
-// keep the group's existing next_execute_at.
-func TestSyncStandaloneAndGrouped_IgnoresScheduleWhitespaceDrift(t *testing.T) {
+// The same cadence-preservation guarantee for the group schedule compare: an
+// identical group schedule re-synced must keep the group's existing
+// next_execute_at.
+func TestSyncStandaloneAndGrouped_ReSyncIdenticalSchedulePreservesCadence(t *testing.T) {
 	st, err := New(t.TempDir())
 	require.NoError(t, err)
 	defer st.Close()
@@ -89,73 +70,17 @@ func TestSyncStandaloneAndGrouped_IgnoresScheduleWhitespaceDrift(t *testing.T) {
 		t.Fatalf("initial sync: %v", err)
 	}
 
-	// Capture the group's next_execute_at, drift the stored schedule
-	// JSON, and re-sync. If the whitespace drift is mistaken for a
-	// schedule change, the cadence (next_execute_at) is reset.
 	var before string
 	require.NoError(t, st.db.QueryRow("SELECT next_execute_at FROM action_groups WHERE id = ?", group.SourceLabel).Scan(&before))
 
-	raw, err := protojson.Marshal(group.Schedule)
-	require.NoError(t, err)
-	drifted := insignificantWhitespaceDrift(t, raw)
-	_, err = st.db.Exec("UPDATE action_groups SET schedule_json = ? WHERE id = ?", drifted, group.SourceLabel)
-	require.NoError(t, err)
-
+	// Re-sync the identical group: its cadence must be preserved.
 	if _, err := st.SyncStandaloneAndGrouped(nil, []*pb.ActionGroup{group}); err != nil {
 		t.Fatalf("resync: %v", err)
 	}
 
 	var after string
 	require.NoError(t, st.db.QueryRow("SELECT next_execute_at FROM action_groups WHERE id = ?", group.SourceLabel).Scan(&after))
-	assert.Equal(t, before, after,
-		"whitespace-only schedule drift must preserve the group's cadence, not reset next_execute_at")
-}
-
-// The companion guarantee for STANDALONE actions: the existing drift test only
-// proved the action is absent from ChangedActionIDs. The upsert's next_execute_at
-// CASE used a raw byte compare of the stored vs incoming action_json — which
-// disagreed with the Go compacted compare — so insignificant whitespace drift
-// reset the action's cadence even though it was reported unchanged. The clock is
-// advanced between syncs so a spurious reset would be observable (the recomputed
-// next_execute_at differs); the test pins that it is NOT reset.
-func TestSyncActions_WhitespaceDrift_PreservesStandaloneCadence(t *testing.T) {
-	st, err := New(t.TempDir())
-	require.NoError(t, err)
-	defer st.Close()
-
-	now1 := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
-	st.now = func() time.Time { return now1 }
-
-	a := &pb.Action{
-		Id:           &pb.ActionId{Value: "pkg-cadence"},
-		Type:         pb.ActionType_ACTION_TYPE_PACKAGE,
-		DesiredState: pb.DesiredState_DESIRED_STATE_PRESENT,
-	}
-	if _, err := st.SyncActions([]*pb.Action{a}); err != nil {
-		t.Fatalf("initial sync: %v", err)
-	}
-
-	var before string
-	require.NoError(t, st.db.QueryRow("SELECT next_execute_at FROM actions WHERE id = ?", a.Id.Value).Scan(&before))
-
-	// Drift the STORED json with insignificant whitespace and advance the clock
-	// so a reset would move next_execute_at forward (now+8h recomputed).
-	raw, err := protojson.Marshal(a)
-	require.NoError(t, err)
-	drifted := insignificantWhitespaceDrift(t, raw)
-	_, err = st.db.Exec("UPDATE actions SET action_json = ? WHERE id = ?", drifted, a.Id.Value)
-	require.NoError(t, err)
-	st.now = func() time.Time { return now1.Add(time.Hour) }
-
-	res, err := st.SyncActions([]*pb.Action{a})
-	require.NoError(t, err)
-	assert.NotContains(t, res.ChangedActionIDs, a.Id.Value,
-		"whitespace-only drift must not flag the standalone action as changed")
-
-	var after string
-	require.NoError(t, st.db.QueryRow("SELECT next_execute_at FROM actions WHERE id = ?", a.Id.Value).Scan(&after))
-	assert.Equal(t, before, after,
-		"whitespace-only drift must PRESERVE the standalone action's cadence (next_execute_at), not reset it")
+	assert.Equal(t, before, after, "re-syncing an identical group schedule must preserve the group's cadence, not reset next_execute_at")
 }
 
 // Positive direction for change detection: a desired-state flip and a params

--- a/internal/store/dispatch_test.go
+++ b/internal/store/dispatch_test.go
@@ -7,39 +7,50 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
 
 	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
 )
 
-// TestStore_DecodesLegacyProtojsonRowWithUnknownField pins the forward-compat
-// fix: a row written by a different SDK revision can carry a field this binary's
-// proto no longer knows (here the removed "paramsCanonical"). With the old strict
-// protojson.Unmarshal, ONE such row failed to decode and aborted the entire
-// GetDueActions query — disabling the whole offline scheduler. The binary store +
-// tolerant protojson fallback must decode it (dropping the unknown field) so the
-// scheduler keeps running.
-func TestStore_DecodesLegacyProtojsonRowWithUnknownField(t *testing.T) {
+// TestStore_BinaryDecodePreservesUnknownFields pins the forward-compat guarantee
+// that motivated binary storage: a stored action carrying a wire field this
+// binary's proto does not know — exactly what a NEWER server would send — still
+// decodes, because proto.Unmarshal KEEPS unknown fields instead of rejecting them.
+// One such row therefore can never abort GetDueActions and disable the offline
+// scheduler. (Strict protojson, the old format, failed this case as an "unknown
+// field" error, e.g. the removed "paramsCanonical".)
+func TestStore_BinaryDecodePreservesUnknownFields(t *testing.T) {
 	st, err := New(t.TempDir())
 	require.NoError(t, err)
 	defer st.Close()
 
-	const id = "legacy-act"
+	const id = "unknown-field-act"
 	require.NoError(t, st.SaveAction(&pb.Action{
 		Id:       &pb.ActionId{Value: id},
 		Type:     pb.ActionType_ACTION_TYPE_SHELL,
 		Schedule: &pb.ActionSchedule{IntervalHours: 1},
 	}))
 
-	// Simulate a pre-cutover row: legacy protojson carrying an unknown field.
-	legacy := `{"id":{"value":"legacy-act"},"type":"ACTION_TYPE_SHELL","paramsCanonical":"c29tZQ=="}`
-	_, err = st.db.Exec("UPDATE actions SET action_json = ? WHERE id = ?", legacy, id)
+	// Re-write the row as binary protobuf carrying an extra UNKNOWN field (field
+	// number 50000) — what a newer SDK would add and this binary cannot name.
+	b, err := proto.Marshal(&pb.Action{
+		Id:       &pb.ActionId{Value: id},
+		Type:     pb.ActionType_ACTION_TYPE_SHELL,
+		Schedule: &pb.ActionSchedule{IntervalHours: 1},
+	})
+	require.NoError(t, err)
+	b = protowire.AppendTag(b, 50000, protowire.VarintType)
+	b = protowire.AppendVarint(b, 1)
+	blob := append([]byte{binaryProtoPrefix}, b...)
+	_, err = st.db.Exec("UPDATE actions SET action_json = ? WHERE id = ?", blob, id)
 	require.NoError(t, err)
 
-	// Advance the clock so the action is due, then read it. This must NOT error on
-	// the unknown field, and must return the decoded action.
+	// Advance the clock so the action is due, then read it: the unknown field must
+	// NOT error, and the action must decode and be returned.
 	st.SetClockForTest(func() time.Time { return time.Now().Add(48 * time.Hour) })
 	due, err := st.GetDueActions(context.Background())
-	require.NoError(t, err, "an unknown field in a stored row must not wedge the scheduler")
+	require.NoError(t, err, "an unknown wire field must not wedge the scheduler")
 
 	var found bool
 	for _, d := range due {
@@ -48,7 +59,7 @@ func TestStore_DecodesLegacyProtojsonRowWithUnknownField(t *testing.T) {
 			assert.Equal(t, pb.ActionType_ACTION_TYPE_SHELL, d.Action.Type)
 		}
 	}
-	assert.True(t, found, "the legacy-protojson action must decode (unknown field dropped) and be returned")
+	assert.True(t, found, "an action carrying an unknown field must still decode and be returned")
 }
 
 // SaveAction is the dispatch path: the handler stores the action AND

--- a/internal/store/migrations/004_binary_proto_cutover.sql
+++ b/internal/store/migrations/004_binary_proto_cutover.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- Binary-protobuf storage cutover. Actions, group schedules and execution outputs
+-- are now stored as binary protobuf with NO protojson read-fallback. Rather than
+-- carry compatibility code, clear the server-synced cache so no legacy protojson
+-- row is ever read: the agent re-syncs actions and group schedules from the server
+-- on its next connection (it only reaches this release via a self-update, which
+-- requires connectivity). results cascade-delete from actions; LUKS/LPS secret
+-- state carries no protojson and is intentionally left untouched.
+DELETE FROM actions;
+DELETE FROM action_groups;
+
+-- +goose Down
+-- No-op: the cache repopulates from the server on the next sync.
+SELECT 1;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/pressly/goose/v3"
 	"github.com/robfig/cron/v3"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	_ "modernc.org/sqlite"
 
@@ -188,39 +187,25 @@ func (s *Store) Close() error {
 	return s.db.Close()
 }
 
-// canonicalProtoJSON marshals m to JSON and strips the per-binary
-// random whitespace protojson injects. protojson deliberately varies
-// insignificant whitespace (seeded from a hash of the running binary)
-// as an anti-pinning measure, so a blob stored by one agent binary can
-// compare byte-unequal to the identical message marshaled by a
-// different binary after a self-update. The store uses these blobs for
-// change detection (SyncActions / SyncStandaloneAndGrouped); without
-// normalization a single self-update would flag EVERY action as changed
-// and re-execute the whole set, resetting all schedules. Compaction
-// yields a stable byte form — protojson's field order is already
-// deterministic, only the whitespace is not.
 // The store keeps proto blobs (actions, schedules, execution outputs) as
-// DETERMINISTIC BINARY protobuf, not protojson. Binary is compact, stable across
+// DETERMINISTIC BINARY protobuf, never protojson. Binary is compact, stable across
 // agent self-updates (protojson randomizes insignificant whitespace per binary,
-// which once forced the canonicalProtoJSON/compactJSON normalization), and — most
-// importantly — proto.Unmarshal PRESERVES fields the running SDK does not know
-// instead of rejecting them. A stale field from a newer/older SDK (e.g. a removed
-// "paramsCanonical") therefore can no longer wedge the whole offline scheduler
-// (GetDueActions aborts the entire query on a single decode failure).
+// which once forced a canonicalProtoJSON/compactJSON normalization step), and —
+// most importantly — proto.Unmarshal PRESERVES fields the running SDK does not
+// know instead of rejecting them, so a stale field from a different SDK revision
+// (e.g. a removed "paramsCanonical") can never wedge the offline scheduler
+// (GetDueActions aborts the whole query on a single decode failure). There is NO
+// protojson read-fallback: migration 004 clears the server-synced cache on the
+// cutover, so a legacy protojson row is never read.
 //
 // binaryProtoPrefix tags a stored blob as binary. It is 0x00 — the first byte of
 // neither protojson (always '{') nor a valid protobuf message (field number 0 is
-// illegal) — so a stored blob is classified unambiguously on read with no schema
-// column and no data migration; rows written as protojson before this cutover
-// still decode via the tolerant fallback in unmarshalStoredProto.
+// illegal) — so a corrupt/foreign blob is rejected rather than silently
+// misparsed.
 const binaryProtoPrefix byte = 0x00
 
-// tolerantProtoJSON decodes a legacy protojson blob permissively (DiscardUnknown)
-// so a pre-cutover row carrying an unknown field still parses.
-var tolerantProtoJSON = protojson.UnmarshalOptions{DiscardUnknown: true}
-
 // canonicalProtoBytes returns the deterministic binary encoding of m — the stable
-// form used for change detection (replaces compactJSON's whitespace stripping).
+// form used for change detection.
 func canonicalProtoBytes(m proto.Message) ([]byte, error) {
 	return proto.MarshalOptions{Deterministic: true}.Marshal(m)
 }
@@ -235,14 +220,13 @@ func marshalStoredProto(m proto.Message) ([]byte, error) {
 	return append([]byte{binaryProtoPrefix}, b...), nil
 }
 
-// unmarshalStoredProto decodes a stored blob into m, accepting BOTH the binary
-// form written by marshalStoredProto and a legacy protojson row. Binary preserves
-// unknown fields; the protojson fallback tolerates them.
+// unmarshalStoredProto decodes a binary stored blob into m. A blob lacking the
+// binary tag (corrupt, or a foreign format) is rejected, not guessed at.
 func unmarshalStoredProto(raw []byte, m proto.Message) error {
-	if len(raw) > 0 && raw[0] == binaryProtoPrefix {
-		return proto.Unmarshal(raw[1:], m)
+	if len(raw) == 0 || raw[0] != binaryProtoPrefix {
+		return fmt.Errorf("stored blob is not binary protobuf")
 	}
-	return tolerantProtoJSON.Unmarshal(raw, m)
+	return proto.Unmarshal(raw[1:], m)
 }
 
 // sameStoredProto reports whether the stored blob decodes (into the empty message


### PR DESCRIPTION
Follow-up to the binary-storage cutover (#152), applying the **no fallbacks / no backwards-compat** direction.

## What
- **Remove the protojson read-fallback.** `unmarshalStoredProto` now decodes **binary only** and rejects a blob lacking the binary tag rather than guessing at a foreign format.
- **Migration 004 clears the server-synced cache** (`actions`, `action_groups`; `results` cascade) on upgrade, so no legacy protojson row is ever read. The agent re-syncs on its next connection — and it only reaches this release via a **self-update, which requires connectivity**, so the re-sync is immediate (no offline gap). LUKS/LPS secret state carries no protojson and is left untouched.

## Tests
- The whitespace-drift change-detection tests are **obsolete** (deterministic binary has no per-binary whitespace to drift) — reframed to the surviving invariant: re-syncing an identical action/group preserves its cadence.
- New `TestStore_BinaryDecodePreservesUnknownFields`: a stored action carrying an unknown **wire** field still decodes (`proto.Unmarshal` keeps unknown fields) — the forward-compat guarantee that motivated binary storage; one such row can never abort `GetDueActions`.

Sequencing: this ships as the agent RC **after** server rc5 restores connectivity.