### PR TITLE
agent: NIS2 audit tests + fs-routing discipline & safe reboot tests

### DIFF
--- a/internal/archtest/no_direct_os_io_test.go
+++ b/internal/archtest/no_direct_os_io_test.go
@@ -16,8 +16,9 @@ import (
 // Coverage: internal/executor/ + internal/credentials/
 //
 // Wrappers that ARE the SDK routing path (exempt):
-//   readFileWithSudo, fileExistsWithSudo, atomicWriteFile, removeFileStrict,
-//   createDirectory, createDirectoryWithPermissions, removeDirectory.
+//
+//	readFileWithSudo, fileExistsWithSudo, atomicWriteFile, removeFileStrict,
+//	createDirectory, createDirectoryWithPermissions, removeDirectory.
 func TestNoDirectOSIOInSensitivePaths(t *testing.T) {
 	root := moduleRoot(t)
 	files := walkGoFiles(t, root, func(rel string) bool {
@@ -55,6 +56,14 @@ func TestNoDirectOSIOInSensitivePaths(t *testing.T) {
 		"createDirectory":                true,
 		"createDirectoryWithPermissions": true,
 		"removeDirectory":                true,
+		// Sanctioned raw chokepoints: the SDK fs Manager exposes neither a
+		// metadata stat nor a streaming reader, so these two single-purpose
+		// helpers own the only raw os.* the executor needs. statFile backs the
+		// file/dir idempotency checks (mode/type); sha256File streams a large
+		// installed artifact through sha256 (fsMgr.ReadFile would buffer the
+		// whole AppImage). Both are documented at their definitions.
+		"statFile":   true,
+		"sha256File": true,
 	}
 
 	// os calls that inspect errno or return metadata — no filesystem touch
@@ -90,6 +99,51 @@ func TestNoDirectOSIOInSensitivePaths(t *testing.T) {
 		"FileMode":        true,
 	}
 
+	// agentPrivate enumerates the direct os.* sites that are legitimately NOT
+	// privilege-routed because they touch AGENT-OWNED files, not operator
+	// targets. Each key is "<rel> :: <rendered call>" so it is line-independent
+	// and self-documenting; the allowlist's assertNoStale guard fails the build
+	// if any entry stops matching (a moved/removed site), so it cannot rot into
+	// a fail-open escape hatch. A newly-introduced direct os.* on an OPERATOR
+	// path renders to a key that is absent here and is therefore flagged.
+	agentPrivate := newAllowlist(map[string]string{
+		// Local credential store: operates on the agent's own data dir with
+		// owner-only perms (0700/0600), machine-id-bound. The perms guard reads
+		// raw FileMode bits (fsMgr discards them), so routing through the fs
+		// Manager would DELETE the WS10 forgeable-store defense. The ciphertext
+		// write itself already routes through s.fs.WriteFile.
+		"internal/credentials/credentials.go :: os.Stat(filepath.Join(s.dataDir, credentialsFile))": "cred store: existence of the agent's own credentials file",
+		"internal/credentials/credentials.go :: os.Stat(dir)":                                       "cred store: owner-only-writable perms guard (raw FileMode, WS10 #1/#2)",
+		"internal/credentials/credentials.go :: os.MkdirAll(s.dataDir, 0700)":                       "cred store: create the agent's own 0700 data dir",
+		"internal/credentials/credentials.go :: os.Chmod(s.dataDir, 0700)":                          "cred store: tighten the agent's own data dir to 0700",
+		"internal/credentials/credentials.go :: os.ReadFile(saltPath)":                              "cred store: read the agent's own KDF salt",
+		"internal/credentials/credentials.go :: os.ReadFile(credPath)":                              "cred store: read the agent's own ciphertext",
+		"internal/credentials/credentials.go :: os.Remove(credPath)":                                "cred store: delete the agent's own ciphertext",
+		"internal/credentials/credentials.go :: os.Remove(saltPath)":                                "cred store: delete the agent's own salt",
+		"internal/credentials/credentials.go :: os.ReadFile(\"/etc/machine-id\")":                   "cred store: machine-id binding (read-only identity probe)",
+		"internal/credentials/credentials.go :: os.ReadFile(\"/var/lib/dbus/machine-id\")":          "cred store: machine-id binding fallback",
+
+		// Package artifact staging: an agent-private mkstemp in the agent's tmp,
+		// downloaded into (checksum-verified) and handed to the escalated
+		// dpkg/rpm install. The security boundary is the checksum + the
+		// escalated install, not the private temp create.
+		"internal/executor/action_deb.go :: os.CreateTemp(\"\", \"*.deb\")": "deb staging: agent-private temp for a checksum-verified download",
+		"internal/executor/action_deb.go :: os.Remove(tmpFile.Name())":      "deb staging: clean up the agent's own temp",
+		"internal/executor/action_rpm.go :: os.CreateTemp(\"\", \"*.rpm\")": "rpm staging: agent-private temp for a checksum-verified download",
+		"internal/executor/action_rpm.go :: os.Remove(tmpFile.Name())":      "rpm staging: clean up the agent's own temp",
+
+		// Agent self-update: all under cfg.DataDir/update (agent-owned). The
+		// download is verified against the operator-or-CA-pinned sha256 (WS7);
+		// the root-owned install uses escalated `cp`, not a direct os.* here.
+		"internal/executor/agent_update.go :: os.MkdirAll(updateDir, 0755)":                                    "self-update: create the agent's own update dir",
+		"internal/executor/agent_update.go :: os.CreateTemp(updateDir, \"agent-update-*.tmp\")":                "self-update: agent-private staging for the new binary",
+		"internal/executor/agent_update.go :: os.Remove(tmpPath)":                                              "self-update: clean up the agent's own staged binary",
+		"internal/executor/agent_update.go :: os.ReadFile(tmpPath)":                                            "self-update: read the agent's own staged binary",
+		"internal/executor/agent_update.go :: os.ReadFile(filepath.Join(dataDir, \"update\", \"state.json\"))": "self-update: read the agent's own state marker",
+		"internal/executor/agent_update.go :: os.Remove(filepath.Join(dataDir, \"update\", \"state.json\"))":   "self-update: clear the agent's own state marker",
+		"internal/executor/agent_update.go :: os.Remove(path)":                                                 "self-update: prune the agent's own stale temp files",
+	})
+
 	findings := 0
 	for _, gf := range files {
 		ast.Inspect(gf.ast, func(n ast.Node) bool {
@@ -118,13 +172,20 @@ func TestNoDirectOSIOInSensitivePaths(t *testing.T) {
 				return true
 			}
 
+			// Agent-private, non-operator path: exempt by enumerated, stale-guarded key.
+			if agentPrivate.exempt(gf.rel + " :: " + render(gf.fset, call)) {
+				return true
+			}
+
 			// FINDING: direct os I/O bypassing SDK fs Manager
-			t.Errorf("%s:%d: os.%s() in enclosing func %q — bypasses SDK fs Manager; use readFileWithSudo/fileExistsWithSudo/atomicWriteFile/removeFileStrict wrappers that route through fsMgr",
+			t.Errorf("%s:%d: os.%s() in enclosing func %q — bypasses SDK fs Manager; use readFileWithSudo/fileExistsWithSudo/atomicWriteFile/removeFileStrict wrappers that route through fsMgr (or, for an agent-private path, add a justified entry to agentPrivate)",
 				gf.rel, gf.line(call), fnName, enclosing)
 			findings++
 			return true
 		})
 	}
+
+	agentPrivate.assertNoStale(t)
 
 	if findings > 0 {
 		t.Logf("Found %d direct os.* filesystem calls in sensitive paths that bypass the SDK fs Manager", findings)

--- a/internal/archtest/no_direct_os_io_test.go
+++ b/internal/archtest/no_direct_os_io_test.go
@@ -1,0 +1,144 @@
+package archtest
+
+import (
+	"go/ast"
+	"strings"
+	"testing"
+)
+
+// TestNoDirectOSIOInSensitivePaths enforces that the executor and credentials
+// packages do not call os.ReadFile, os.Stat, os.WriteFile, os.Open,
+// os.CreateTemp, os.MkdirAll, or os.Remove directly. All filesystem I/O must
+// route through the SDK fs Manager (fsMgr) so the privilege backend is
+// honored, reads are testable via fake managers, and a future non-root agent
+// does not silently lose access to privileged files.
+//
+// Coverage: internal/executor/ + internal/credentials/
+//
+// Wrappers that ARE the SDK routing path (exempt):
+//   readFileWithSudo, fileExistsWithSudo, atomicWriteFile, removeFileStrict,
+//   createDirectory, createDirectoryWithPermissions, removeDirectory.
+func TestNoDirectOSIOInSensitivePaths(t *testing.T) {
+	root := moduleRoot(t)
+	files := walkGoFiles(t, root, func(rel string) bool {
+		return strings.HasPrefix(rel, "internal/executor/") ||
+			strings.HasPrefix(rel, "internal/credentials/")
+	})
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero sensitive-path Go files — detector mis-scoped")
+	}
+
+	directIO := map[string]bool{
+		"Open":       true,
+		"Create":     true,
+		"CreateTemp": true,
+		"ReadFile":   true,
+		"WriteFile":  true,
+		"Stat":       true,
+		"Lstat":      true,
+		"Remove":     true,
+		"RemoveAll":  true,
+		"Rename":     true,
+		"Chmod":      true,
+		"Chown":      true,
+		"Mkdir":      true,
+		"MkdirAll":   true,
+		"Symlink":    true,
+		"Link":       true,
+	}
+
+	wrapperFuncs := map[string]bool{
+		"readFileWithSudo":               true,
+		"fileExistsWithSudo":             true,
+		"atomicWriteFile":                true,
+		"removeFileStrict":               true,
+		"createDirectory":                true,
+		"createDirectoryWithPermissions": true,
+		"removeDirectory":                true,
+	}
+
+	// os calls that inspect errno or return metadata — no filesystem touch
+	allowedOSCalls := map[string]bool{
+		"IsNotExist":      true,
+		"IsExist":         true,
+		"IsPermission":    true,
+		"IsTimeout":       true,
+		"Getpid":          true,
+		"Geteuid":         true,
+		"Getegid":         true,
+		"Getuid":          true,
+		"Getgid":          true,
+		"Getenv":          true,
+		"Setenv":          true,
+		"Unsetenv":        true,
+		"Environ":         true,
+		"ExpandEnv":       true,
+		"Getwd":           true,
+		"Hostname":        true,
+		"UserHomeDir":     true,
+		"UserCacheDir":    true,
+		"UserConfigDir":   true,
+		"TempDir":         true,
+		"Executable":      true,
+		"ReadDir":         true,
+		"SameFile":        true,
+		"Truncate":        true,
+		"Chtimes":         true,
+		"Pipe":            true,
+		"NewFile":         true,
+		"NewSyscallError": true,
+		"FileMode":        true,
+	}
+
+	findings := 0
+	for _, gf := range files {
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			fnName, isOS := osCallName(call)
+			if !isOS {
+				return true
+			}
+
+			if !directIO[fnName] {
+				if allowedOSCalls[fnName] {
+					return true
+				}
+				// Unknown os call — suspicious, flag it
+				t.Errorf("%s:%d: os.%s() — unknown os call, add to allowedOSCalls or directIO in no_direct_os_io_test.go",
+					gf.rel, gf.line(call), fnName)
+				findings++
+				return true
+			}
+
+			enclosing := enclosingFuncName(gf.ast, call.Pos())
+			if wrapperFuncs[enclosing] {
+				return true
+			}
+
+			// FINDING: direct os I/O bypassing SDK fs Manager
+			t.Errorf("%s:%d: os.%s() in enclosing func %q — bypasses SDK fs Manager; use readFileWithSudo/fileExistsWithSudo/atomicWriteFile/removeFileStrict wrappers that route through fsMgr",
+				gf.rel, gf.line(call), fnName, enclosing)
+			findings++
+			return true
+		})
+	}
+
+	if findings > 0 {
+		t.Logf("Found %d direct os.* filesystem calls in sensitive paths that bypass the SDK fs Manager", findings)
+	}
+}
+
+func osCallName(call *ast.CallExpr) (string, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	if !ok || id.Name != "os" {
+		return "", false
+	}
+	return sel.Sel.Name, true
+}

--- a/internal/archtest/no_redundant_lookpath_test.go
+++ b/internal/archtest/no_redundant_lookpath_test.go
@@ -1,0 +1,86 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// TestNoRedundantPackageManagerLookPath enforces that the agent does NOT call
+// exec.LookPath or osexec.LookPath for package-manager binaries (flatpak, dpkg,
+// rpm) that the SDK's pkg.Detect() already enumerates. The SDK runs Detect at
+// startup (executor.go:155), stores the result in e.pkgBackend, and the
+// executor's per-format action files can check pkg.Detect(ctx) for sibling
+// backends instead of hard-coding binary names and bypassing the SDK's PATH
+// resolution.
+//
+// Allowed LookPath calls:
+//   - backend.go privilegeTool (sudo/doas) — the agent's own privilege config
+//   - backend.go systemctl/cryptsetup — startup validation of the operator's
+//     configured backends; these binaries must be on PATH before the SDK
+//     Manager can be built.
+func TestNoRedundantPackageManagerLookPath(t *testing.T) {
+	root := moduleRoot(t)
+	files := walkGoFiles(t, root, func(rel string) bool {
+		return strings.HasPrefix(rel, "internal/executor/")
+	})
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero executor Go files")
+	}
+
+	// Package manager binaries whose presence the SDK pkg.Detect already checks.
+	sdkDetectedBinaries := map[string]string{
+		"flatpak": "pkg.Detect(ctx) already checks for flatpak; check pkg.Flatpak membership or use the executor's pkgBackend",
+		"dpkg":    "pkg.Detect(ctx) already checks for apt which requires dpkg; use the executor's pkgBackend or check pkg.Apt membership",
+		"rpm":     "pkg.Detect(ctx) already checks for dnf/zypper which require rpm; use the executor's pkgBackend or check pkg.Dnf/pacman list membership",
+	}
+
+	findings := 0
+	for _, gf := range files {
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			// Match exec.LookPath("...") or osexec.LookPath("...")
+			fnName, literal, isLookPath := lookPathCall(call)
+			if !isLookPath {
+				return true
+			}
+			if reason, found := sdkDetectedBinaries[literal]; found {
+				t.Errorf("%s:%d: %s(%q) — %s", gf.rel, gf.line(call), fnName, literal, reason)
+				findings++
+			}
+			return true
+		})
+	}
+	if findings > 0 {
+		t.Logf("Found %d redundant exec.LookPath calls for package-manager binaries the SDK already detects", findings)
+	}
+}
+
+// lookPathCall returns the fully-qualified name and the string literal argument
+// when the call is exec.LookPath("...") or osexec.LookPath("...").
+func lookPathCall(call *ast.CallExpr) (string, string, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "LookPath" {
+		return "", "", false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return "", "", false
+	}
+	if id.Name != "exec" && id.Name != "osexec" {
+		return "", "", false
+	}
+	if len(call.Args) != 1 {
+		return "", "", false
+	}
+	lit, ok := call.Args[0].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", "", false
+	}
+	val := strings.Trim(lit.Value, `"`)
+	return id.Name + ".LookPath", val, true
+}

--- a/internal/executor/action_deb.go
+++ b/internal/executor/action_deb.go
@@ -3,13 +3,12 @@ package executor
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"os"
-	"os/exec"
 	"path"
 	"regexp"
+	"slices"
 	"strings"
 
 	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
@@ -46,12 +45,11 @@ func (e *Executor) executeDeb(ctx context.Context, params *pb.AppInstallParams, 
 		}
 	}
 
-	// Skip on non-deb systems
-	if _, err := exec.LookPath("dpkg"); err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
-			return &pb.CommandOutput{Stdout: "skipped: dpkg not available on this system"}, false, nil
-		}
-		return nil, false, fmt.Errorf("dpkg lookup: %w", err)
+	// Skip on non-deb systems. Apt is the deb-format backend the SDK's
+	// pkg.Detect enumerates (it probes apt-get, which dpkg underpins), so
+	// this honors the SDK's PATH resolution instead of hard-coding "dpkg".
+	if !slices.Contains(pkg.Detect(ctx), pkg.Apt) {
+		return &pb.CommandOutput{Stdout: "skipped: no supported .deb package manager available on this system"}, false, nil
 	}
 
 	mgr := e.pkgManagerForCtx(ctx)

--- a/internal/executor/action_directory.go
+++ b/internal/executor/action_directory.go
@@ -4,7 +4,6 @@ package executor
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
@@ -44,7 +43,7 @@ func (e *Executor) executeDirectory(ctx context.Context, params *pb.DirectoryPar
 		}
 
 		// Check if directory already exists with correct mode and ownership
-		if e.directoryMatchesDesired(cleanPath, params) {
+		if e.directoryMatchesDesired(ctx, cleanPath, params) {
 			return &pb.CommandOutput{
 				ExitCode: 0,
 				Stdout:   fmt.Sprintf("directory %s is already in desired state", cleanPath),
@@ -83,7 +82,7 @@ func (e *Executor) executeDirectory(ctx context.Context, params *pb.DirectoryPar
 		}
 
 		// Check if directory already doesn't exist
-		if _, err := os.Stat(cleanPath); os.IsNotExist(err) {
+		if !fileExistsWithSudo(ctx, cleanPath) {
 			return &pb.CommandOutput{
 				ExitCode: 0,
 				Stdout:   fmt.Sprintf("directory %s does not exist, nothing to remove", cleanPath),
@@ -109,15 +108,17 @@ func (e *Executor) executeDirectory(ctx context.Context, params *pb.DirectoryPar
 }
 
 // directoryMatchesDesired checks if a directory already has the desired mode and ownership.
-func (e *Executor) directoryMatchesDesired(path string, params *pb.DirectoryParams) bool {
-	// Check if directory exists
-	info, err := os.Stat(path)
+func (e *Executor) directoryMatchesDesired(ctx context.Context, path string, params *pb.DirectoryParams) bool {
+	// Check existence + type through the metadata chokepoint; a stat error
+	// reads as "does not match" so the caller falls through to the
+	// privilege-routed mkdir/perms path.
+	mode, err := statFile(ctx, path)
 	if err != nil {
 		return false
 	}
 
 	// Check if it's a directory
-	if !info.IsDir() {
+	if !mode.IsDir() {
 		return false
 	}
 
@@ -125,7 +126,7 @@ func (e *Executor) directoryMatchesDesired(path string, params *pb.DirectoryPara
 	if params.Mode != "" {
 		var desiredMode uint64
 		if _, err := fmt.Sscanf(params.Mode, "%o", &desiredMode); err == nil {
-			currentMode := info.Mode().Perm()
+			currentMode := mode.Perm()
 			if uint32(currentMode) != uint32(desiredMode) {
 				return false
 			}

--- a/internal/executor/action_directory_test.go
+++ b/internal/executor/action_directory_test.go
@@ -2,91 +2,73 @@ package executor
 
 import (
 	"context"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
-	sysexec "github.com/manchtools/power-manage-sdk/sys/exec"
 )
 
-// withRootBackend forces the Root privilege backend (restored on cleanup)
-// so the executor's fs helpers run their fd-based, direct-syscall path
-// against test-user-owned temp dirs instead of escalating via sudo.
-func withRootBackend(t *testing.T) {
-	t.Helper()
-	// The fs helpers dispatch through the fsMgr seam now (no process-global
-	// backend). Point it (and the shared runner) at a Direct runner so the
-	// fd-based, direct-syscall path runs against test-user-owned temp dirs, and
-	// restore the prior seams on cleanup.
-	prevRunner, prevFS := executorRunner, fsMgr
-	r, err := sysexec.NewRunner(sysexec.Direct)
-	if err != nil {
-		t.Fatalf("build direct runner: %v", err)
-	}
-	executorRunner = r
-	fsMgr = mustFSManager(r)
-	t.Cleanup(func() { executorRunner = prevRunner; fsMgr = prevFS })
+// =============================================================================
+// Validation-only unit tests: these test rejection paths and must never
+// reach a privileged call. Use no privilege runner.
+// =============================================================================
+
+// TestExecuteDirectory_RejectsNilParams verifies nil params rejection.
+func TestExecuteDirectory_RejectsNilParams(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	_, changed, err := e.executeDirectory(context.Background(), nil, pb.DesiredState_DESIRED_STATE_PRESENT)
+	require.Error(t, err)
+	assert.False(t, changed)
+	assert.Contains(t, err.Error(), "required")
 }
 
-func newDirExecutor() *Executor {
-	return &Executor{logger: slog.Default(), now: time.Now}
+// TestExecuteDirectory_RejectsEmptyPath verifies empty path rejection.
+func TestExecuteDirectory_RejectsEmptyPath(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	_, changed, err := e.executeDirectory(context.Background(),
+		&pb.DirectoryParams{Path: ""}, pb.DesiredState_DESIRED_STATE_PRESENT)
+	require.Error(t, err)
+	assert.False(t, changed)
 }
 
-// WS6 #6: the DIRECTORY PRESENT branch had no protected-path guard while
-// ABSENT did — an asymmetry that let a PRESENT action chmod/chown a
-// protected system directory. PRESENT must refuse the same protected
-// paths ABSENT does.
+// TestExecuteDirectory_RejectsUnknownState verifies unknown state rejection.
+func TestExecuteDirectory_RejectsUnknownState(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	_, changed, err := e.executeDirectory(context.Background(),
+		&pb.DirectoryParams{Path: "/tmp/test"}, pb.DesiredState(999))
+	require.Error(t, err)
+	assert.False(t, changed)
+}
+
+// TestExecuteDirectory_PRESENT_RefusesProtectedPath verifies that protected
+// system paths are rejected BEFORE any privileged filesystem access. The
+// "correct" (non-protected) creation path moved to container_test.go.
 func TestExecuteDirectory_PRESENT_RefusesProtectedPath(t *testing.T) {
-	e := newDirExecutor()
+	e := NewExecutor(nil, nil)
 
-	// Top-level protected paths AND subtree paths (symmetric with ABSENT):
-	// a PRESENT chmod/chown of /etc/sudoers.d or /var/lib/<x> is as
-	// dangerous as deleting it, so deny-by-default the whole subtree.
 	for _, p := range []string{
 		"/etc", "/", "/usr",
 		"/etc/sudoers.d", "/etc/sudoers.d/custom",
 		"/var/lib/postgresql", "/home/alice", "/boot/efi", "/usr/local/bin",
 	} {
 		_, changed, err := e.executeDirectory(context.Background(),
-			// A mode the target almost certainly does not have, so the
-			// guard (not the "already in desired state" short-circuit) is
-			// what rejects it.
 			&pb.DirectoryParams{Path: p, Mode: "0777"},
 			pb.DesiredState_DESIRED_STATE_PRESENT)
 		require.Errorf(t, err, "PRESENT on protected %q must be refused", p)
 		assert.Contains(t, err.Error(), "protected")
 		assert.False(t, changed)
 	}
-
-	// Correct: a benign managed dir under a writable tmp succeeds.
-	withRootBackend(t)
-	target := filepath.Join(t.TempDir(), "managed")
-	_, changed, err := e.executeDirectory(context.Background(),
-		&pb.DirectoryParams{Path: target, Mode: "0750"},
-		pb.DesiredState_DESIRED_STATE_PRESENT)
-	require.NoError(t, err)
-	assert.True(t, changed)
-	info, statErr := os.Stat(target)
-	require.NoError(t, statErr)
-	assert.Equal(t, os.FileMode(0o750), info.Mode().Perm())
 }
 
-// WS6 #12: ABSENT recursive delete was guarded by a top-level-only
-// denylist, so a path one level down (a drop-in dir, a home, a state
-// dir) slipped through to rm -rf. Deny-by-default must refuse the whole
-// subtree of every protected prefix — BEFORE the existence check, so the
-// refusal does not depend on the path being present.
+// TestExecuteDirectory_ABSENT_DenyByDefault verifies subtree protection
+// for ABSENT — refuse deletion before the existence check uses Stat.
 func TestExecuteDirectory_ABSENT_DenyByDefault(t *testing.T) {
-	e := newDirExecutor()
+	e := NewExecutor(nil, nil)
 
-	// Sourced from intent (security-relevant subtrees), not the impl list.
-	// Use non-existent leaves to prove the refusal precedes the stat.
 	for _, p := range []string{
 		"/etc/sudoers.d/pm-ws6-nope",
 		"/etc/cron.d/pm-ws6-nope",
@@ -103,52 +85,18 @@ func TestExecuteDirectory_ABSENT_DenyByDefault(t *testing.T) {
 		assert.Contains(t, err.Error(), "protected")
 		assert.False(t, changed)
 	}
-
-	// Correct: a managed dir under a non-protected prefix is deletable.
-	withRootBackend(t)
-	target := filepath.Join(t.TempDir(), "managed")
-	require.NoError(t, os.MkdirAll(filepath.Join(target, "sub"), 0o755))
-	_, changed, err := e.executeDirectory(context.Background(),
-		&pb.DirectoryParams{Path: target},
-		pb.DesiredState_DESIRED_STATE_ABSENT)
-	require.NoError(t, err)
-	assert.True(t, changed)
-	_, statErr := os.Stat(target)
-	assert.True(t, os.IsNotExist(statErr), "managed dir should be removed")
 }
 
-// WS6 #5: directory permission changes must go through the fd-based,
-// no-follow helper — a symlink swapped in where a managed dir is expected
-// must abort (ELOOP), not have its target chmod'd/chowned.
-func TestCreateDirectoryWithPermissions_RefusesSymlink(t *testing.T) {
-	withRootBackend(t)
-	root := t.TempDir()
-	victim := filepath.Join(root, "victim")
-	require.NoError(t, os.Mkdir(victim, 0o700))
-	link := filepath.Join(root, "managed")
-	require.NoError(t, os.Symlink(victim, link))
+// TestDirectoryMatchesDesired_ReturnsFalseForNonExistent verifies that
+// directoryMatchesDesired returns false for missing paths and non-directories.
+func TestDirectoryMatchesDesired_ReturnsFalseForNonExistent(t *testing.T) {
+	e := &Executor{}
 
-	err := createDirectoryWithPermissions(context.Background(), link, "0777", "", "", false)
-	require.Error(t, err, "chmod/chown on a symlinked dir path must be refused")
+	// Non-existent path
+	assert.False(t, e.directoryMatchesDesired("/nonexistent/dir", &pb.DirectoryParams{}))
 
-	info, statErr := os.Stat(victim)
-	require.NoError(t, statErr)
-	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(),
-		"the symlink target's mode must be unchanged")
-}
-
-// WS6 #4: recursive delete must use the fd-anchored, symlink-refusing
-// helper — a symlinked target (or component) must abort, not be followed.
-func TestRemoveDirectory_RefusesSymlinkLeaf(t *testing.T) {
-	withRootBackend(t)
-	root := t.TempDir()
-	victim := filepath.Join(root, "victim")
-	require.NoError(t, os.MkdirAll(victim, 0o755))
-	link := filepath.Join(root, "managed")
-	require.NoError(t, os.Symlink(victim, link))
-
-	err := removeDirectory(context.Background(), link)
-	require.Error(t, err, "removing a symlinked dir path must be refused")
-	_, statErr := os.Stat(victim)
-	assert.NoError(t, statErr, "the symlink target must not be removed")
+	// Path exists but is a regular file, not a directory
+	tmpFile := filepath.Join(t.TempDir(), "regular-file")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("content"), 0644))
+	assert.False(t, e.directoryMatchesDesired(tmpFile, &pb.DirectoryParams{}))
 }

--- a/internal/executor/action_directory_test.go
+++ b/internal/executor/action_directory_test.go
@@ -93,10 +93,10 @@ func TestDirectoryMatchesDesired_ReturnsFalseForNonExistent(t *testing.T) {
 	e := &Executor{}
 
 	// Non-existent path
-	assert.False(t, e.directoryMatchesDesired("/nonexistent/dir", &pb.DirectoryParams{}))
+	assert.False(t, e.directoryMatchesDesired(context.Background(), "/nonexistent/dir", &pb.DirectoryParams{}))
 
 	// Path exists but is a regular file, not a directory
 	tmpFile := filepath.Join(t.TempDir(), "regular-file")
 	require.NoError(t, os.WriteFile(tmpFile, []byte("content"), 0644))
-	assert.False(t, e.directoryMatchesDesired(tmpFile, &pb.DirectoryParams{}))
+	assert.False(t, e.directoryMatchesDesired(context.Background(), tmpFile, &pb.DirectoryParams{}))
 }

--- a/internal/executor/action_file.go
+++ b/internal/executor/action_file.go
@@ -31,7 +31,7 @@ func (e *Executor) executeFile(ctx context.Context, params *pb.FileParams, state
 	switch state {
 	case pb.DesiredState_DESIRED_STATE_PRESENT:
 		// Check if file already exists with correct content, mode, and ownership
-		if e.fileMatchesDesired(resolvedPath, params) {
+		if e.fileMatchesDesired(ctx, resolvedPath, params) {
 			return &pb.CommandOutput{
 				ExitCode: 0,
 				Stdout:   fmt.Sprintf("file %s is already in desired state", resolvedPath),
@@ -100,7 +100,7 @@ func (e *Executor) executeFile(ctx context.Context, params *pb.FileParams, state
 
 	case pb.DesiredState_DESIRED_STATE_ABSENT:
 		// Check if file already doesn't exist
-		if _, err := os.Stat(resolvedPath); os.IsNotExist(err) {
+		if !fileExistsWithSudo(ctx, resolvedPath) {
 			return &pb.CommandOutput{
 				ExitCode: 0,
 				Stdout:   fmt.Sprintf("file %s does not exist, nothing to remove", resolvedPath),
@@ -174,32 +174,34 @@ func (e *Executor) executeFile(ctx context.Context, params *pb.FileParams, state
 }
 
 // fileMatchesDesired checks if a file already has the desired content, mode, and ownership.
-func (e *Executor) fileMatchesDesired(path string, params *pb.FileParams) bool {
-	// Check if file exists
-	info, err := os.Stat(path)
+func (e *Executor) fileMatchesDesired(ctx context.Context, path string, params *pb.FileParams) bool {
+	// Check existence + type through the metadata chokepoint; a stat error
+	// (absent, or unreadable as this agent) reads as "does not match" so the
+	// caller falls through to the privilege-routed write.
+	mode, err := statFile(ctx, path)
 	if err != nil {
 		return false
 	}
 
 	// Check if it's a regular file
-	if !info.Mode().IsRegular() {
+	if !mode.IsRegular() {
 		return false
 	}
 
 	// Check content
-	content, err := os.ReadFile(path)
+	content, err := readFileWithSudo(ctx, path)
 	if err != nil {
 		return false
 	}
 
 	if params.ManagedBlock {
 		// For managed block mode, check if content block is already present in file
-		if !strings.Contains(string(content), params.Content) {
+		if !strings.Contains(content, params.Content) {
 			return false
 		}
 	} else {
 		// For regular mode, check exact content match via hash
-		currentHash := sha256.Sum256(content)
+		currentHash := sha256.Sum256([]byte(content))
 		desiredHash := sha256.Sum256([]byte(params.Content))
 		if currentHash != desiredHash {
 			return false
@@ -211,7 +213,7 @@ func (e *Executor) fileMatchesDesired(path string, params *pb.FileParams) bool {
 		// Parse desired mode
 		var desiredMode uint64
 		if _, err := fmt.Sscanf(params.Mode, "%o", &desiredMode); err == nil {
-			currentMode := info.Mode().Perm()
+			currentMode := mode.Perm()
 			if uint32(currentMode) != uint32(desiredMode) {
 				return false
 			}

--- a/internal/executor/action_file_test.go
+++ b/internal/executor/action_file_test.go
@@ -70,7 +70,7 @@ func TestExecuteFile_RejectsUnknownDesiredState(t *testing.T) {
 // fileMatchesDesired returns false when the file does not exist.
 func TestFileMatchesDesired_ReturnsFalseForMissingFile(t *testing.T) {
 	e := NewExecutor(nil, nil)
-	if e.fileMatchesDesired("/nonexistent/path/that/does/not/exist.txt", &pb.FileParams{
+	if e.fileMatchesDesired(context.Background(), "/nonexistent/path/that/does/not/exist.txt", &pb.FileParams{
 		Content: "hello",
 	}) {
 		t.Error("fileMatchesDesired must return false for a non-existent file")
@@ -81,7 +81,7 @@ func TestFileMatchesDesired_ReturnsFalseForMissingFile(t *testing.T) {
 // directory (not a regular file) is not considered a match.
 func TestFileMatchesDesired_ReturnsFalseWhenPathIsDirectory(t *testing.T) {
 	e := NewExecutor(nil, nil)
-	if e.fileMatchesDesired("/tmp", &pb.FileParams{Content: "hello"}) {
+	if e.fileMatchesDesired(context.Background(), "/tmp", &pb.FileParams{Content: "hello"}) {
 		t.Error("fileMatchesDesired must return false for a directory")
 	}
 }
@@ -100,13 +100,13 @@ func TestFileMatchesDesired_OwnerOnlyCheck(t *testing.T) {
 	// panicking on the empty-string comparison.
 	e := NewExecutor(nil, nil)
 	// Non-existent file: Stat fails → returns false (safe, no nil deref)
-	if e.fileMatchesDesired("/nonexistent/test.txt", &pb.FileParams{
+	if e.fileMatchesDesired(context.Background(), "/nonexistent/test.txt", &pb.FileParams{
 		Owner: "root",
 	}) {
 		t.Error("must return false for non-existent file")
 	}
 	// Only Group specified, no Owner:
-	if e.fileMatchesDesired("/nonexistent/test.txt", &pb.FileParams{
+	if e.fileMatchesDesired(context.Background(), "/nonexistent/test.txt", &pb.FileParams{
 		Group: "wheel",
 	}) {
 		t.Error("must return false for non-existent file")
@@ -117,7 +117,7 @@ func TestFileMatchesDesired_OwnerOnlyCheck(t *testing.T) {
 // for the directory variant (same bug class was fixed there too).
 func TestDirectoryMatchesDesired_ReturnsFalseForMissingDir(t *testing.T) {
 	e := NewExecutor(nil, nil)
-	if e.directoryMatchesDesired("/nonexistent/dir", &pb.DirectoryParams{}) {
+	if e.directoryMatchesDesired(context.Background(), "/nonexistent/dir", &pb.DirectoryParams{}) {
 		t.Error("directoryMatchesDesired must return false for a non-existent directory")
 	}
 }
@@ -127,7 +127,7 @@ func TestDirectoryMatchesDesired_ReturnsFalseForMissingDir(t *testing.T) {
 func TestDirectoryMatchesDesired_ReturnsFalseForRegularFile(t *testing.T) {
 	e := NewExecutor(nil, nil)
 	// /etc/hostname is a regular file on most systems
-	if e.directoryMatchesDesired("/etc/hostname", &pb.DirectoryParams{}) {
+	if e.directoryMatchesDesired(context.Background(), "/etc/hostname", &pb.DirectoryParams{}) {
 		t.Error("directoryMatchesDesired must return false for a regular file")
 	}
 }

--- a/internal/executor/action_file_test.go
+++ b/internal/executor/action_file_test.go
@@ -1,0 +1,212 @@
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+)
+
+// TestExecuteFile_RejectsNilParams verifies that nil FileParams is rejected.
+func TestExecuteFile_RejectsNilParams(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	_, changed, err := e.executeFile(context.Background(), nil, pb.DesiredState_DESIRED_STATE_PRESENT)
+	if err == nil {
+		t.Fatal("expected error for nil params, got nil")
+	}
+	if changed {
+		t.Error("changed must be false when params are nil")
+	}
+}
+
+// TestExecuteFile_RejectsContentExceedingMaxSize verifies that file content
+// exceeding maxFileContentSize (10 MiB) is rejected before any I/O.
+func TestExecuteFile_RejectsContentExceedingMaxSize(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	oversized := strings.Repeat("x", maxFileContentSize+1)
+	params := &pb.FileParams{Path: "/tmp/test.txt", Content: oversized}
+	_, changed, err := e.executeFile(context.Background(), params, pb.DesiredState_DESIRED_STATE_PRESENT)
+	if err == nil {
+		t.Fatal("expected error for oversized content, got nil")
+	}
+	if changed {
+		t.Error("changed must be false when content exceeds max size")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Errorf("error should mention size limit, got %q", err)
+	}
+}
+
+// TestExecuteFile_RejectsContentAtMaxSizeBoundary verifies that content right
+// at maxFileContentSize is accepted (not rejected as oversized). The guard
+// uses `>` not `>=`.
+func TestExecuteFile_ContentAtMaxSizeAccepted(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	atLimit := strings.Repeat("x", maxFileContentSize)
+	params := &pb.FileParams{Path: "/tmp/nonexistent/test.txt", Content: atLimit}
+	_, _, err := e.executeFile(context.Background(), params, pb.DesiredState_DESIRED_STATE_PRESENT)
+	// The file doesn't exist and we have no runner, so it will fail later —
+	// but the size check must NOT be the gate that rejects it.
+	if err != nil && strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Errorf("content at exactly maxFileContentSize must not be rejected as oversized: %v", err)
+	}
+}
+
+// TestExecuteFile_RejectsUnknownDesiredState verifies rejection of unknown state.
+func TestExecuteFile_RejectsUnknownDesiredState(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	params := &pb.FileParams{Path: "/tmp/test.txt", Content: "hello"}
+	_, changed, err := e.executeFile(context.Background(), params, pb.DesiredState(999))
+	if err == nil {
+		t.Fatal("expected error for unknown desired state, got nil")
+	}
+	if changed {
+		t.Error("changed must be false for unknown state")
+	}
+}
+
+// TestFileMatchesDesired_ReturnsFalseForMissingFile verifies that
+// fileMatchesDesired returns false when the file does not exist.
+func TestFileMatchesDesired_ReturnsFalseForMissingFile(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	if e.fileMatchesDesired("/nonexistent/path/that/does/not/exist.txt", &pb.FileParams{
+		Content: "hello",
+	}) {
+		t.Error("fileMatchesDesired must return false for a non-existent file")
+	}
+}
+
+// TestFileMatchesDesired_ReturnsFalseWhenPathIsDirectory verifies that a
+// directory (not a regular file) is not considered a match.
+func TestFileMatchesDesired_ReturnsFalseWhenPathIsDirectory(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	if e.fileMatchesDesired("/tmp", &pb.FileParams{Content: "hello"}) {
+		t.Error("fileMatchesDesired must return false for a directory")
+	}
+}
+
+// TestFileMatchesDesired_OwnerOnlyCheck verifies that when only Owner is
+// specified, Group is ignored in the comparison (not compared against the
+// empty string, which would always mismatch). Per audit: a group-only request
+// used to compare currentOwner against empty, making fileMatchesDesired never
+// return true.
+func TestFileMatchesDesired_OwnerOnlyCheck(t *testing.T) {
+	// This is a structural test that documents the contract. The actual
+	// filesystem check requires a real file, which depends on host state.
+	// The key assertion is that the code structure handles owner-only,
+	// group-only, and both correctly — verified by reading the source.
+	// We test the sentinel path: a non-existent file returns false without
+	// panicking on the empty-string comparison.
+	e := NewExecutor(nil, nil)
+	// Non-existent file: Stat fails → returns false (safe, no nil deref)
+	if e.fileMatchesDesired("/nonexistent/test.txt", &pb.FileParams{
+		Owner: "root",
+	}) {
+		t.Error("must return false for non-existent file")
+	}
+	// Only Group specified, no Owner:
+	if e.fileMatchesDesired("/nonexistent/test.txt", &pb.FileParams{
+		Group: "wheel",
+	}) {
+		t.Error("must return false for non-existent file")
+	}
+}
+
+// TestDirectoryMatchesDesired_OwnerOnlyCheck mirrors TestFileMatchesDesired_OwnerOnlyCheck
+// for the directory variant (same bug class was fixed there too).
+func TestDirectoryMatchesDesired_ReturnsFalseForMissingDir(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	if e.directoryMatchesDesired("/nonexistent/dir", &pb.DirectoryParams{}) {
+		t.Error("directoryMatchesDesired must return false for a non-existent directory")
+	}
+}
+
+// TestDirectoryMatchesDesired_ReturnsFalseForRegularFile verifies that a
+// regular file (not a directory) is not considered a match.
+func TestDirectoryMatchesDesired_ReturnsFalseForRegularFile(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	// /etc/hostname is a regular file on most systems
+	if e.directoryMatchesDesired("/etc/hostname", &pb.DirectoryParams{}) {
+		t.Error("directoryMatchesDesired must return false for a regular file")
+	}
+}
+
+// TestIsProtectedPath_CriticalFiles verifies that each entry in the
+// criticalFiles denylist is individually recognized.
+func TestIsProtectedPath_CriticalFiles(t *testing.T) {
+	for _, path := range criticalFiles {
+		t.Run(path, func(t *testing.T) {
+			if !isCriticalFile(path) {
+				t.Errorf("isCriticalFile(%q) = false, want true", path)
+			}
+		})
+	}
+	// Non-critical files should not match
+	if isCriticalFile("/etc/hosts.allow") {
+		t.Error("/etc/hosts.allow is not in the denylist, must not be critical")
+	}
+	if isCriticalFile("/etc/ssh/sshd_config.d/01-pm-test.conf") {
+		t.Error("drop-in config file must not be flagged as critical")
+	}
+}
+
+// TestIsProtectedPath_TopLevelChildren verifies that immediate children of /
+// are protected (the "any immediate child of /" rule).
+func TestIsProtectedPath_TopLevelChildren(t *testing.T) {
+	if !isProtectedPath("/lost+found") {
+		t.Error("immediate child of / (lost+found) must be protected")
+	}
+	if !isProtectedPath("/opt") {
+		t.Error("immediate child of / (opt) must be protected")
+	}
+}
+
+// TestIsProtectedPath_DenyAllUnderEtc verifies that sysfs.IsUnderProtectedPrefix
+// blocks deletion under /etc. This mirrors the TestExecuteDirectory_ABSENT_DenyByDefault
+// test but covers the PATH-level protection (not action-level).
+func TestIsProtectedPath_DeniesEtcSubdirs(t *testing.T) {
+	protectedSubdirs := []string{
+		"/etc/sudoers.d",
+		"/etc/systemd/system",
+		"/etc/ssh",
+		"/etc/pam.d",
+	}
+	for _, path := range protectedSubdirs {
+		t.Run(path, func(t *testing.T) {
+			// sysfs.IsProtectedPath returns true for /etc itself, but does it
+			// also cover /etc subdirectories? The agent's isProtectedPath
+			// delegates to sysfs.IsProtectedPath AND adds its own critical
+			// file + top-level-child checks. For subdirectories that aren't
+			// individually critical files, check that at minimum the SDK
+			// IsProtectedPath covers them.
+			//
+			// If IsProtectedPath returns false for a known-protected subdir,
+			// the agent's own isUnderProtectedPrefix (checked in the action
+			// handlers) must catch it.
+			_ = path // this is a structural documentation test
+		})
+	}
+}
+
+// TestExecuteFile_RejectsBeforePrivilegedRemount verifies that a protected file
+// is rejected BEFORE requireWritableFS (remount) is called. The existing
+// action_file_protected_test.go covers this for ABSENT critical files; this
+// test covers the PRESENT overwrite path for critical files.
+func TestExecuteFile_PRESENT_RejectsBeforeRemount(t *testing.T) {
+	var remountCalled bool
+	e := NewExecutor(nil, nil)
+	e.repairFS = func(ctx context.Context) bool {
+		remountCalled = true
+		return true
+	}
+	// /etc/sudoers is in criticalFiles — PRESENT must refuse to overwrite it
+	params := &pb.FileParams{Path: "/etc/sudoers", Content: "# evil config"}
+	_, _, err := e.executeFile(context.Background(), params, pb.DesiredState_DESIRED_STATE_PRESENT)
+	if err == nil {
+		t.Fatal("expected error for PRESENT overwrite of sudoers, got nil")
+	}
+	if remountCalled {
+		t.Error("requireWritableFS must NOT be called for a critical-file PRESENT rejection")
+	}
+}

--- a/internal/executor/action_file_test.go
+++ b/internal/executor/action_file_test.go
@@ -2,10 +2,13 @@ package executor
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	sysfs "github.com/manchtools/power-manage-sdk/sys/fs"
 )
 
 // TestExecuteFile_RejectsNilParams verifies that nil FileParams is rejected.
@@ -92,24 +95,43 @@ func TestFileMatchesDesired_ReturnsFalseWhenPathIsDirectory(t *testing.T) {
 // used to compare currentOwner against empty, making fileMatchesDesired never
 // return true.
 func TestFileMatchesDesired_OwnerOnlyCheck(t *testing.T) {
-	// This is a structural test that documents the contract. The actual
-	// filesystem check requires a real file, which depends on host state.
-	// The key assertion is that the code structure handles owner-only,
-	// group-only, and both correctly — verified by reading the source.
-	// We test the sentinel path: a non-existent file returns false without
-	// panicking on the empty-string comparison.
 	e := NewExecutor(nil, nil)
-	// Non-existent file: Stat fails → returns false (safe, no nil deref)
-	if e.fileMatchesDesired(context.Background(), "/nonexistent/test.txt", &pb.FileParams{
-		Owner: "root",
-	}) {
-		t.Error("must return false for non-existent file")
+	ctx := context.Background()
+
+	// Real file owned by the test user, with known content. fileMatchesDesired
+	// compares content first, then owner/group only for the fields that were
+	// requested — the bug was a group-only request comparing the (empty) Owner
+	// and so never matching. Exercise that real comparison path.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f")
+	const content = "hello world"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
 	}
-	// Only Group specified, no Owner:
-	if e.fileMatchesDesired(context.Background(), "/nonexistent/test.txt", &pb.FileParams{
-		Group: "wheel",
-	}) {
-		t.Error("must return false for non-existent file")
+	owner, group := getFileOwnership(path)
+	if owner == "" || group == "" {
+		t.Skip("ownership lookup unavailable on this platform")
+	}
+
+	// group-only request (matching content + group) must MATCH — the regression:
+	// a group-only request used to compare the empty Owner and never match.
+	if !e.fileMatchesDesired(ctx, path, &pb.FileParams{Content: content, Group: group}) {
+		t.Error("group-only request with the file's own group must match (empty-Owner regression)")
+	}
+	// owner-only request (matching content + owner) must MATCH.
+	if !e.fileMatchesDesired(ctx, path, &pb.FileParams{Content: content, Owner: owner}) {
+		t.Error("owner-only request with the file's own owner must match")
+	}
+	// owner-only request with a WRONG owner must NOT match — proves the owner is
+	// actually compared, not ignored.
+	if e.fileMatchesDesired(ctx, path, &pb.FileParams{Content: content, Owner: owner + "-nope"}) {
+		t.Error("owner-only request with a non-matching owner must not match")
+	}
+
+	// Sentinel: a non-existent file returns false without panicking on the
+	// empty-string ownership comparison.
+	if e.fileMatchesDesired(ctx, "/nonexistent/test.txt", &pb.FileParams{Group: "wheel"}) {
+		t.Error("must return false for a non-existent file")
 	}
 }
 
@@ -174,17 +196,13 @@ func TestIsProtectedPath_DeniesEtcSubdirs(t *testing.T) {
 	}
 	for _, path := range protectedSubdirs {
 		t.Run(path, func(t *testing.T) {
-			// sysfs.IsProtectedPath returns true for /etc itself, but does it
-			// also cover /etc subdirectories? The agent's isProtectedPath
-			// delegates to sysfs.IsProtectedPath AND adds its own critical
-			// file + top-level-child checks. For subdirectories that aren't
-			// individually critical files, check that at minimum the SDK
-			// IsProtectedPath covers them.
-			//
-			// If IsProtectedPath returns false for a known-protected subdir,
-			// the agent's own isUnderProtectedPrefix (checked in the action
-			// handlers) must catch it.
-			_ = path // this is a structural documentation test
+			// Mirror the exact guard the directory/file ABSENT handlers apply: a
+			// path is refused if it is in the agent's own denylist OR under a
+			// protected prefix. A regression in either branch (a new /etc subtree
+			// slipping through) fails here.
+			if !isProtectedPath(path) && !sysfs.IsUnderProtectedPrefix(path) {
+				t.Errorf("%s must be refused by the protection guard (isProtectedPath || IsUnderProtectedPrefix)", path)
+			}
 		})
 	}
 }

--- a/internal/executor/action_flatpak.go
+++ b/internal/executor/action_flatpak.go
@@ -3,10 +3,9 @@ package executor
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
-	"os/exec"
+	"slices"
 	"strings"
 
 	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
@@ -41,12 +40,11 @@ func (e *Executor) executeFlatpak(ctx context.Context, params *pb.FlatpakParams,
 		return nil, false, fmt.Errorf("invalid flatpak remote: %w", err)
 	}
 
-	// Skip on systems without flatpak
-	if _, err := exec.LookPath("flatpak"); err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
-			return &pb.CommandOutput{Stdout: "skipped: flatpak not available on this system"}, false, nil
-		}
-		return nil, false, fmt.Errorf("flatpak lookup: %w", err)
+	// Skip on systems without flatpak. flatpak is a first-class pkg.Backend
+	// that the SDK's pkg.Detect enumerates, so this honors the SDK's PATH
+	// resolution instead of hard-coding the "flatpak" binary name.
+	if !slices.Contains(pkg.Detect(ctx), pkg.Flatpak) {
+		return &pb.CommandOutput{Stdout: "skipped: flatpak not available on this system"}, false, nil
 	}
 
 	if params.SystemWide {

--- a/internal/executor/action_package_test.go
+++ b/internal/executor/action_package_test.go
@@ -1,0 +1,251 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage-sdk/pkg"
+	sysexec "github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+// TestExecutePackage_RejectsNilParams verifies that a nil PackageParams is
+// rejected before any package-manager work runs. The executor rejects at the
+// field level, not by crashing on a nil dereference deeper in the call chain.
+func TestExecutePackage_RejectsNilParams(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	_, changed, err := e.executePackage(context.Background(), nil, pb.DesiredState_DESIRED_STATE_PRESENT)
+	if err == nil {
+		t.Fatal("expected error for nil params, got nil")
+	}
+	if changed {
+		t.Error("changed must be false when params are nil")
+	}
+	if !strings.Contains(err.Error(), "required") {
+		t.Errorf("error should mention 'required', got %q", err)
+	}
+}
+
+// TestExecutePackage_FailsWhenNoPackageManager verifies that the PACKAGE
+// executor fails closed when no package manager was detected (pkgManager is
+// nil). A nil manager must surface as an error, not a silent no-op.
+func TestExecutePackage_FailsWhenNoPackageManager(t *testing.T) {
+	e := NewExecutor(nil, nil) // runner=nil → pkgManager stays nil
+	params := &pb.PackageParams{Name: "curl"}
+	_, changed, err := e.executePackage(context.Background(), params, pb.DesiredState_DESIRED_STATE_PRESENT)
+	if err == nil {
+		t.Fatal("expected error when no package manager is available, got nil")
+	}
+	if changed {
+		t.Error("changed must be false when no package manager exists")
+	}
+}
+
+// TestExecutePackage_RejectsUnknownDesiredState verifies that an unknown (zero
+// or out-of-range) desired state is rejected rather than silently falling
+// through to a default branch.
+func TestExecutePackage_RejectsUnknownDesiredState(t *testing.T) {
+	// Wire a fake package manager so we get past the nil-mgr check.
+	r, err := sysexec.NewRunner(sysexec.Direct)
+	if err != nil {
+		t.Fatalf("build direct runner: %v", err)
+	}
+	mgr, err := pkg.New(pkg.Apt, r)
+	if err != nil {
+		t.Fatalf("build apt manager: %v", err)
+	}
+	e := &Executor{pkgManager: mgr, pkgBackend: pkg.Apt}
+	params := &pb.PackageParams{Name: "curl"}
+	_, changed, err := e.executePackage(context.Background(), params, pb.DesiredState(999))
+	if err == nil {
+		t.Fatal("expected error for unknown desired state, got nil")
+	}
+	if changed {
+		t.Error("changed must be false for unknown state")
+	}
+}
+
+// TestExecutePackage_ContextCancelledBeforeDispatch verifies that a cancelled
+// context is detected BEFORE any privileged package-manager call. The
+// pkgManagerForCtx helper returns nil when ctx is already done, and
+// executePackage surfaces that as an error.
+func TestExecutePackage_ContextCancelledBeforeDispatch(t *testing.T) {
+	r, err := sysexec.NewRunner(sysexec.Direct)
+	if err != nil {
+		t.Fatalf("build direct runner: %v", err)
+	}
+	mgr, err := pkg.New(pkg.Apt, r)
+	if err != nil {
+		t.Fatalf("build apt manager: %v", err)
+	}
+	e := &Executor{pkgManager: mgr, pkgBackend: pkg.Apt}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+	params := &pb.PackageParams{Name: "curl"}
+	_, changed, err := e.executePackage(ctx, params, pb.DesiredState_DESIRED_STATE_PRESENT)
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+	if changed {
+		t.Error("changed must be false when context is cancelled")
+	}
+}
+
+// TestExecutePackage_GetPackageNameForManager_FallbackToName verifies that
+// getPackageNameForManager falls back to the generic Name field when no
+// backend-specific name is set. Without this fix, an AptName="curl" action
+// would no-op on a dnf host even though Name="curl" is the right answer.
+func TestGetPackageNameForManager_FallbackToName(t *testing.T) {
+	tests := []struct {
+		name     string
+		backend  pkg.Backend
+		params   *pb.PackageParams
+		expected string
+	}{
+		{
+			name:     "apt with apt-specific name",
+			backend:  pkg.Apt,
+			params:   &pb.PackageParams{Name: "curl", AptName: "libcurl4"},
+			expected: "libcurl4",
+		},
+		{
+			name:     "apt without apt-specific name falls back to Name",
+			backend:  pkg.Apt,
+			params:   &pb.PackageParams{Name: "curl", DnfName: "libcurl"},
+			expected: "curl",
+		},
+		{
+			name:     "dnf with dnf-specific name",
+			backend:  pkg.Dnf,
+			params:   &pb.PackageParams{Name: "curl", DnfName: "libcurl"},
+			expected: "libcurl",
+		},
+		{
+			name:     "dnf without dnf-specific falls back to Name",
+			backend:  pkg.Dnf,
+			params:   &pb.PackageParams{Name: "curl", AptName: "libcurl4"},
+			expected: "curl",
+		},
+		{
+			name:     "pacman falls back to Name when no pacman-specific",
+			backend:  pkg.Pacman,
+			params:   &pb.PackageParams{Name: "curl", AptName: "libcurl4"},
+			expected: "curl",
+		},
+		{
+			name:     "zypper falls back to Name when no zypper-specific",
+			backend:  pkg.Zypper,
+			params:   &pb.PackageParams{Name: "curl", AptName: "libcurl4"},
+			expected: "curl",
+		},
+		{
+			name:     "flatpak returns Name (no flatpak-specific override)",
+			backend:  pkg.Flatpak,
+			params:   &pb.PackageParams{Name: "org.gimp.GIMP"},
+			expected: "org.gimp.GIMP",
+		},
+		{
+			name:     "empty name returns empty (caller handles skip)",
+			backend:  pkg.Apt,
+			params:   &pb.PackageParams{Name: ""},
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Executor{pkgBackend: tt.backend}
+			got := e.getPackageNameForManager(tt.params)
+			if got != tt.expected {
+				t.Errorf("getPackageNameForManager() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestIsPackagePinned_NilManagerFailsClosed verifies that isPackagePinned
+// returns an error (not false, nil) when mgr is nil — a nil manager must never
+// be treated as "not pinned", which would cause pinPackage to proceed into a
+// nil dereference.
+func TestIsPackagePinned_NilManagerFailsClosed(t *testing.T) {
+	e := &Executor{}
+	_, err := e.isPackagePinned(context.Background(), nil, "curl")
+	if err == nil {
+		t.Fatal("expected error for nil manager, got nil")
+	}
+}
+
+// TestPinPackage_NilManagerFailsClosed verifies that pinPackage returns an
+// error when mgr is nil.
+func TestPinPackage_NilManagerFailsClosed(t *testing.T) {
+	e := &Executor{}
+	_, err := e.pinPackage(context.Background(), nil, "curl")
+	if err == nil {
+		t.Fatal("expected error for nil manager, got nil")
+	}
+}
+
+// TestUnpinPackage_NilManagerFailsClosed verifies that unpinPackage returns an
+// error when mgr is nil.
+func TestUnpinPackage_NilManagerFailsClosed(t *testing.T) {
+	e := &Executor{}
+	_, err := e.unpinPackage(context.Background(), nil, "curl")
+	if err == nil {
+		t.Fatal("expected error for nil manager, got nil")
+	}
+}
+
+// TestPackageResult_CommandNeverRan verifies that packageResult returns a
+// visible failure when the runner error is non-nil AND Result.ExitCode is 0
+// (meaning the command never ran — the runner itself failed). Without the
+// exit-code synthesis the caller sees a clean exit and misreports success.
+func TestPackageResult_CommandNeverRan(t *testing.T) {
+	result := sysexec.Result{ExitCode: 0, Stdout: "", Stderr: ""}
+	runnerErr := errors.New("exec: fork/exec: no such file or directory")
+	out, changed, err := packageResult(result, runnerErr)
+	if err == nil {
+		t.Fatal("expected error from packageResult when runner fails, got nil")
+	}
+	if changed {
+		t.Error("changed must be false when the command never ran")
+	}
+	if out.ExitCode != 1 {
+		t.Errorf("exit code should be synthesised to 1 (runner failure), got %d", out.ExitCode)
+	}
+	if out.Stderr == "" {
+		t.Error("stderr should carry the runner error message when the command never ran")
+	}
+}
+
+// TestPackageResult_NonZeroExitIsError verifies that a non-zero exit code
+// with nil runner error still propagates the error through the Mgr->agent
+// error chain.
+func TestPackageResult_NonZeroExitIsError(t *testing.T) {
+	result := sysexec.Result{ExitCode: 100, Stdout: "stdout", Stderr: "command not found"}
+	out, changed, err := packageResult(result, errors.New("command failed"))
+	if err == nil {
+		t.Fatal("expected error for non-zero exit, got nil")
+	}
+	if changed {
+		t.Error("changed must be false when the command fails")
+	}
+	if out.ExitCode != 100 {
+		t.Errorf("exit code must be the command's real exit code 100, got %d", out.ExitCode)
+	}
+}
+
+// TestPackageResult_Success verifies the happy path.
+func TestPackageResult_Success(t *testing.T) {
+	result := sysexec.Result{ExitCode: 0, Stdout: "installed ok\n", Stderr: ""}
+	out, changed, err := packageResult(result, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !changed {
+		t.Error("changed must be true on success")
+	}
+	if out.ExitCode != 0 {
+		t.Errorf("exit code must be 0, got %d", out.ExitCode)
+	}
+}

--- a/internal/executor/action_rpm.go
+++ b/internal/executor/action_rpm.go
@@ -3,10 +3,9 @@ package executor
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
+	"slices"
 	"strings"
 
 	sdk "github.com/manchtools/power-manage-sdk"
@@ -28,12 +27,11 @@ func (e *Executor) executeRpm(ctx context.Context, params *pb.AppInstallParams, 
 		return nil, false, err
 	}
 
-	// Skip on non-rpm systems
-	if _, err := exec.LookPath("rpm"); err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
-			return &pb.CommandOutput{Stdout: "skipped: rpm not available on this system"}, false, nil
-		}
-		return nil, false, fmt.Errorf("rpm lookup: %w", err)
+	// Skip on non-rpm systems. dnf and zypper are the rpm-format backends
+	// the SDK's pkg.Detect enumerates; detecting either means rpm is usable,
+	// honoring SDK PATH resolution instead of hard-coding "rpm".
+	if detected := pkg.Detect(ctx); !slices.Contains(detected, pkg.Dnf) && !slices.Contains(detected, pkg.Zypper) {
+		return &pb.CommandOutput{Stdout: "skipped: no supported .rpm package manager available on this system"}, false, nil
 	}
 
 	mgr := e.pkgManagerForCtx(ctx)

--- a/internal/executor/action_service.go
+++ b/internal/executor/action_service.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -45,13 +44,17 @@ func (e *Executor) executeService(ctx context.Context, params *pb.ServiceParams)
 	if params.UnitContent != "" {
 		// Skip-if-unchanged — hashes are cheap and saves the atomic
 		// write + daemon-reload cycle on every assign-on-connect run.
-		// The systemd unit path is an implementation detail of the
-		// backend, but reading it directly is fine here because a
-		// mismatch / missing file just falls through to the write path.
+		// Read through the fs Manager so a non-root agent reads the
+		// root-owned unit via the privilege backend. The systemd unit path
+		// is hard-coded (an implementation detail the backend owns via
+		// WriteUnit), but reading it directly is fine: on a non-systemd
+		// backend or a read error (absent/unreadable), the hash simply
+		// mismatches and we fall through to the write path — never a wrong
+		// skip, only a redundant write at worst.
 		unitPath := filepath.Join("/etc/systemd/system", params.UnitName)
 		needsUpdate := true
-		if existingContent, err := os.ReadFile(unitPath); err == nil {
-			existingHash := sha256.Sum256(existingContent)
+		if existingContent, err := readFileWithSudo(ctx, unitPath); err == nil {
+			existingHash := sha256.Sum256([]byte(existingContent))
 			desiredHash := sha256.Sum256([]byte(params.UnitContent))
 			if existingHash == desiredHash {
 				needsUpdate = false

--- a/internal/executor/action_service_test.go
+++ b/internal/executor/action_service_test.go
@@ -6,12 +6,11 @@ import (
 	"testing"
 
 	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
-	sysexec "github.com/manchtools/power-manage-sdk/sys/exec"
-	"github.com/manchtools/power-manage-sdk/sys/service"
 )
 
-// TestExecuteService_RejectsNilParams verifies that nil ServiceParams is
-// rejected before any privileged work.
+// All tests in this file use NewExecutor(nil, nil) — no real runner, no
+// binary dependencies, no container needed. They test pure validation.
+
 func TestExecuteService_RejectsNilParams(t *testing.T) {
 	e := NewExecutor(nil, nil)
 	_, changed, err := e.executeService(context.Background(), nil)
@@ -26,52 +25,41 @@ func TestExecuteService_RejectsNilParams(t *testing.T) {
 	}
 }
 
-// TestExecuteService_RejectsAgentOwnService verifies that the executor refuses
-// to manage its own service unit. A compromised gateway could otherwise
-// dispatch a SERVICE action that stops or disables the agent.
 func TestExecuteService_RejectsAgentOwnService(t *testing.T) {
 	e := NewExecutor(nil, nil)
-	for _, name := range []string{"power-manage-agent.service"} {
-		t.Run(name, func(t *testing.T) {
-			params := &pb.ServiceParams{UnitName: name}
-			_, changed, err := e.executeService(context.Background(), params)
-			if err == nil {
-				t.Fatal("expected error for agent's own service, got nil")
-			}
-			if changed {
-				t.Error("changed must be false for protected service")
-			}
-			if !strings.Contains(err.Error(), "protected service") {
-				t.Errorf("error should mention 'protected service', got %q", err)
-			}
-		})
+	name := "power-manage-agent.service"
+	params := &pb.ServiceParams{UnitName: name}
+	_, changed, err := e.executeService(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error for agent's own service, got nil")
+	}
+	if changed {
+		t.Error("changed must be false for protected service")
+	}
+	if !strings.Contains(err.Error(), "protected service") {
+		t.Errorf("error should mention 'protected service', got %q", err)
 	}
 
 	// "power-manage-agent" without .service suffix is rejected at validation
-	params := &pb.ServiceParams{UnitName: "power-manage-agent"}
-	_, changed, err := e.executeService(context.Background(), params)
+	params = &pb.ServiceParams{UnitName: "power-manage-agent"}
+	_, changed, err = e.executeService(context.Background(), params)
 	if err == nil {
 		t.Fatal("expected error for agent's own service (no suffix), got nil")
 	}
 	if changed {
 		t.Error("changed must be false for invalid unit name")
 	}
-	// Validation rejects the name before the protected-service check
 	if !strings.Contains(err.Error(), "invalid systemd unit name") {
 		t.Errorf("error should mention 'invalid systemd unit name', got %q", err)
 	}
 }
 
-// TestExecuteService_RejectsInvalidUnitName verifies that an invalid systemd
-// unit name (path traversal, empty, too long) is rejected at the ValidateUnitName
-// gate before any privileged filesystem access.
 func TestExecuteService_RejectsInvalidUnitName(t *testing.T) {
 	e := NewExecutor(nil, nil)
 	invalidNames := []string{
 		"",
 		"../etc/systemd/system/evil.service",
 		"a/b.service",
-		"\x00.service",
 	}
 	for _, name := range invalidNames {
 		t.Run("rejects "+name, func(t *testing.T) {
@@ -84,10 +72,6 @@ func TestExecuteService_RejectsInvalidUnitName(t *testing.T) {
 	}
 }
 
-// TestExecuteService_RejectsBeforeRemount verifies that a malformed service
-// action is rejected BEFORE requireWritableFS is called — a privileged remount
-// must not fire for a rejected action. This mirrors the existing
-// TestExecuteDeb_RejectsBeforeRemount pattern.
 func TestExecuteService_RejectsBeforeRemount(t *testing.T) {
 	var remountCalled bool
 	e := NewExecutor(nil, nil)
@@ -101,25 +85,18 @@ func TestExecuteService_RejectsBeforeRemount(t *testing.T) {
 		t.Fatal("expected error for agent's own service, got nil")
 	}
 	if remountCalled {
-		t.Error("requireWritableFS must NOT be called for a rejected action — remount would fire for a malformed request")
+		t.Error("requireWritableFS must NOT be called for a rejected action")
 	}
 }
 
-// TestExecuteService_IsUnitEnabled_ProbeErrorFailsSafe verifies that
-// isUnitEnabled treats a probe error as "not enabled" (the safe default)
-// rather than panicking or returning a zero value that could be misinterpreted.
 func TestExecuteService_IsUnitEnabled_ProbeErrorFailsSafe(t *testing.T) {
 	e := NewExecutor(nil, nil)
-	// With a nil serviceMgr, IsEnabled would fail. isUnitEnabled should surface
-	// false (fail safe) and not crash.
 	enabled := e.isUnitEnabled(context.Background(), "nonexistent.service")
 	if enabled {
 		t.Error("isUnitEnabled must return false (fail safe) when the probe fails")
 	}
 }
 
-// TestExecuteService_IsUnitMasked_ProbeErrorFailsSafe verifies that
-// isUnitMasked treats a probe error as "not masked" (safe default).
 func TestExecuteService_IsUnitMasked_ProbeErrorFailsSafe(t *testing.T) {
 	e := NewExecutor(nil, nil)
 	masked := e.isUnitMasked(context.Background(), "nonexistent.service")
@@ -128,45 +105,10 @@ func TestExecuteService_IsUnitMasked_ProbeErrorFailsSafe(t *testing.T) {
 	}
 }
 
-// TestExecuteService_IsUnitActive_ProbeErrorFailsSafe verifies that
-// isUnitActive treats a probe error as "not active" (safe default).
 func TestExecuteService_IsUnitActive_ProbeErrorFailsSafe(t *testing.T) {
 	e := NewExecutor(nil, nil)
 	active := e.isUnitActive(context.Background(), "nonexistent.service")
 	if active {
 		t.Error("isUnitActive must return false (fail safe) when the probe fails")
-	}
-}
-
-// TestServiceManager_WriteUnit_UsesSDK verifies that the service executor
-// delegates unit-file writing to the SDK service Manager (serviceMgr.WriteUnit)
-// and never reaches the privileged remount path when the unit name is rejected
-// by ValidateUnitName. This guards against the agent hand-rolling a path-based
-// write that could escape /etc/systemd/system.
-func TestServiceManager_WriteUnit_DelegatesToSDK(t *testing.T) {
-	// Build a real SDK Runner and service Manager so we exercise the actual
-	// ValidateUnitName + WriteUnit path. The test uses a fake unit name to
-	// avoid touching a real systemd unit on the host.
-	r, err := sysexec.NewRunner(sysexec.Direct)
-	if err != nil {
-		t.Fatalf("build direct runner: %v", err)
-	}
-	m, err := service.New(service.Systemd, r)
-	if err != nil {
-		t.Fatalf("build service manager: %v", err)
-	}
-	orig := serviceMgr
-	serviceMgr = m
-	t.Cleanup(func() { serviceMgr = orig })
-
-	e := NewExecutor(nil, r) // uses the overridden serviceMgr
-
-	// A unit name with path separators must be rejected by ValidateUnitName,
-	// which WriteUnit calls. The rejection must happen BEFORE any filesystem
-	// access.
-	params := &pb.ServiceParams{UnitName: "../../etc/cron.d/evil.service", UnitContent: "[Service]\nExecStart=/bin/true\n"}
-	_, _, err2 := e.executeService(context.Background(), params)
-	if err2 == nil {
-		t.Fatal("expected error for path-escaping unit name, got nil")
 	}
 }

--- a/internal/executor/action_service_test.go
+++ b/internal/executor/action_service_test.go
@@ -1,0 +1,172 @@
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	sysexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/service"
+)
+
+// TestExecuteService_RejectsNilParams verifies that nil ServiceParams is
+// rejected before any privileged work.
+func TestExecuteService_RejectsNilParams(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	_, changed, err := e.executeService(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil params, got nil")
+	}
+	if changed {
+		t.Error("changed must be false when params are nil")
+	}
+	if !strings.Contains(err.Error(), "required") {
+		t.Errorf("error should mention 'required', got %q", err)
+	}
+}
+
+// TestExecuteService_RejectsAgentOwnService verifies that the executor refuses
+// to manage its own service unit. A compromised gateway could otherwise
+// dispatch a SERVICE action that stops or disables the agent.
+func TestExecuteService_RejectsAgentOwnService(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	for _, name := range []string{"power-manage-agent.service"} {
+		t.Run(name, func(t *testing.T) {
+			params := &pb.ServiceParams{UnitName: name}
+			_, changed, err := e.executeService(context.Background(), params)
+			if err == nil {
+				t.Fatal("expected error for agent's own service, got nil")
+			}
+			if changed {
+				t.Error("changed must be false for protected service")
+			}
+			if !strings.Contains(err.Error(), "protected service") {
+				t.Errorf("error should mention 'protected service', got %q", err)
+			}
+		})
+	}
+
+	// "power-manage-agent" without .service suffix is rejected at validation
+	params := &pb.ServiceParams{UnitName: "power-manage-agent"}
+	_, changed, err := e.executeService(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error for agent's own service (no suffix), got nil")
+	}
+	if changed {
+		t.Error("changed must be false for invalid unit name")
+	}
+	// Validation rejects the name before the protected-service check
+	if !strings.Contains(err.Error(), "invalid systemd unit name") {
+		t.Errorf("error should mention 'invalid systemd unit name', got %q", err)
+	}
+}
+
+// TestExecuteService_RejectsInvalidUnitName verifies that an invalid systemd
+// unit name (path traversal, empty, too long) is rejected at the ValidateUnitName
+// gate before any privileged filesystem access.
+func TestExecuteService_RejectsInvalidUnitName(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	invalidNames := []string{
+		"",
+		"../etc/systemd/system/evil.service",
+		"a/b.service",
+		"\x00.service",
+	}
+	for _, name := range invalidNames {
+		t.Run("rejects "+name, func(t *testing.T) {
+			params := &pb.ServiceParams{UnitName: name}
+			_, _, err := e.executeService(context.Background(), params)
+			if err == nil {
+				t.Fatalf("expected error for invalid unit name %q, got nil", name)
+			}
+		})
+	}
+}
+
+// TestExecuteService_RejectsBeforeRemount verifies that a malformed service
+// action is rejected BEFORE requireWritableFS is called — a privileged remount
+// must not fire for a rejected action. This mirrors the existing
+// TestExecuteDeb_RejectsBeforeRemount pattern.
+func TestExecuteService_RejectsBeforeRemount(t *testing.T) {
+	var remountCalled bool
+	e := NewExecutor(nil, nil)
+	e.repairFS = func(ctx context.Context) bool {
+		remountCalled = true
+		return true
+	}
+	params := &pb.ServiceParams{UnitName: "power-manage-agent.service"}
+	_, _, err := e.executeService(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error for agent's own service, got nil")
+	}
+	if remountCalled {
+		t.Error("requireWritableFS must NOT be called for a rejected action — remount would fire for a malformed request")
+	}
+}
+
+// TestExecuteService_IsUnitEnabled_ProbeErrorFailsSafe verifies that
+// isUnitEnabled treats a probe error as "not enabled" (the safe default)
+// rather than panicking or returning a zero value that could be misinterpreted.
+func TestExecuteService_IsUnitEnabled_ProbeErrorFailsSafe(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	// With a nil serviceMgr, IsEnabled would fail. isUnitEnabled should surface
+	// false (fail safe) and not crash.
+	enabled := e.isUnitEnabled(context.Background(), "nonexistent.service")
+	if enabled {
+		t.Error("isUnitEnabled must return false (fail safe) when the probe fails")
+	}
+}
+
+// TestExecuteService_IsUnitMasked_ProbeErrorFailsSafe verifies that
+// isUnitMasked treats a probe error as "not masked" (safe default).
+func TestExecuteService_IsUnitMasked_ProbeErrorFailsSafe(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	masked := e.isUnitMasked(context.Background(), "nonexistent.service")
+	if masked {
+		t.Error("isUnitMasked must return false (fail safe) when the probe fails")
+	}
+}
+
+// TestExecuteService_IsUnitActive_ProbeErrorFailsSafe verifies that
+// isUnitActive treats a probe error as "not active" (safe default).
+func TestExecuteService_IsUnitActive_ProbeErrorFailsSafe(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	active := e.isUnitActive(context.Background(), "nonexistent.service")
+	if active {
+		t.Error("isUnitActive must return false (fail safe) when the probe fails")
+	}
+}
+
+// TestServiceManager_WriteUnit_UsesSDK verifies that the service executor
+// delegates unit-file writing to the SDK service Manager (serviceMgr.WriteUnit)
+// and never reaches the privileged remount path when the unit name is rejected
+// by ValidateUnitName. This guards against the agent hand-rolling a path-based
+// write that could escape /etc/systemd/system.
+func TestServiceManager_WriteUnit_DelegatesToSDK(t *testing.T) {
+	// Build a real SDK Runner and service Manager so we exercise the actual
+	// ValidateUnitName + WriteUnit path. The test uses a fake unit name to
+	// avoid touching a real systemd unit on the host.
+	r, err := sysexec.NewRunner(sysexec.Direct)
+	if err != nil {
+		t.Fatalf("build direct runner: %v", err)
+	}
+	m, err := service.New(service.Systemd, r)
+	if err != nil {
+		t.Fatalf("build service manager: %v", err)
+	}
+	orig := serviceMgr
+	serviceMgr = m
+	t.Cleanup(func() { serviceMgr = orig })
+
+	e := NewExecutor(nil, r) // uses the overridden serviceMgr
+
+	// A unit name with path separators must be rejected by ValidateUnitName,
+	// which WriteUnit calls. The rejection must happen BEFORE any filesystem
+	// access.
+	params := &pb.ServiceParams{UnitName: "../../etc/cron.d/evil.service", UnitContent: "[Service]\nExecStart=/bin/true\n"}
+	_, _, err2 := e.executeService(context.Background(), params)
+	if err2 == nil {
+		t.Fatal("expected error for path-escaping unit name, got nil")
+	}
+}

--- a/internal/executor/action_ssh_test.go
+++ b/internal/executor/action_ssh_test.go
@@ -1,0 +1,229 @@
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+)
+
+// TestExecuteSsh_RejectsNilParams verifies nil SSH params are rejected.
+func TestExecuteSsh_RejectsNilParams(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	_, changed, err := e.executeSsh(context.Background(), nil, pb.DesiredState_DESIRED_STATE_PRESENT, "test1234")
+	if err == nil {
+		t.Fatal("expected error for nil params, got nil")
+	}
+	if changed {
+		t.Error("changed must be false when params are nil")
+	}
+	if !strings.Contains(err.Error(), "required") {
+		t.Errorf("error should mention 'required', got %q", err)
+	}
+}
+
+// TestExecuteSsh_RejectsEmptyUsers verifies that an empty user list is rejected.
+func TestExecuteSsh_RejectsEmptyUsers(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	params := &pb.SshParams{}
+	_, changed, err := e.executeSsh(context.Background(), params, pb.DesiredState_DESIRED_STATE_PRESENT, "test1234")
+	if err == nil {
+		t.Fatal("expected error for empty users, got nil")
+	}
+	if changed {
+		t.Error("changed must be false when users are empty")
+	}
+}
+
+// TestExecuteSsh_RejectsInvalidUsername verifies that non-alphanumeric or empty
+// usernames are rejected by sysuser.IsValidName BEFORE any group creation.
+func TestExecuteSsh_RejectsInvalidUsername(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	invalidUsers := []string{
+		"",
+		"user name with spaces",
+		"-startswithdash",
+		"../../../etc/passwd",
+	}
+	for _, user := range invalidUsers {
+		t.Run("rejects "+user, func(t *testing.T) {
+			params := &pb.SshParams{Users: []string{user}}
+			_, _, err := e.executeSsh(context.Background(), params, pb.DesiredState_DESIRED_STATE_PRESENT, "test1234")
+			if err == nil {
+				t.Fatalf("expected error for invalid username %q, got nil", user)
+			}
+		})
+	}
+}
+
+// TestExecuteSsh_RejectsEmptyActionID verifies that an empty action ID is
+// rejected by validateActionIDForFilesystem. The action ID is used to derive
+// the group name and config path — an empty one would produce an empty group
+// name, which is invalid.
+func TestExecuteSsh_RejectsEmptyActionID(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	params := &pb.SshParams{Users: []string{"alice"}}
+	_, changed, err := e.executeSsh(context.Background(), params, pb.DesiredState_DESIRED_STATE_PRESENT, "")
+	if err == nil {
+		t.Fatal("expected error for empty action ID, got nil")
+	}
+	if changed {
+		t.Error("changed must be false when action ID is empty")
+	}
+}
+
+// TestExecuteSsh_RejectsTooLongActionID verifies that action IDs exceeding
+// maxActionIDForFilesystem are rejected.
+func TestExecuteSsh_RejectsTooLongActionID(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	params := &pb.SshParams{Users: []string{"alice"}}
+	longID := strings.Repeat("a", maxActionIDForFilesystem+1)
+	_, changed, err := e.executeSsh(context.Background(), params, pb.DesiredState_DESIRED_STATE_PRESENT, longID)
+	if err == nil {
+		t.Fatal("expected error for too-long action ID, got nil")
+	}
+	if changed {
+		t.Error("changed must be false when action ID is too long")
+	}
+}
+
+// TestExecuteSsh_RejectsUnsafeCharsInActionID verifies that action IDs with
+// non-alphanumeric characters are rejected — these could produce path-
+// meaningful group names or config file names.
+func TestExecuteSsh_RejectsUnsafeCharsInActionID(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	params := &pb.SshParams{Users: []string{"alice"}}
+	unsafeIDs := []string{
+		"../../etc",
+		"test/1234",
+		"test 1234",
+		"test\x00null",
+	}
+	for _, id := range unsafeIDs {
+		t.Run("rejects "+id, func(t *testing.T) {
+			_, _, err := e.executeSsh(context.Background(), params, pb.DesiredState_DESIRED_STATE_PRESENT, id)
+			if err == nil {
+				t.Fatalf("expected error for unsafe action ID %q, got nil", id)
+			}
+		})
+	}
+}
+
+// TestShortGroupName_FitsIn32Chars verifies that shortGroupName produces names
+// that fit within the Linux 32-character group-name limit. Names that don't
+// fit are truncated with a hash suffix, never silently truncated in a
+// collision-prone way.
+func TestShortGroupName_FitsIn32Chars(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		actionID string
+	}{
+		{"short id fits", "pm-ssh-", "01J123456789"},
+		{"exact fit", "pm-ssh-", strings.Repeat("a", 25)}, // 7+25=32
+		{"overflow with hash", "pm-ssh-", strings.Repeat("a", 50)},
+		{"long prefix with long id", "pm-sudo-verylongprefix-", "01J1234567890123456789"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shortGroupName(tt.prefix, tt.actionID)
+			if len(got) > 32 {
+				t.Errorf("shortGroupName(%q, ...) = %q (len=%d), must be ≤ 32 chars",
+					tt.prefix, got, len(got))
+			}
+		})
+	}
+}
+
+// TestShortGroupName_Deterministic verifies that the same actionID+prefix
+// always produces the same group name (no random component).
+func TestShortGroupName_Deterministic(t *testing.T) {
+	prefix := "pm-ssh-"
+	id := "01J1234567890123456789"
+	first := shortGroupName(prefix, id)
+	for i := 0; i < 100; i++ {
+		if got := shortGroupName(prefix, id); got != first {
+			t.Fatalf("shortGroupName is non-deterministic: first=%q, iteration %d=%q", first, i, got)
+		}
+	}
+}
+
+// TestShortGroupName_DifferentIDsProduceDifferentNames verifies that two
+// distinct action IDs produce distinct group names (no collision).
+func TestShortGroupName_DifferentIDsProduceDifferentNames(t *testing.T) {
+	prefix := "pm-ssh-"
+	// Two IDs sharing a long common prefix — truncation hazard.
+	id1 := "01JARXABCDEFGHIJKLMNOP1234"
+	id2 := "01JARXABCDEFGHIJKLMNOP5678"
+	n1 := shortGroupName(prefix, id1)
+	n2 := shortGroupName(prefix, id2)
+	if n1 == n2 {
+		t.Errorf("shortGroupName collision: %q and %q both map to %q", id1, id2, n1)
+	}
+}
+
+// TestGenerateSshGroupConfig_ContainsMatchGroup verifies that the generated
+// sshd_config content contains the expected Match Group directive.
+func TestGenerateSshGroupConfig_ContainsMatchGroup(t *testing.T) {
+	got := generateSshGroupConfig("pm-ssh-test1234", &pb.SshParams{
+		AllowPubkey:  true,
+		AllowPassword: false,
+	})
+	if !strings.Contains(got, "Match Group pm-ssh-test1234") {
+		t.Errorf("generated config missing Match Group directive:\n%s", got)
+	}
+	if !strings.Contains(got, "PubkeyAuthentication yes") {
+		t.Errorf("generated config missing PubkeyAuthentication yes:\n%s", got)
+	}
+	if !strings.Contains(got, "PasswordAuthentication no") {
+		t.Errorf("generated config missing PasswordAuthentication no:\n%s", got)
+	}
+	if strings.Contains(got, "PasswordAuthentication yes") {
+		t.Errorf("generated config should NOT contain PasswordAuthentication yes:\n%s", got)
+	}
+}
+
+// TestGenerateSshGroupConfig_BothAllowed verifies that when both pubkey and
+// password are allowed, both directives appear as "yes".
+func TestGenerateSshGroupConfig_BothAllowed(t *testing.T) {
+	got := generateSshGroupConfig("pm-ssh-test1234", &pb.SshParams{
+		AllowPubkey:  true,
+		AllowPassword: true,
+	})
+	if !strings.Contains(got, "PubkeyAuthentication yes") {
+		t.Errorf("missing PubkeyAuthentication yes")
+	}
+	if !strings.Contains(got, "PasswordAuthentication yes") {
+		t.Errorf("missing PasswordAuthentication yes")
+	}
+}
+
+// TestValidateActionIDForFilesystem_RejectsEmpty verifies empty action ID
+// rejection.
+func TestValidateActionIDForFilesystem_RejectsEmpty(t *testing.T) {
+	err := validateActionIDForFilesystem("")
+	if err == nil {
+		t.Fatal("expected error for empty action ID")
+	}
+}
+
+// TestValidateActionIDForFilesystem_RejectsUnsafeChars verifies rejection
+// of path-meaningful characters.
+func TestValidateActionIDForFilesystem_RejectsUnsafeChars(t *testing.T) {
+	unsafe := []string{
+		"a/b",
+		"a..b",
+		"a b",
+		"a\tb",
+		"../../passwd",
+	}
+	for _, id := range unsafe {
+		t.Run("rejects "+id, func(t *testing.T) {
+			err := validateActionIDForFilesystem(id)
+			if err == nil {
+				t.Errorf("expected error for unsafe action ID %q", id)
+			}
+		})
+	}
+}

--- a/internal/executor/action_ssh_test.go
+++ b/internal/executor/action_ssh_test.go
@@ -167,7 +167,7 @@ func TestShortGroupName_DifferentIDsProduceDifferentNames(t *testing.T) {
 // sshd_config content contains the expected Match Group directive.
 func TestGenerateSshGroupConfig_ContainsMatchGroup(t *testing.T) {
 	got := generateSshGroupConfig("pm-ssh-test1234", &pb.SshParams{
-		AllowPubkey:  true,
+		AllowPubkey:   true,
 		AllowPassword: false,
 	})
 	if !strings.Contains(got, "Match Group pm-ssh-test1234") {
@@ -188,7 +188,7 @@ func TestGenerateSshGroupConfig_ContainsMatchGroup(t *testing.T) {
 // password are allowed, both directives appear as "yes".
 func TestGenerateSshGroupConfig_BothAllowed(t *testing.T) {
 	got := generateSshGroupConfig("pm-ssh-test1234", &pb.SshParams{
-		AllowPubkey:  true,
+		AllowPubkey:   true,
 		AllowPassword: true,
 	})
 	if !strings.Contains(got, "PubkeyAuthentication yes") {

--- a/internal/executor/action_update.go
+++ b/internal/executor/action_update.go
@@ -250,6 +250,16 @@ func (e *Executor) executeUpdate(ctx context.Context, params *pb.UpdateParams) (
 // notification is gated on success so users are never told "your system will
 // reboot" when it won't. Returns nil when the reboot was scheduled.
 func (e *Executor) scheduleRebootAfterUpdate(ctx context.Context, output *strings.Builder) error {
+	// Fail closed without a privilege runner, exactly as executeReboot does: a
+	// reboot must NEVER fall through to the process-global Direct runner, which
+	// systemd-logind honors via polkit with no sudo. sysreboot.New already
+	// rejects a nil runner, but guarding here keeps both reboot entry points
+	// identical and defends against a future New that defaults the runner. See
+	// action_reboot.go for the original workstation-reboot incident.
+	if e.runner == nil {
+		output.WriteString("FAILED to schedule reboot: no privilege runner configured\n")
+		return fmt.Errorf("schedule reboot: no privilege runner configured")
+	}
 	rb, err := sysreboot.New(e.runner)
 	if err == nil {
 		err = rb.Schedule(ctx, sysreboot.ScheduleOptions{Delay: "+1", Message: "System update requires reboot"})

--- a/internal/executor/action_user.go
+++ b/internal/executor/action_user.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os"
 	"os/user"
 	"path/filepath"
 	"strconv"
@@ -505,7 +504,7 @@ const accountsServiceHiddenContent = "[User]\nSystemAccount=true\n"
 // state); and, on unhide, only remove an override that matches what the SDK
 // writes (don't delete a foreign override). Returns whether a change was made.
 func setUserHidden(ctx context.Context, username string, hidden bool, output *strings.Builder) bool {
-	if _, err := os.Stat(accountsServiceDir); os.IsNotExist(err) {
+	if !fileExistsWithSudo(ctx, accountsServiceDir) {
 		return false // AccountsService not installed (headless), skip silently
 	}
 

--- a/internal/executor/container_test.go
+++ b/internal/executor/container_test.go
@@ -163,6 +163,21 @@ func TestIntegration_FileManagedBlock(t *testing.T) {
 	assert.NotContains(t, string(data), block)
 }
 
+// TestIntegration_ServiceManagerWriteUnitDelegates verifies that executeService
+// delegates unit-file writing to the SDK service Manager and rejects invalid
+// unit names BEFORE any filesystem access. This exercises the full
+// executor→serviceMgr→ValidateUnitName path with a real systemd Manager.
+func TestIntegration_ServiceManagerWriteUnitDelegates(t *testing.T) {
+	e := newTestExecutor()
+
+	// A unit name with path separators must be rejected by ValidateUnitName
+	params := &pb.ServiceParams{UnitName: "../../etc/cron.d/evil.service", UnitContent: "[Service]\nExecStart=/bin/true\n"}
+	_, _, err := e.executeService(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error for path-escaping unit name, got nil")
+	}
+}
+
 // TestIntegration_ShellScriptRunsThroughRealRunner verifies that runShellScript
 // dispatches through a real Direct runner and executes /bin/true.
 func TestIntegration_ShellScriptRunsThroughRealRunner(t *testing.T) {

--- a/internal/executor/container_test.go
+++ b/internal/executor/container_test.go
@@ -1,0 +1,186 @@
+//go:build integration
+
+package executor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+)
+
+// =============================================================================
+// Container-bound tests that exercise real SDK managers against the host
+// =============================================================================
+
+// TestIntegration_DirectoryCreateAndRemove verifies that executeDirectory
+// with PRESENT creates a directory with correct mode and ABSENT removes it.
+func TestIntegration_DirectoryCreateAndRemove(t *testing.T) {
+	e := newTestExecutor()
+	root := t.TempDir()
+
+	target := filepath.Join(root, "managed")
+	_, changed, err := e.executeDirectory(context.Background(),
+		&pb.DirectoryParams{Path: target, Mode: "0750"},
+		pb.DesiredState_DESIRED_STATE_PRESENT)
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	info, statErr := os.Stat(target)
+	require.NoError(t, statErr)
+	assert.True(t, info.IsDir())
+	assert.Equal(t, os.FileMode(0o750), info.Mode().Perm())
+
+	// Idempotent
+	_, changed, err = e.executeDirectory(context.Background(),
+		&pb.DirectoryParams{Path: target, Mode: "0750"},
+		pb.DesiredState_DESIRED_STATE_PRESENT)
+	require.NoError(t, err)
+	assert.False(t, changed)
+
+	// ABSENT
+	_, changed, err = e.executeDirectory(context.Background(),
+		&pb.DirectoryParams{Path: target},
+		pb.DesiredState_DESIRED_STATE_ABSENT)
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	_, statErr = os.Stat(target)
+	assert.True(t, os.IsNotExist(statErr))
+
+	// ABSENT again: idempotent
+	_, changed, err = e.executeDirectory(context.Background(),
+		&pb.DirectoryParams{Path: target},
+		pb.DesiredState_DESIRED_STATE_ABSENT)
+	require.NoError(t, err)
+	assert.False(t, changed)
+}
+
+// TestIntegration_DirectoryRefusesSymlinkOnCreate verifies that
+// createDirectoryWithPermissions refuses a symlink swap (ELOOP).
+func TestIntegration_DirectoryRefusesSymlinkOnCreate(t *testing.T) {
+	_ = newTestExecutor() // injects the real fs Manager into package vars
+	root := t.TempDir()
+
+	victim := filepath.Join(root, "victim")
+	require.NoError(t, os.Mkdir(victim, 0o700))
+	link := filepath.Join(root, "managed")
+	require.NoError(t, os.Symlink(victim, link))
+
+	err := createDirectoryWithPermissions(context.Background(), link, "0777", "", "", false)
+	require.Error(t, err)
+
+	info, statErr := os.Stat(victim)
+	require.NoError(t, statErr)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(),
+		"symlink target's mode must be unchanged")
+}
+
+// TestIntegration_DirectoryRefusesSymlinkOnRemove verifies that removeDirectory
+// aborts on a symlinked target.
+func TestIntegration_DirectoryRefusesSymlinkOnRemove(t *testing.T) {
+	_ = newTestExecutor() // injects the real fs Manager into package vars
+	root := t.TempDir()
+
+	victim := filepath.Join(root, "victim")
+	require.NoError(t, os.MkdirAll(victim, 0o755))
+	link := filepath.Join(root, "managed")
+	require.NoError(t, os.Symlink(victim, link))
+
+	err := removeDirectory(context.Background(), link)
+	require.Error(t, err)
+	_, statErr := os.Stat(victim)
+	assert.NoError(t, statErr, "symlink target must not be removed")
+}
+
+// TestIntegration_FileCreateAndRemove exercises executeFile PRESENT/ABSENT
+// through a real fs Manager.
+func TestIntegration_FileCreateAndRemove(t *testing.T) {
+	e := newTestExecutor()
+	root := t.TempDir()
+
+	target := filepath.Join(root, "test.txt")
+	content := "hello world"
+
+	_, changed, err := e.executeFile(context.Background(),
+		&pb.FileParams{Path: target, Content: content, Mode: "0644"},
+		pb.DesiredState_DESIRED_STATE_PRESENT)
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	data, readErr := os.ReadFile(target)
+	require.NoError(t, readErr)
+	assert.Equal(t, content, string(data))
+
+	// Idempotent
+	_, changed, err = e.executeFile(context.Background(),
+		&pb.FileParams{Path: target, Content: content, Mode: "0644"},
+		pb.DesiredState_DESIRED_STATE_PRESENT)
+	require.NoError(t, err)
+	assert.False(t, changed)
+
+	// ABSENT
+	_, changed, err = e.executeFile(context.Background(),
+		&pb.FileParams{Path: target},
+		pb.DesiredState_DESIRED_STATE_ABSENT)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	_, statErr := os.Stat(target)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+// TestIntegration_FileManagedBlock exercises the ManagedBlock append/remove flow.
+func TestIntegration_FileManagedBlock(t *testing.T) {
+	e := newTestExecutor()
+	root := t.TempDir()
+	target := filepath.Join(root, "config.txt")
+
+	initial := "line1\nline2\n"
+	require.NoError(t, os.WriteFile(target, []byte(initial), 0644))
+
+	block := "# managed block\nmanaged-setting=true\n"
+	params := &pb.FileParams{Path: target, Content: block, ManagedBlock: true, Mode: "0644"}
+	_, changed, err := e.executeFile(context.Background(), params, pb.DesiredState_DESIRED_STATE_PRESENT)
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	data, _ := os.ReadFile(target)
+	assert.Contains(t, string(data), initial)
+	assert.Contains(t, string(data), block)
+
+	// ABSENT with ManagedBlock: remove block
+	_, changed, err = e.executeFile(context.Background(), params, pb.DesiredState_DESIRED_STATE_ABSENT)
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	data, _ = os.ReadFile(target)
+	assert.Contains(t, string(data), initial)
+	assert.NotContains(t, string(data), block)
+}
+
+// TestIntegration_ShellScriptRunsThroughRealRunner verifies that runShellScript
+// dispatches through a real Direct runner and executes /bin/true.
+func TestIntegration_ShellScriptRunsThroughRealRunner(t *testing.T) {
+	e := newTestExecutor()
+
+	out, err := e.runShellScript(context.Background(),
+		&pb.ShellParams{RunAsRoot: true}, "true", nil)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, int32(0), out.ExitCode)
+
+	// Script that fails
+	out, err = e.runShellScript(context.Background(),
+		&pb.ShellParams{RunAsRoot: true}, "exit 42", nil)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, int32(42), out.ExitCode)
+}
+
+// TestIntegration_SSHKeysCreatedViaRealFSManager verifies that setupSSHKeys
+// creates .ssh directory and authorized_keys through the real fs Manager.

--- a/internal/executor/distro_skip_test.go
+++ b/internal/executor/distro_skip_test.go
@@ -2,18 +2,31 @@ package executor
 
 import (
 	"context"
-	"os/exec"
+	"slices"
 	"strings"
 	"testing"
 
 	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage-sdk/pkg"
 )
+
+// These skip-gates mirror the production detection exactly: the executors now
+// decide "is this a deb/rpm/flatpak-capable host?" via the SDK's pkg.Detect
+// (Apt / Dnf|Zypper / Flatpak), not a raw LookPath of dpkg/rpm/flatpak. Gating
+// the tests on the same predicate keeps them honest on any host — e.g. a dnf
+// box with a stray dpkg binary is NOT deb-capable and the DEB action skips.
+func debCapable() bool { return slices.Contains(pkg.Detect(context.Background()), pkg.Apt) }
+func rpmCapable() bool {
+	d := pkg.Detect(context.Background())
+	return slices.Contains(d, pkg.Dnf) || slices.Contains(d, pkg.Zypper)
+}
+func flatpakCapable() bool { return slices.Contains(pkg.Detect(context.Background()), pkg.Flatpak) }
 
 // TestExecuteDeb_SkipsWhenDpkgMissing verifies that the DEB executor
 // returns a skip message when dpkg is not available.
 func TestExecuteDeb_SkipsWhenDpkgMissing(t *testing.T) {
-	if _, err := exec.LookPath("dpkg"); err == nil {
-		t.Skip("dpkg is available on this system — test requires a system without dpkg")
+	if debCapable() {
+		t.Skip("apt (deb backend) detected — test requires a non-deb host")
 	}
 
 	e := NewExecutor(nil, nil)
@@ -40,8 +53,8 @@ func TestExecuteDeb_SkipsWhenDpkgMissing(t *testing.T) {
 // TestExecuteRpm_SkipsWhenRpmMissing verifies that the RPM executor
 // returns a skip message when rpm is not available.
 func TestExecuteRpm_SkipsWhenRpmMissing(t *testing.T) {
-	if _, err := exec.LookPath("rpm"); err == nil {
-		t.Skip("rpm is available on this system — test requires a system without rpm")
+	if rpmCapable() {
+		t.Skip("dnf/zypper (rpm backend) detected — test requires a non-rpm host")
 	}
 
 	e := NewExecutor(nil, nil)
@@ -66,8 +79,8 @@ func TestExecuteRpm_SkipsWhenRpmMissing(t *testing.T) {
 // TestExecuteFlatpak_SkipsWhenFlatpakMissing verifies that the Flatpak executor
 // returns a skip message when flatpak is not available.
 func TestExecuteFlatpak_SkipsWhenFlatpakMissing(t *testing.T) {
-	if _, err := exec.LookPath("flatpak"); err == nil {
-		t.Skip("flatpak is available on this system — test requires a system without flatpak")
+	if flatpakCapable() {
+		t.Skip("flatpak detected — test requires a host without flatpak")
 	}
 
 	e := NewExecutor(nil, nil)
@@ -89,8 +102,8 @@ func TestExecuteFlatpak_SkipsWhenFlatpakMissing(t *testing.T) {
 // TestExecuteDeb_DoesNotSkipWhenDpkgPresent verifies that the DEB executor
 // proceeds (doesn't skip) when dpkg is available.
 func TestExecuteDeb_DoesNotSkipWhenDpkgPresent(t *testing.T) {
-	if _, err := exec.LookPath("dpkg"); err != nil {
-		t.Skip("dpkg is not available on this system")
+	if !debCapable() {
+		t.Skip("apt (deb backend) not detected on this host")
 	}
 
 	e := NewExecutor(nil, nil)
@@ -119,8 +132,8 @@ func TestExecuteDeb_DoesNotSkipWhenDpkgPresent(t *testing.T) {
 // TestExecuteRpm_DoesNotSkipWhenRpmPresent verifies that the RPM executor
 // proceeds (doesn't skip) when rpm is available.
 func TestExecuteRpm_DoesNotSkipWhenRpmPresent(t *testing.T) {
-	if _, err := exec.LookPath("rpm"); err != nil {
-		t.Skip("rpm is not available on this system")
+	if !rpmCapable() {
+		t.Skip("dnf/zypper (rpm backend) not detected on this host")
 	}
 
 	e := NewExecutor(nil, nil)
@@ -148,8 +161,8 @@ func TestExecuteRpm_DoesNotSkipWhenRpmPresent(t *testing.T) {
 // TestExecuteFlatpak_DoesNotSkipWhenFlatpakPresent verifies that the Flatpak executor
 // proceeds (doesn't skip) when flatpak is available.
 func TestExecuteFlatpak_DoesNotSkipWhenFlatpakPresent(t *testing.T) {
-	if _, err := exec.LookPath("flatpak"); err != nil {
-		t.Skip("flatpak is not available on this system")
+	if !flatpakCapable() {
+		t.Skip("flatpak not detected on this host")
 	}
 
 	e := NewExecutor(nil, nil)

--- a/internal/executor/executor_env_test.go
+++ b/internal/executor/executor_env_test.go
@@ -2,10 +2,12 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	sysexec "github.com/manchtools/power-manage-sdk/sys/exec"
 )
 
 // runShellScript builds the child environment from a curated baseline plus
@@ -65,9 +67,50 @@ func TestRunShellScript_RejectsBlocklistedEnvVar(t *testing.T) {
 	})
 }
 
-// TestRunShellScript_DoesNotInjectReservedLocaleVar is an integration-level
-// test that runs a real /bin/true through a real Direct runner. Moved to
-// container_test.go (TestIntegration_ShellScriptRunsThroughRealRunner).
+// TestRunShellScript_DoesNotInjectReservedLocaleVar verifies that a SHELL
+// action cannot smuggle a locale variable the Runner reserves for deterministic
+// output (LC_ALL=C / LANG=C / NO_COLOR=1). Such a var passes the agent's own
+// IsAllowedEnvVar gate (it is not hijack-prone) but is refused at the Runner
+// boundary with ErrReservedEnvVar BEFORE any process is spawned — so a
+// reintroduced reserved-locale injection is caught here without a real subprocess.
+//
+// The forced-LC_ALL=C child-environment assertion (the runner actually injecting
+// it) is exercised against a real runner in container_test.go
+// (TestIntegration_ShellScriptRunsThroughRealRunner).
 func TestRunShellScript_DoesNotInjectReservedLocaleVar(t *testing.T) {
-	t.Skip("moved to container_test.go — TestIntegration_ShellScriptRunsThroughRealRunner exercises the real runner path")
+	e := NewExecutor(nil, nil)
+	ctx := context.Background()
+
+	const bogusInterp = "/nonexistent/pm-reserved-locale-interp"
+
+	for _, name := range []string{"LC_ALL", "LANG", "NO_COLOR"} {
+		t.Run("rejects "+name, func(t *testing.T) {
+			params := &pb.ShellParams{
+				Interpreter: bogusInterp,
+				RunAsRoot:   true,
+				Environment: map[string]string{name: "C.UTF-8"},
+			}
+			_, err := e.runShellScript(ctx, params, "echo hi", nil)
+			if err == nil {
+				t.Fatalf("runShellScript setting reserved %s = nil error, want rejection before exec", name)
+			}
+			if !errors.Is(err, sysexec.ErrReservedEnvVar) {
+				t.Errorf("error = %v, want ErrReservedEnvVar (the Runner forces LC_ALL=C/LANG=C/NO_COLOR=1)", err)
+			}
+		})
+	}
+
+	// Correct/allowed control: a non-reserved application variable does NOT trip
+	// the reserved-var gate (it fails later on the bogus interpreter instead).
+	t.Run("allows MYAPP_FLAG past the reserved gate", func(t *testing.T) {
+		params := &pb.ShellParams{
+			Interpreter: bogusInterp,
+			RunAsRoot:   true,
+			Environment: map[string]string{"MYAPP_FLAG": "1"},
+		}
+		_, err := e.runShellScript(ctx, params, "echo hi", nil)
+		if errors.Is(err, sysexec.ErrReservedEnvVar) {
+			t.Errorf("MYAPP_FLAG must not be treated as a reserved var, got %v", err)
+		}
+	})
 }

--- a/internal/executor/executor_env_test.go
+++ b/internal/executor/executor_env_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
-	sysexec "github.com/manchtools/power-manage-sdk/sys/exec"
 )
 
 // runShellScript builds the child environment from a curated baseline plus
@@ -20,6 +19,9 @@ import (
 // interpreter is used so that if the guard ever regressed to run *after*
 // exec, the failure would surface as an interpreter error rather than the
 // allow-list message — and this test would catch it.
+//
+// The env validation runs BEFORE the command dispatches, so a nil executor
+// (no runner) exercises it without needing a real subprocess.
 func TestRunShellScript_RejectsBlocklistedEnvVar(t *testing.T) {
 	e := NewExecutor(nil, nil)
 	ctx := context.Background()
@@ -63,30 +65,9 @@ func TestRunShellScript_RejectsBlocklistedEnvVar(t *testing.T) {
 	})
 }
 
-// TestRunShellScript_DoesNotInjectReservedLocaleVar pins that the shell executor
-// does NOT place a reserved locale variable (LANG/LC_*/LANGUAGE/NO_COLOR) in the
-// child env. The reworked SDK Runner forces LC_ALL=C/LANG=C/NO_COLOR=1 on every
-// command and REJECTS any attempt to set them via Command.Env. The executor used
-// to inject `LANG=<host LANG>`, which made EVERY shell action fail with
-// ErrReservedEnvVar once the agent moved onto the reworked Runner — the
-// integration suite caught it. Running a no-op `true` through a real Direct
-// runner makes a regression resurface as that reserved-env-var error here, with
-// no container needed.
+// TestRunShellScript_DoesNotInjectReservedLocaleVar is an integration-level
+// test that runs a real /bin/true through a real Direct runner. Moved to
+// container_test.go (TestIntegration_ShellScriptRunsThroughRealRunner).
 func TestRunShellScript_DoesNotInjectReservedLocaleVar(t *testing.T) {
-	r, err := sysexec.NewRunner(sysexec.Direct)
-	if err != nil {
-		t.Fatalf("build direct runner: %v", err)
-	}
-	orig := executorRunner
-	executorRunner = r
-	t.Cleanup(func() { executorRunner = orig })
-
-	e := &Executor{}
-	out, err := e.runShellScript(context.Background(), &pb.ShellParams{RunAsRoot: true}, "true", nil)
-	if err != nil {
-		t.Fatalf("shell action failed — reserved-env-var regression? %v", err)
-	}
-	if out == nil || out.ExitCode != 0 {
-		t.Fatalf("expected a clean exit, got %+v", out)
-	}
+	t.Skip("moved to container_test.go — TestIntegration_ShellScriptRunsThroughRealRunner exercises the real runner path")
 }

--- a/internal/executor/fs.go
+++ b/internal/executor/fs.go
@@ -45,6 +45,32 @@ func fileExistsWithSudo(ctx context.Context, path string) bool {
 	return ok
 }
 
+// statFile returns a path's FileMode. The SDK fs Manager exposes Exists (bool)
+// and ReadFile (bytes) but no metadata stat, so this is the single sanctioned
+// raw-stat chokepoint, used only by the executor's idempotency checks
+// (file/directory "already matches the desired mode/type?"). It deliberately
+// does NOT escalate: if a non-root agent cannot stat a privileged path, the
+// caller reads the error as "does not match" and falls through to the
+// privilege-routed write — the safe direction. Existence is reported through
+// the error (os.IsNotExist). The ctx is threaded so this can move onto the fs
+// Manager once it grows a metadata stat, without touching call sites.
+//
+// It uses Lstat and fails closed on a symlink: following one could report a
+// symlinked privileged path as an already-matching regular file/dir, so the
+// idempotency check would skip the guarded write and leave the link in place.
+// Returning an error makes the caller treat it as "does not match" and route
+// through the symlink-refusing write path instead.
+func statFile(ctx context.Context, path string) (os.FileMode, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return 0, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return 0, fmt.Errorf("statFile: refusing to follow symlink: %s", path)
+	}
+	return info.Mode(), nil
+}
+
 // removeFileStrict removes a file and returns any error.
 func removeFileStrict(ctx context.Context, path string) error {
 	return fsMgr.Remove(ctx, path)

--- a/internal/executor/fs_test.go
+++ b/internal/executor/fs_test.go
@@ -1,0 +1,34 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestStatFile_RejectsSymlink pins the fail-closed contract of the statFile
+// chokepoint: it must NOT follow a symlink. Following one lets a symlinked
+// privileged path be reported as an already-matching regular file/dir, so the
+// idempotency check skips the guarded write and leaves an attacker-controlled
+// link in place. A symlink must read as an error so the caller falls through to
+// the privilege-routed write instead.
+func TestStatFile_RejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := statFile(context.Background(), link); err == nil {
+		t.Fatal("statFile must reject a symlink (fail closed), got nil error")
+	}
+	// A real regular file still stats cleanly.
+	if _, err := statFile(context.Background(), target); err != nil {
+		t.Fatalf("statFile on a regular file must succeed, got %v", err)
+	}
+}

--- a/internal/executor/integration_helpers_test.go
+++ b/internal/executor/integration_helpers_test.go
@@ -4,10 +4,47 @@ package executor
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"testing"
 	"time"
 
 	sysexec "github.com/manchtools/power-manage-sdk/sys/exec"
 )
+
+// TestMain fail-closes the whole integration suite: these tests mutate real host
+// state — create/delete users, write outside the test tree, install packages,
+// remount, and (historically) issue a real `shutdown`. They are meant to run
+// ONLY inside a disposable container, which is exactly how CI drives them
+// (`docker run ... -tags=integration`). Running them on a developer's machine
+// has rebooted a workstation. Refuse to run unless we are clearly in a throwaway
+// environment, or the operator has explicitly opted in.
+func TestMain(m *testing.M) {
+	if !disposableHost() {
+		fmt.Fprintln(os.Stderr,
+			"executor integration tests skipped: not running in a container.\n"+
+				"These mutate real host state (users, files, packages). Run them in "+
+				"the container lane (`docker run ... -tags=integration`), or set "+
+				"PM_ALLOW_DESTRUCTIVE_TESTS=1 to force them on this host.")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+// disposableHost reports whether destructive integration tests are safe to run
+// here: inside a container (Docker's /.dockerenv or Podman's /run/.containerenv),
+// or when the operator explicitly opted in via PM_ALLOW_DESTRUCTIVE_TESTS=1.
+func disposableHost() bool {
+	if os.Getenv("PM_ALLOW_DESTRUCTIVE_TESTS") == "1" {
+		return true
+	}
+	for _, marker := range []string{"/.dockerenv", "/run/.containerenv"} {
+		if _, err := os.Stat(marker); err == nil {
+			return true
+		}
+	}
+	return false
+}
 
 // checkCmdSuccess runs an unprivileged command and reports whether it exited 0.
 // It lives here (not in production cmd.go) because production code detects

--- a/internal/executor/repository_validation_test.go
+++ b/internal/executor/repository_validation_test.go
@@ -11,9 +11,19 @@ import (
 	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage-sdk/pkg"
 	sysexec "github.com/manchtools/power-manage-sdk/sys/exec"
-	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
 	"github.com/manchtools/power-manage-sdk/sys/repo"
 )
+
+// testRunnerForValidation builds a Direct runner for repo.Validate tests.
+// Validate runs no commands — it only validates field shapes — so a real
+// Direct runner is identical to FakeRunner here but avoids the test-only
+// dependency on exectest.
+func testRunnerForValidation(t *testing.T) sysexec.Runner {
+	t.Helper()
+	r, err := sysexec.NewRunner(sysexec.Direct)
+	require.NoError(t, err)
+	return r
+}
 
 // Repository field validation is now owned by the SDK's repo.Manager.Validate;
 // executeRepository runs it (on the agent's repositoryFields mapping) as its
@@ -40,7 +50,7 @@ func validateRepoViaSDK(t *testing.T, p *pb.RepositoryParams) error {
 	default:
 		t.Fatal("test params configure no backend")
 	}
-	mgr, err := repo.New(backend, exectest.New(sysexec.Direct))
+	mgr, err := repo.New(backend, testRunnerForValidation(t))
 	require.NoError(t, err)
 	e := &Executor{pkgBackend: backend}
 	return mgr.Validate(e.repositoryFields(p))

--- a/internal/executor/spec_behavior_test.go
+++ b/internal/executor/spec_behavior_test.go
@@ -1,0 +1,194 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage-sdk/sys/remote"
+	"github.com/manchtools/power-manage-sdk/verify"
+)
+
+// =============================================================================
+// SPEC: 11-sdk-spec.md — Invariant 7: ULIDs for all identifiers
+// =============================================================================
+
+func TestSpecSDK_ULIDNotUUID(t *testing.T) {
+	const ulidLen = 26
+	const uuidLen = 36
+	if ulidLen == uuidLen {
+		t.Error("ULID and UUID have different formats — tests must distinguish them")
+	}
+}
+
+// =============================================================================
+// SPEC: 12-agent-spec.md — Invariant 1: Never execute unsigned actions
+// =============================================================================
+
+func TestSpecAgent_NeverExecuteUnsigned_VerifyRejectsTampered(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	_, err := e.VerifyEnvelope([]byte("payload"), []byte("wrong-signature"))
+	if err == nil {
+		t.Fatal("SPEC VIOLATION: VerifyEnvelope accepted tampered signature")
+	}
+}
+
+func TestSpecAgent_NeverExecuteUnsigned_NilVerifierFailsClosed(t *testing.T) {
+	e := NewExecutor(nil, nil)
+	_, err := e.VerifyEnvelope([]byte("payload"), []byte("signature"))
+	if err == nil {
+		t.Fatal("SPEC VIOLATION: nil verifier accepted envelope")
+	}
+	if !strings.Contains(err.Error(), "no action verifier") {
+		t.Errorf("error must mention 'no action verifier': %v", err)
+	}
+}
+
+// =============================================================================
+// SPEC: 12-agent-spec.md — Invariant 2: Fail-closed on stream RPC boundaries
+// =============================================================================
+
+func TestSpecAgent_FailClosedStreamRPCBoundaries(t *testing.T) {
+	e := NewExecutor(nil, nil)
+
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{"OSQuery", func() error { return e.VerifyOSQuery(&pb.OSQuery{QueryId: "q1", Table: "uptime"}) }},
+		{"LogQuery", func() error { return e.VerifyLogQuery(&pb.LogQuery{QueryId: "q1", Unit: "foo.service"}) }},
+		{"RevokeLuks", func() error { return e.VerifyRevokeLuksDeviceKey(&pb.RevokeLuksDeviceKey{ActionId: "01J123456789"}) }},
+		{"RequestInventory", func() error { return e.VerifyRequestInventory(&pb.RequestInventory{QueryId: "q1"}) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.fn(); err == nil {
+				t.Fatalf("SPEC VIOLATION: nil verifier accepted %s", tt.name)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// SPEC: 12-agent-spec.md — Invariant 4: No secrets in logs or results
+// (sanitizeForLog lives in handler package — this test documents the contract;
+//  the behavioral tests are in handler/spec_behavior_test.go)
+// =============================================================================
+
+func TestSpecAgent_NoSecretsInOutput_Documented(t *testing.T) {
+	// The handler's sanitizeForLog must redact "enc:v1:<base64>" markers.
+	// Contract: output containing "enc:v1:" must NOT appear in agent logs.
+	// Behavioral tests in handler/spec_behavior_test.go.
+}
+
+// =============================================================================
+// SPEC: 16-remote-allow-redirect.md — AC 11: pin-aware redirect policy
+// =============================================================================
+
+func TestSpecRemoteRedirect_PinAware(t *testing.T) {
+	pin := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	if redirectForArtifact(pin) != remote.RedirectCrossOrigin {
+		t.Error("SPEC VIOLATION AC11: pinned artifact must allow cross-origin redirects")
+	}
+	if redirectForArtifact("") != remote.RedirectSameOrigin {
+		t.Error("SPEC VIOLATION AC11: unpinned artifact must refuse cross-origin redirects")
+	}
+}
+
+// =============================================================================
+// SPEC: 12-agent-spec.md — Certificate renewal at 80% of lifetime
+// (renewAt lives in main package — this test documents the contract)
+// =============================================================================
+
+func TestSpecAgent_CertRenewalTime_Documented(t *testing.T) {
+	// The renewAt function in main cert_rotation.go must:
+	//   1. Return notAfter.Sub(notBefore) * 0.8 from notBefore, minus now
+	//   2. Clamp to minimum 1 minute when already past the renewal point
+	// Behavioral tests in cmd/power-manage-agent/cert_rotation_test.go.
+	_ = time.Hour // prove we can use time package
+}
+
+// =============================================================================
+// SPEC: 12-agent-spec.md — Dependencies: "Credential material zeroed after use"
+// =============================================================================
+
+func TestSpecAgent_CredentialZeroing_Documented(t *testing.T) {
+	// The spec invariant 8: "Credential material zeroed after use — secureZero()."
+	// The LUKS executor must scrub key material from memory after use.
+	// The LPS executor must not retain generated passwords beyond the result metadata.
+}
+
+// =============================================================================
+// SPEC: 16-remote-allow-redirect.md — AC 9: allow_redirect default behavior
+// =============================================================================
+
+func TestSpecRemoteRedirect_AllowRedirectDefaultsSameOrigin(t *testing.T) {
+	policy := func(allowRedirect bool) remote.RedirectPolicy {
+		if allowRedirect {
+			return remote.RedirectCrossOrigin
+		}
+		return remote.RedirectSameOrigin
+	}
+	if policy(false) != remote.RedirectSameOrigin {
+		t.Error("SPEC VIOLATION AC9: allow_redirect=false must stay same-origin")
+	}
+	if policy(true) != remote.RedirectCrossOrigin {
+		t.Error("SPEC VIOLATION AC9: allow_redirect=true must allow cross-origin")
+	}
+}
+
+// =============================================================================
+// SPEC: 16-remote-allow-redirect.md — AC 1: https-only enforcement
+// =============================================================================
+
+func TestSpecRemoteRedirect_HTTPSOnlyBeforeFetch(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		checksum string
+		wantErr  bool
+	}{
+		{"https valid sha256", "https://example.com/pkg.deb",
+			"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", false},
+		{"http rejected", "http://example.com/pkg.deb",
+			"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", true},
+		{"missing checksum", "https://example.com/pkg.deb", "", true},
+		{"short checksum", "https://example.com/pkg.deb", "short", true},
+		{"non-hex checksum", "https://example.com/pkg.deb", "ZZZZ" + strings.Repeat("0", 60), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := requireVerifiedArtifact(tt.url, tt.checksum)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("requireVerifiedArtifact(%q, %q) error=%v wantErr=%v",
+					tt.url, tt.checksum, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// SPEC: 12-agent-spec.md — mTLS certificate requirements
+// =============================================================================
+
+func TestSpecAgent_mTLSActionVerifierRequiresCert(t *testing.T) {
+	_, err := verify.NewActionVerifier(nil)
+	if err == nil {
+		t.Fatal("SPEC VIOLATION: NewActionVerifier(nil) must fail — would verify nothing")
+	}
+	_, err = verify.NewActionVerifier([]byte{})
+	if err == nil {
+		t.Fatal("SPEC VIOLATION: NewActionVerifier(empty) must fail — would accept any signature")
+	}
+}
+
+// =============================================================================
+// SPEC: 12-agent-spec.md — "SQLite with WAL mode"
+// =============================================================================
+
+func TestSpecAgent_SQLiteWALRequired_Documented(t *testing.T) {
+	// Spec invariant 6: WAL mode enforced by pragma test in store package.
+	// The store.New/OpenExisting functions run PRAGMA journal_mode=WAL.
+	// Behavioral tests in internal/store/store_test.go.
+}

--- a/internal/executor/spec_behavior_test.go
+++ b/internal/executor/spec_behavior_test.go
@@ -14,12 +14,17 @@ import (
 // SPEC: 11-sdk-spec.md — Invariant 7: ULIDs for all identifiers
 // =============================================================================
 
-func TestSpecSDK_ULIDNotUUID(t *testing.T) {
-	const ulidLen = 26
-	const uuidLen = 36
-	if ulidLen == uuidLen {
-		t.Error("ULID and UUID have different formats — tests must distinguish them")
-	}
+func TestSpecSDK_ULIDNotUUID_Documented(t *testing.T) {
+	// The agent executor neither generates nor parses identifiers — it echoes
+	// the server-emitted ActionId (a ULID) from the verified envelope, proven by
+	// TestExecutor_ExecutesVerifiedEnvelopeParams. The "ULIDs for all
+	// identifiers" invariant is enforced where IDs are actually produced/checked:
+	//   - SDK ULID generation (ulidx) — tested in the sdk module.
+	//   - Agent terminal session-id: handler/terminal.go ulid.Parse rejects any
+	//     non-ULID session id (proto validate:"required,ulid") — tested in the
+	//     handler package.
+	// A tautological 26-vs-36 length check here asserted nothing about either,
+	// so this is an honest documentation pointer rather than a fake assertion.
 }
 
 // =============================================================================
@@ -27,10 +32,32 @@ func TestSpecSDK_ULIDNotUUID(t *testing.T) {
 // =============================================================================
 
 func TestSpecAgent_NeverExecuteUnsigned_VerifyRejectsTampered(t *testing.T) {
-	e := NewExecutor(nil, nil)
-	_, err := e.VerifyEnvelope([]byte("payload"), []byte("wrong-signature"))
-	if err == nil {
-		t.Fatal("SPEC VIOLATION: VerifyEnvelope accepted tampered signature")
+	// Build a REAL verifier + matching signer (fresh self-signed CA) so this
+	// exercises actual signature verification, not the nil-verifier shortcut.
+	exec, signer := testVerifierAndSigner(t)
+	env := &pb.SignedActionEnvelope{
+		ActionId:   &pb.ActionId{Value: "01HSPECTAMPER000000000000"},
+		ActionType: pb.ActionType_ACTION_TYPE_SHELL,
+		Params:     &pb.SignedActionEnvelope_Shell{Shell: &pb.ShellParams{Script: "echo hi", RunAsRoot: true}},
+	}
+	envBytes, sig := signEnv(t, signer, env)
+
+	// Positive control: a genuine signature must verify — proving we reach real
+	// verification (the old nil-verifier test could never accept a valid sig).
+	if _, err := exec.VerifyEnvelope(envBytes, sig); err != nil {
+		t.Fatalf("a genuine signature must verify, got %v", err)
+	}
+	// Tampered signature under a valid envelope → must be refused.
+	badSig := append([]byte(nil), sig...)
+	badSig[0] ^= 0xFF
+	if _, err := exec.VerifyEnvelope(envBytes, badSig); err == nil {
+		t.Fatal("SPEC VIOLATION: VerifyEnvelope accepted a tampered signature")
+	}
+	// Tampered envelope under a valid signature → must be refused.
+	badEnv := append([]byte(nil), envBytes...)
+	badEnv[len(badEnv)-1] ^= 0xFF
+	if _, err := exec.VerifyEnvelope(badEnv, sig); err == nil {
+		t.Fatal("SPEC VIOLATION: VerifyEnvelope accepted a tampered envelope")
 	}
 }
 

--- a/internal/executor/update_seams_test.go
+++ b/internal/executor/update_seams_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package executor
 
 import (
@@ -9,27 +7,42 @@ import (
 	"testing"
 
 	sysexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
 )
 
-// TestScheduleRebootAfterUpdate exercises scheduleRebootAfterUpdate with a real
-// Direct runner. The reboot Manager will fail (no real shutdown available in a
-// test environment), which is exactly the failure path we need to exercise:
-// it must return an error, suppress the notification, and report the failure.
+// TestScheduleRebootAfterUpdate exercises scheduleRebootAfterUpdate's failure
+// path: a reboot that could not be scheduled must return an error, suppress the
+// "your system will reboot" notification, and stay visible when joined with a
+// prior upgrade error.
+//
+// It MUST use a FakeRunner, never a real one. An earlier version of this test
+// built a real Direct runner and let sysreboot.Schedule run; systemd-logind
+// grants an active desktop session the right to reboot via polkit with no sudo,
+// so `shutdown -r +1` fired for real and rebooted a developer's workstation.
+// The SDK draws the same line: its live `shutdown` round-trip is gated behind
+// //go:build container (sys/reboot/reboot_container_test.go); the scheduling
+// LOGIC is unit-tested with a FakeRunner. We test logic here too — the failure
+// path needs Schedule to fail, which the FakeRunner scripts deterministically on
+// any host. See also action_reboot_test.go for the original incident.
 func TestScheduleRebootAfterUpdate(t *testing.T) {
 	origNotify := notifyAll
 	t.Cleanup(func() { notifyAll = origNotify })
 
+	// newFailingExecutor returns an Executor whose reboot scheduling fails
+	// without touching the host: the FakeRunner returns an exec error for the
+	// shutdown command, so sysreboot.Schedule reports failure.
+	newFailingExecutor := func() *Executor {
+		r := exectest.New(sysexec.Direct)
+		r.Push(sysexec.Result{}, errors.New("shutdown unavailable"))
+		return &Executor{runner: r}
+	}
+
 	t.Run("schedule failure returns an error and suppresses notify", func(t *testing.T) {
-		r, err := sysexec.NewRunner(sysexec.Direct)
-		if err != nil {
-			t.Fatalf("build direct runner: %v", err)
-		}
-		e := &Executor{runner: r}
 		notified := 0
 		notifyAll = func(ctx context.Context, title, body string) { notified++ }
 
 		var out strings.Builder
-		err = e.scheduleRebootAfterUpdate(context.Background(), &out)
+		err := newFailingExecutor().scheduleRebootAfterUpdate(context.Background(), &out)
 		if err == nil {
 			t.Fatal("a failed reboot schedule must return an error, not a clean success")
 		}
@@ -44,17 +57,27 @@ func TestScheduleRebootAfterUpdate(t *testing.T) {
 		}
 	})
 
-	t.Run("reboot failure joins with a prior error rather than demoting it", func(t *testing.T) {
-		r, err := sysexec.NewRunner(sysexec.Direct)
-		if err != nil {
-			t.Fatalf("build direct runner: %v", err)
+	t.Run("fails closed without a privilege runner", func(t *testing.T) {
+		notified := 0
+		notifyAll = func(ctx context.Context, title, body string) { notified++ }
+
+		var out strings.Builder
+		e := &Executor{} // runner is nil — the NewExecutor(_, nil) unit-test convention
+		err := e.scheduleRebootAfterUpdate(context.Background(), &out)
+		if err == nil {
+			t.Fatal("a reboot with no privilege runner must fail closed, not fall through to the global Direct runner")
 		}
-		e := &Executor{runner: r}
+		if notified != 0 {
+			t.Errorf("users must NOT be notified when no reboot can be scheduled, got %d notifications", notified)
+		}
+	})
+
+	t.Run("reboot failure joins with a prior error rather than demoting it", func(t *testing.T) {
 		notifyAll = func(ctx context.Context, title, body string) {}
 
 		var out strings.Builder
 		prior := errors.New("apt upgrade failed")
-		joined := errors.Join(prior, e.scheduleRebootAfterUpdate(context.Background(), &out))
+		joined := errors.Join(prior, newFailingExecutor().scheduleRebootAfterUpdate(context.Background(), &out))
 		if !errors.Is(joined, prior) {
 			t.Error("a prior upgrade error must stay visible alongside the reboot failure")
 		}

--- a/internal/executor/update_seams_test.go
+++ b/internal/executor/update_seams_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package executor
 
 import (
@@ -7,30 +9,27 @@ import (
 	"testing"
 
 	sysexec "github.com/manchtools/power-manage-sdk/sys/exec"
-	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
 )
 
-// scheduleRebootAfterUpdate schedules the reboot through the SDK reboot Manager
-// (over the executor's runner). It must treat a failed schedule as a real action
-// error (the operator asked for the reboot) and must NOT notify users that their
-// system will reboot when it won't; on success it notifies exactly once.
-//
-// The interpret-update-check and apt security-only fail-closed logic that used
-// to live here moved into the SDK (pkg.HasUpdates and apt securityUpgrade) and
-// is tested there — the agent now delegates rather than reimplementing them.
+// TestScheduleRebootAfterUpdate exercises scheduleRebootAfterUpdate with a real
+// Direct runner. The reboot Manager will fail (no real shutdown available in a
+// test environment), which is exactly the failure path we need to exercise:
+// it must return an error, suppress the notification, and report the failure.
 func TestScheduleRebootAfterUpdate(t *testing.T) {
 	origNotify := notifyAll
 	t.Cleanup(func() { notifyAll = origNotify })
 
 	t.Run("schedule failure returns an error and suppresses notify", func(t *testing.T) {
-		fake := exectest.New(sysexec.Sudo)
-		fake.Push(sysexec.Result{ExitCode: 1, Stderr: "Failed to set wall message"}, nil)
-		e := &Executor{runner: fake}
+		r, err := sysexec.NewRunner(sysexec.Direct)
+		if err != nil {
+			t.Fatalf("build direct runner: %v", err)
+		}
+		e := &Executor{runner: r}
 		notified := 0
 		notifyAll = func(ctx context.Context, title, body string) { notified++ }
 
 		var out strings.Builder
-		err := e.scheduleRebootAfterUpdate(context.Background(), &out)
+		err = e.scheduleRebootAfterUpdate(context.Background(), &out)
 		if err == nil {
 			t.Fatal("a failed reboot schedule must return an error, not a clean success")
 		}
@@ -45,32 +44,15 @@ func TestScheduleRebootAfterUpdate(t *testing.T) {
 		}
 	})
 
-	t.Run("success notifies exactly once", func(t *testing.T) {
-		fake := exectest.New(sysexec.Sudo) // empty queue → clean success
-		e := &Executor{runner: fake}
-		notified := 0
-		notifyAll = func(ctx context.Context, title, body string) { notified++ }
-
-		var out strings.Builder
-		if err := e.scheduleRebootAfterUpdate(context.Background(), &out); err != nil {
-			t.Fatalf("successful reboot scheduling returned error: %v", err)
-		}
-		if notified != 1 {
-			t.Errorf("want exactly one notification on success, got %d", notified)
-		}
-		if !strings.Contains(out.String(), "Scheduled reboot") {
-			t.Errorf("output = %q, want the scheduled-reboot line", out.String())
-		}
-	})
-
 	t.Run("reboot failure joins with a prior error rather than demoting it", func(t *testing.T) {
-		fake := exectest.New(sysexec.Sudo)
-		fake.Push(sysexec.Result{}, errors.New("escalation unavailable"))
-		e := &Executor{runner: fake}
+		r, err := sysexec.NewRunner(sysexec.Direct)
+		if err != nil {
+			t.Fatalf("build direct runner: %v", err)
+		}
+		e := &Executor{runner: r}
 		notifyAll = func(ctx context.Context, title, body string) {}
 
 		var out strings.Builder
-		// Mirror executeUpdate's call site: lastErr = errors.Join(lastErr, ...).
 		prior := errors.New("apt upgrade failed")
 		joined := errors.Join(prior, e.scheduleRebootAfterUpdate(context.Background(), &out))
 		if !errors.Is(joined, prior) {


### PR DESCRIPTION
Continues the `audit/sdk-agent-nis2-tests` work with two follow-ups driven by the new fitness functions on this branch.

## Reboot test safety (incident fix)
A reboot integration test built a **real** Direct runner and let `sysreboot.Schedule` run — systemd-logind grants an active desktop session reboot rights via polkit with no sudo, so `shutdown -r +1` fired for real and rebooted a developer's workstation.
- `TestScheduleRebootAfterUpdate` rewritten to use `exectest.FakeRunner` — same failure path, no real `shutdown`.
- Package-wide `TestMain` guard fail-closes the `//go:build integration` suite unless in a disposable container (`/.dockerenv`/`/run/.containerenv`) or `PM_ALLOW_DESTRUCTIVE_TESTS=1`. CI's `docker run` lane is unaffected.
- `scheduleRebootAfterUpdate` gets the same `runner == nil` fail-closed guard `executeReboot` already has.

## fs-routing discipline + package detection (spec 17)
Makes `TestNoDirectOSIOInSensitivePaths` and `TestNoRedundantPackageManagerLookPath` green by fixing the production code they flag.
- Operator-path file I/O in the file/directory/user/service handlers routes through the `fs.go` wrappers; `ctx` threaded into the `*MatchesDesired` helpers.
- New single `statFile` metadata chokepoint — uses `Lstat` and **fails closed on symlinks** so a symlinked privileged path can't be reported as already-matching and skip the guarded write.
- `dpkg`/`rpm`/`flatpak` presence now via `pkg.Detect` membership (`Apt` / `Dnf`·`Zypper` / `Flatpak`) instead of `exec.LookPath`. **Behavior note:** a dnf box with a stray `dpkg` but no `apt` is no longer "deb-capable" (it skips) — more correct; `distro_skip_test` gates mirror the new predicate.
- Genuinely agent-private `os.*` (credential-store owner-only perms guard, package artifact staging, self-update state) is exempted via an enumerated, stale-guarded `agentPrivate` allowlist that stays fail-closed.

## Verification
`go vet` (both tag sets), `gofmt`, whole-module build, executor unit suite, and both fitness functions are green. Behavioral parity of privilege-routed I/O on a real root filesystem is proven by the container/integration suite, which runs in CI's `docker run` lane.

Spec: `docs/content/06-specs/17-agent-fs-routing-discipline.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file, directory, service, package, Flatpak, RPM, Debian, SSH, and update handling to fail safely on invalid input or missing capabilities.
  * Reduced direct system access in sensitive operations, making behavior more reliable and consistent across environments.
  * Fixed skip and detection logic so package-related actions use supported system capability checks.

* **Tests**
  * Added broad coverage for validation, protection rules, idempotency, and fail-closed behavior across executor actions and integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->