### PR TITLE
feat(cli): CLI store-open skips migrations; list subcommands in --help

### DIFF
--- a/cmd/power-manage-agent/cmd_tty.go
+++ b/cmd/power-manage-agent/cmd_tty.go
@@ -70,7 +70,9 @@ func runTTY(args []string) int {
 		}
 	}
 
-	st, err := store.New(*dataDir)
+	// OpenExisting (not New): the agent service owns migrations, so a CLI toggle
+	// must not run goose on an already-initialised database.
+	st, err := store.OpenExisting(*dataDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: open agent store: %v\n", err)
 		return 1

--- a/cmd/power-manage-agent/main.go
+++ b/cmd/power-manage-agent/main.go
@@ -341,6 +341,27 @@ func main() {
 func parseFlags() *Config {
 	cfg := &Config{}
 
+	// Subcommands are dispatched in main() before flags are parsed, so the
+	// default flag usage (flags only) never mentions them. List them here so
+	// `power-manage-agent --help` shows the full surface (notably `tty`, which
+	// operators otherwise can't discover).
+	flag.Usage = func() {
+		out := flag.CommandLine.Output()
+		fmt.Fprintln(out, "power-manage-agent — Power Manage device agent")
+		fmt.Fprintln(out, "\nUsage:")
+		fmt.Fprintln(out, "  power-manage-agent [flags]           run the agent (default)")
+		fmt.Fprintln(out, "  power-manage-agent <command> [args]  run a subcommand")
+		fmt.Fprintln(out, "\nSubcommands:")
+		fmt.Fprintln(out, "  enroll      enroll this device with a control server (token or power-manage:// URI)")
+		fmt.Fprintln(out, "  tty         toggle the device-local remote-terminal gate (enable|disable|status)")
+		fmt.Fprintln(out, "  luks        LUKS passphrase operations")
+		fmt.Fprintln(out, "  query       run a local osquery query")
+		fmt.Fprintln(out, "  self-test   run agent self-diagnostics")
+		fmt.Fprintln(out, "  version     print the agent version")
+		fmt.Fprintln(out, "\nFlags (default run mode):")
+		flag.PrintDefaults()
+	}
+
 	var uri string
 	flag.StringVar(&uri, "uri", "", "Registration URI (power-manage://server:port?token=xxx)")
 	flag.StringVar(&cfg.Token, "token", "", "Registration token for first-time setup")

--- a/internal/store/open_existing_test.go
+++ b/internal/store/open_existing_test.go
@@ -1,0 +1,38 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpenExisting_RequiresInitialisedDB: the CLI store-open must not silently
+// create-and-run on an unmigrated database — it errors when the DB is absent
+// (the agent service, store.New, is the only thing that creates + migrates it).
+func TestOpenExisting_RequiresInitialisedDB(t *testing.T) {
+	dir := t.TempDir()
+	_, err := OpenExisting(dir)
+	require.Error(t, err, "OpenExisting on a non-existent DB must error, not create an empty one")
+	assert.NoFileExists(t, filepath.Join(dir, "agent.db"), "OpenExisting must not create the database")
+}
+
+// TestOpenExisting_OpensWithoutMigrating: once the service initialised the store,
+// the CLI path opens it and can read/write the tty toggle — no goose involved.
+func TestOpenExisting_OpensWithoutMigrating(t *testing.T) {
+	dir := t.TempDir()
+
+	svc, err := New(dir) // service creates + migrates
+	require.NoError(t, err)
+	require.NoError(t, svc.SetTTYEnabled(true))
+	require.NoError(t, svc.Close())
+
+	cli, err := OpenExisting(dir) // CLI re-opens, no migration
+	require.NoError(t, err)
+	defer cli.Close()
+
+	enabled, err := cli.IsTTYEnabled()
+	require.NoError(t, err)
+	assert.True(t, enabled, "OpenExisting must read the setting the service wrote")
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -84,7 +84,29 @@ type StoredResult struct {
 }
 
 // New creates a new store with the given data directory.
-func New(dataDir string) (*Store, error) {
+// New opens the agent store (creating the data dir/database if needed) and runs
+// any pending migrations. Used by the agent service, which OWNS the schema.
+func New(dataDir string) (*Store, error) { return open(dataDir, true) }
+
+// OpenExisting opens an already-initialised agent store WITHOUT running
+// migrations. It is for the CLI subcommands (e.g. `tty enable`, `luks`) that only
+// read/write a setting in a database the agent service already created and
+// migrated — re-running goose on every CLI invocation is needless work and log
+// noise (the confusing "goose: no migrations to run" line on a simple toggle).
+// Fails cleanly when the database does not exist yet, rather than silently
+// creating an empty, unmigrated one.
+func OpenExisting(dataDir string) (*Store, error) {
+	dbPath := filepath.Join(dataDir, "agent.db")
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("agent database %s does not exist — start the agent service first (it creates and migrates the database)", dbPath)
+		}
+		return nil, fmt.Errorf("stat agent database: %w", err)
+	}
+	return open(dataDir, false)
+}
+
+func open(dataDir string, migrate bool) (*Store, error) {
 	if err := os.MkdirAll(dataDir, 0700); err != nil {
 		return nil, fmt.Errorf("create data directory: %w", err)
 	}
@@ -112,19 +134,24 @@ func New(dataDir string) (*Store, error) {
 	// favour of modernc.org/sqlite's per-conn locking would unlock the
 	// real benefit. Audit F021.
 
-	goose.SetBaseFS(migrations.FS)
-	// Audit F009: goose's dialect name is the legacy "sqlite3" even
-	// though the registered driver is "sqlite" (modernc.org/sqlite).
-	// The discrepancy is intentional — both are correct for their
-	// respective libraries — but called out here so the next reader
-	// doesn't try to "fix" the mismatch.
-	if err := goose.SetDialect("sqlite3"); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("set goose dialect: %w", err)
-	}
-	if err := goose.Up(db, "."); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("run migrations: %w", err)
+	// Migrations are the agent service's responsibility (store.New); the CLI
+	// store-open path (OpenExisting) skips them so a `tty enable` toggle doesn't
+	// run goose on an already-migrated database.
+	if migrate {
+		goose.SetBaseFS(migrations.FS)
+		// Audit F009: goose's dialect name is the legacy "sqlite3" even
+		// though the registered driver is "sqlite" (modernc.org/sqlite).
+		// The discrepancy is intentional — both are correct for their
+		// respective libraries — but called out here so the next reader
+		// doesn't try to "fix" the mismatch.
+		if err := goose.SetDialect("sqlite3"); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("set goose dialect: %w", err)
+		}
+		if err := goose.Up(db, "."); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("run migrations: %w", err)
+		}
 	}
 
 	// WS6 #10: the DB holds action secrets (PSK, WiFi/EAP keys, LUKS


### PR DESCRIPTION
## Two operator-facing niceties

**1. `tty enable` no longer runs goose.** `store.New` runs `goose.Up` on every open. The CLI subcommands only toggle a setting in an already-initialised DB, so re-running migrations just produced the confusing `goose: no migrations to run. current version: N` line. New `store.OpenExisting` opens **without** migrations (the agent *service* owns the schema), and `tty` uses it. It also **fails cleanly** if the DB was never created, rather than silently making an empty, unmigrated one.

**2. `--help` lists the subcommands.** `enroll`/`tty`/`luks`/`query`/`self-test`/`version` are dispatched before flag parsing, so the default usage never mentioned them — `tty` was undiscoverable. `parseFlags` now sets a custom `flag.Usage` listing them.

## Tests
`OpenExisting` errors on a missing DB (no silent create) and reads a setting the service wrote, without migrating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved help output to list all supported commands and clarify the default run mode.
* **Bug Fixes**
  * The TTY command now opens an existing database safely, avoiding unintended reinitialization on already set-up installations.
  * Database access now distinguishes between creating a new store and reopening an existing one, preventing unnecessary setup work.
* **Tests**
  * Added coverage for opening an existing database and for verifying data remains readable without rerunning setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->