### PR TITLE
test(archtest): guard math/rand is never used for crypto

### DIFF
--- a/internal/archtest/archtest.go
+++ b/internal/archtest/archtest.go
@@ -34,6 +34,7 @@
 //   - TestSecretComparesAreConstantTime ... secret_compare_test.go
 //   - TestNoUnabstractedTimeNow ........... time_now_test.go
 //   - TestNoStdlibJSONOfProtoMessage ...... proto_json_test.go
+//   - TestNoMathRandForCrypto ............. mathrand_test.go
 package archtest
 
 import (

--- a/internal/archtest/mathrand_test.go
+++ b/internal/archtest/mathrand_test.go
@@ -1,0 +1,47 @@
+package archtest
+
+import (
+	"testing"
+)
+
+// TestNoMathRandForCrypto enforces the NIS2 / CLAUDE rule: never use math/rand
+// (or math/rand/v2) for security-sensitive values — nonces, keys, challenges,
+// IDs. math/rand is a deterministic PRNG seeded from a predictable source; an
+// attacker who recovers its state can predict every subsequent value. IDs use
+// ulidx (crypto-seeded) and secret material uses crypto/rand.
+//
+// The rule is about INTENT, but the honest enforceable proxy is the import:
+// math/rand legitimately appears only for non-cryptographic jitter/backoff/
+// load-balancing. Forbid the import everywhere and allowlist those few
+// non-crypto uses by file, with a justification. A NEW math/rand import — the
+// most likely vector for "I'll just roll an ID with rand" — fails the build.
+//
+// The single allowlist entry doubles as the liveness probe: assertNoStale
+// fails if the detector ever stops finding math/rand at all (a broken scan or
+// the jitter use being removed), so the guard cannot pass vacuously.
+func TestNoMathRandForCrypto(t *testing.T) {
+	root := moduleRoot(t)
+	files := walkGoFiles(t, root, func(string) bool { return true })
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero production Go files — detector is mis-scoped")
+	}
+
+	allow := newAllowlist(map[string]string{
+		"cmd/power-manage-agent/backend.go :: math/rand/v2": "connection backoff jitter (rand.Int64N) — non-cryptographic; IDs use ulidx and secret material uses crypto/rand",
+	})
+
+	for _, gf := range files {
+		for _, imp := range gf.ast.Imports {
+			p := unquoteLit(imp.Path)
+			if p != "math/rand" && p != "math/rand/v2" {
+				continue
+			}
+			if allow.exempt(gf.rel + " :: " + p) {
+				continue
+			}
+			t.Errorf("%s imports %s at %s:%d — math/rand is not cryptographically secure; use crypto/rand for nonces/keys/challenges and ulidx for IDs. If this is a non-crypto use (jitter/backoff/load-balancing), allowlist the file with a justification.",
+				gf.rel, p, gf.rel, gf.line(imp))
+		}
+	}
+	allow.assertNoStale(t)
+}


### PR DESCRIPTION
## What

Adds `TestNoMathRandForCrypto` — a self-discovering import scan that makes
the NIS2 / CLAUDE rule build-failing: never use `math/rand` (or
`math/rand/v2`) for nonces, keys, challenges, or IDs. `math/rand` is a
deterministic PRNG; an attacker who recovers its state predicts every
subsequent value. IDs use `ulidx` (crypto-seeded) and secret material
uses `crypto/rand`.

## Design

- Pure-stdlib scan of every production import.
- `math/rand` legitimately appears only for **non-cryptographic backoff
  jitter** (`cmd/.../backend.go`, `rand.Int64N`), which is allowlisted
  **by file** with a justification. Any new `math/rand` import — the
  likely "I'll just roll an ID with rand" vector — fails the build.
- The single allowlist entry doubles as the **liveness probe**:
  `assertNoStale` fails if the detector ever stops finding `math/rand`
  (broken scan, or the jitter use removed), so the guard cannot pass
  vacuously.

## Scope

Agent only — it holds the codebase's sole `math/rand` use. Server and SDK
have **zero** `math/rand`, and their crypto-RNG correctness is already
guarded (`crypto_rand_test`, `secret_compare_test`); this guard is the
template to port if their crypto surface ever grows. Tracked as G2 in
`INVARIANTS.md`.

Test-only. `go vet`, `staticcheck`, and `internal/archtest` are green;
proven red on a new `math/rand` import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new guard to prevent unintended use of random-number packages in production code.
  * Existing allowed usage for backoff-related behavior remains documented and checked.
  * Added a safeguard to keep the coverage of this scan up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->