### PR TITLE
fix(handler): propagate request context into inventory osquery + guard

### DIFF
--- a/internal/archtest/archtest.go
+++ b/internal/archtest/archtest.go
@@ -34,6 +34,7 @@
 //   - TestSecretComparesAreConstantTime ... secret_compare_test.go
 //   - TestNoUnabstractedTimeNow ........... time_now_test.go
 //   - TestNoStdlibJSONOfProtoMessage ...... proto_json_test.go
+//   - TestNoContextBackgroundInRequestPaths ... context_background_test.go
 package archtest
 
 import (

--- a/internal/archtest/context_background_test.go
+++ b/internal/archtest/context_background_test.go
@@ -1,0 +1,133 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// TestNoContextBackgroundInRequestPaths enforces the NIS2 / spec-12 / CLAUDE
+// rule on the agent: request-path code (the signed On* stream-RPC handlers and
+// everything they call) MUST propagate the caller's context and MUST NOT root a
+// fresh context.Background()/context.TODO(). A fresh root silently drops the
+// RPC's deadline and cancellation — the bug this guard pins was
+// supplementWithOsquery dropping the RequestInventory ctx so a cancelled
+// inventory RPC kept running osquery. Mirrors the server archtest guard and the
+// TestNoUnabstractedTimeNow shape.
+//
+// Two CATEGORY exemptions, deliberately not per-site blessings:
+//
+//   - package main under cmd/ — the agent CLI / bootstrap legitimately ROOTs
+//     the process lifecycle context; there is no caller context to inherit.
+//     cmd/ files are still walked (only the error is skipped) so their roots
+//     keep the matches-zero liveness probe alive.
+//
+//   - daemon-lifecycle work that is NOT an RPC request path: per-session
+//     terminal goroutines that must outlive the start RPC, background sweep/
+//     heartbeat tickers, startup backend detection, shutdown cleanup, and
+//     local credential-file writes. Each is allowlisted by enclosing function
+//     with a justification and is bounded by its own timeout or by the callee
+//     (osquery applies its own defaultTimeout). assertNoStale fails the build
+//     if one of these functions stops rooting a context, so the escape hatch
+//     cannot rot open.
+//
+// The allowlist is keyed by enclosing function (not file, not line): every
+// context.Background() renders identically, so a file-level key would fail open
+// and silently bless a future root anywhere in that file.
+func TestNoContextBackgroundInRequestPaths(t *testing.T) {
+	root := moduleRoot(t)
+	files := walkGoFiles(t, root, func(rel string) bool {
+		if strings.HasPrefix(rel, "internal/store/generated/") {
+			return false
+		}
+		if strings.HasPrefix(rel, "internal/testutil/") {
+			return false
+		}
+		return true
+	})
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero production Go files — detector is mis-scoped")
+	}
+
+	allow := newAllowlist(map[string]string{
+		"internal/credentials/credentials.go :: writeFile":      "local credential-file write on the enrollment/cert-rotation path, not an RPC request; fs write is synchronous",
+		"internal/deviceauth/enroll_server.go :: Shutdown":      "enrollment-socket shutdown path; no caller context to inherit; bounded 5s",
+		"internal/executor/agent_update.go :: getBinaryVersion": "bounded 10s subprocess version probe during self-update verification",
+		"internal/executor/executor.go :: NewExecutor":          "constructor-time package-backend detection at startup; callee-bounded, no request",
+		"internal/handler/handler.go :: BuildHeartbeat":         "best-effort periodic heartbeat metrics; no RPC caller; osquery bounds each call (defaultTimeout)",
+		"internal/handler/terminal.go :: OnTerminalStart":       "terminal session must outlive the start RPC; sessionCtx roots its own lifecycle and teardown must run even when the start ctx is gone",
+		"internal/handler/terminal.go :: pumpTerminalOutput":    "detached per-session output pump; owns sessionCtx; its sends/cleanup are bounded by their own timeouts",
+		"internal/handler/terminal.go :: sweepIdleTerminals":    "background idle-terminal sweep ticker; no RPC caller; bounded cleanup",
+	})
+
+	// Liveness probe: every context.Background()/context.TODO() seen anywhere
+	// (cmd/ included). Keying matches-zero off this — not off non-cmd
+	// violations — keeps the guard non-vacuous even once every request path is
+	// clean, because cmd/ bootstrap always roots a context.
+	sawCtxRoot := 0
+	for _, gf := range files {
+		underCmd := strings.HasPrefix(gf.rel, "cmd/")
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			name, ok := contextRootCall(call)
+			if !ok {
+				return true
+			}
+			sawCtxRoot++
+			if underCmd {
+				return true // category exemption: process lifecycle root
+			}
+			fn := enclosingFuncName(gf.ast, call.Pos())
+			if allow.exempt(gf.rel + " :: " + fn) {
+				return true
+			}
+			t.Errorf("context.%s() rooted in a request path at %s:%d (enclosing func %q) — propagate the caller's context.Context instead; a fresh root drops the request deadline and cancellation. If this is detached daemon-lifecycle work, allowlist it by enclosing function with a justification.",
+				name, gf.rel, gf.line(call), fn)
+			return true
+		})
+	}
+	if sawCtxRoot == 0 {
+		t.Fatal("matches-zero guard: found no context.Background()/context.TODO() anywhere (not even in cmd/ bootstrap) — the detector is dead, the guard would pass vacuously")
+	}
+	allow.assertNoStale(t)
+}
+
+// contextRootCall reports whether call is exactly context.Background() or
+// context.TODO() (zero args), returning the bare method name.
+func contextRootCall(call *ast.CallExpr) (string, bool) {
+	if len(call.Args) != 0 {
+		return "", false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	if sel.Sel.Name != "Background" && sel.Sel.Name != "TODO" {
+		return "", false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	if !ok || id.Name != "context" {
+		return "", false
+	}
+	return sel.Sel.Name, true
+}
+
+// enclosingFuncName returns the name of the top-level FuncDecl whose source
+// range contains pos (covering calls nested inside closures), or "<file-scope>"
+// when pos sits outside any function.
+func enclosingFuncName(file *ast.File, pos token.Pos) string {
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if pos >= fd.Pos() && pos <= fd.End() {
+			return fd.Name.Name
+		}
+	}
+	return "<file-scope>"
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -578,7 +578,7 @@ func (h *Handler) CollectInventory(ctx context.Context) *pb.DeviceInventory {
 	// Phase 2: Supplement/override with osquery if available
 	oq := h.getOsquery()
 	if oq != nil {
-		h.supplementWithOsquery(oq, tables)
+		h.supplementWithOsquery(ctx, oq, tables)
 	}
 
 	if len(tables) == 0 {
@@ -728,7 +728,7 @@ var (
 	}
 )
 
-func (h *Handler) supplementWithOsquery(oq osqueryRunner, baseline map[string]*pb.InventoryTable) {
+func (h *Handler) supplementWithOsquery(ctx context.Context, oq osqueryRunner, baseline map[string]*pb.InventoryTable) {
 	// osquery tables that override baseline
 	coreTables := inventoryCoreTables
 
@@ -736,7 +736,7 @@ func (h *Handler) supplementWithOsquery(oq osqueryRunner, baseline map[string]*p
 	packageTables := inventoryPackageTables
 
 	for _, tableName := range coreTables {
-		rows, err := oq.QueryTable(context.Background(), tableName)
+		rows, err := oq.QueryTable(ctx, tableName)
 		if err != nil {
 			h.logger.Debug("osquery table unavailable", "table", tableName, "error", err)
 			continue
@@ -751,7 +751,7 @@ func (h *Handler) supplementWithOsquery(oq osqueryRunner, baseline map[string]*p
 	}
 
 	for _, tableName := range packageTables {
-		rows, err := oq.QueryTable(context.Background(), tableName)
+		rows, err := oq.QueryTable(ctx, tableName)
 		if err != nil {
 			continue
 		}

--- a/internal/handler/inventory_ctx_test.go
+++ b/internal/handler/inventory_ctx_test.go
@@ -1,0 +1,51 @@
+package handler
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/agent/internal/executor"
+)
+
+// ctxCapturingOsquery records the context handed to each osquery call so a
+// test can prove the request context is propagated rather than dropped to a
+// fresh context.Background().
+type ctxCapturingOsquery struct {
+	lastTableCtx context.Context
+}
+
+func (f *ctxCapturingOsquery) Query(_ context.Context, q *pb.OSQuery) (*pb.OSQueryResult, error) {
+	return &pb.OSQueryResult{QueryId: q.GetQueryId(), Success: true}, nil
+}
+
+func (f *ctxCapturingOsquery) QueryTable(ctx context.Context, _ string) ([]*pb.OSQueryRow, error) {
+	f.lastTableCtx = ctx
+	return []*pb.OSQueryRow{{Data: map[string]string{"k": "v"}}}, nil
+}
+
+type inventoryCtxKey string
+
+// TestSupplementWithOsquery_PropagatesRequestContext proves inventory osquery
+// collection honours the caller's context. A signed RequestInventory RPC flows
+// OnRequestInventory(ctx) -> CollectInventory(ctx) -> supplementWithOsquery;
+// before the fix that last hop dropped the ctx and rooted context.Background()
+// for every osquery QueryTable, so the RPC's deadline/cancellation never
+// reached osquery. This is the NIS2 / spec-12 "no context.Background() in a
+// request path" invariant for the inventory path.
+func TestSupplementWithOsquery_PropagatesRequestContext(t *testing.T) {
+	h := NewHandler(slog.Default(), executor.NewExecutor(nil, nil), nil, nil, make(chan struct{}, 1))
+	oq := &ctxCapturingOsquery{}
+
+	const k inventoryCtxKey = "req-sentinel"
+	ctx := context.WithValue(context.Background(), k, "v1")
+
+	h.supplementWithOsquery(ctx, oq, map[string]*pb.InventoryTable{})
+
+	require.NotNil(t, oq.lastTableCtx, "osquery QueryTable was never called — the test is vacuous")
+	require.Equal(t, "v1", oq.lastTableCtx.Value(k),
+		"supplementWithOsquery dropped the caller context (rooted a fresh context.Background()); a cancelled or deadlined RequestInventory RPC would not propagate to osquery")
+}


### PR DESCRIPTION
## Real bug fixed

`CollectInventory(ctx)` threaded the caller context into the baseline
phase but `supplementWithOsquery` **dropped it** and rooted a fresh
`context.Background()` for every osquery `QueryTable`. A signed
`RequestInventory` RPC

```
OnRequestInventory(ctx) -> CollectInventory(ctx) -> supplementWithOsquery
```

therefore had its deadline and cancellation **silently ignored** once
osquery collection began (each call only bounded by osquery's own
`defaultTimeout`, looping over ~10 tables). Root-cause fix: thread `ctx`
through the one helper that dropped it.

**Regression test** (red on the buggy version): a `context` value
sentinel must reach the osquery call, proving the request context is
honoured rather than replaced by `Background()`.

## Guard

Adds `TestNoContextBackgroundInRequestPaths` — a self-discovering AST
fitness function that makes the NIS2 / spec-12 / CLAUDE invariant
build-failing: agent request-path code (the signed `On*` stream-RPC
handlers and everything they call) must never root a fresh
`context.Background()`/`context.TODO()`. Mirrors the server archtest
guard (power-manage-server#479) and the `TestNoUnabstractedTimeNow`
shape.

- `cmd/` main packages are **category-exempt** (the agent CLI / bootstrap
  legitimately roots the process lifecycle; still walked, so its roots
  keep the matches-zero liveness probe alive).
- **Detached daemon-lifecycle work** (per-session terminal goroutines
  that outlive the start RPC, sweep/heartbeat tickers, startup backend
  detection, shutdown cleanup, local credential-file writes) is
  allowlisted **by enclosing function** with a justification. Each is
  bounded by its own timeout or by the callee. `assertNoStale` fails the
  build if one of those functions stops rooting a context.
- Function-level keys (not file/line): every `context.Background()`
  renders identically, so a file key would fail open.

This guard catches exactly the class of bug fixed above — it was the one
genuine request-path violation; all other sites are legitimate.

## Verification

`go vet`, `staticcheck`, and `go test -race ./internal/handler ./internal/archtest`
are green. Both the guard and the regression test were shown to go **red**
on a real violation.