### PR TITLE
fix(scheduler): log synced_total so group-only syncs don't read as empty

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -692,7 +692,15 @@ func (s *Scheduler) SyncActions(ctx context.Context, standalone []*pb.Action, gr
 		return err
 	}
 
+	// synced_total counts every action received — standalone PLUS each group's
+	// members — so the line doesn't read as "nothing received" when an action set
+	// arrived but carried no standalone actions (standalone_total=0).
+	syncedTotal := len(standalone)
+	for _, g := range groups {
+		syncedTotal += len(g.GetActions())
+	}
 	s.logger.Info("actions synced successfully",
+		"synced_total", syncedTotal,
 		"standalone_total", len(standalone),
 		"groups_total", len(groups),
 		"new_standalone", len(syncResult.NewActionIDs),


### PR DESCRIPTION
## What

The `actions synced successfully` log line in `SyncActions` logged `standalone_total` but not the actions delivered inside action-set **groups**. A sync that carried only group members (so `standalone_total=0`) read as if nothing was received — a misleading "empty sync" in the agent log.

## Change

Add `synced_total = len(standalone) + sum(len(group.GetActions()))` to the log line, so it reflects the full count actually synced. `standalone_total` / `groups_total` stay for the breakdown.

## Context

Carry-forward item (b) from the 2026.07 release tracker (server#320). Observability-only — no behavior change.
