### PR TITLE
chore(deps): pin power-manage-sdk to the v0.5.3 release tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.11
 
 require (
 	connectrpc.com/connect v1.18.1
-	github.com/manchtools/power-manage-sdk v0.5.3-0.20260702060415-6943c8ab7f4f
+	github.com/manchtools/power-manage-sdk v0.5.3
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pressly/goose/v3 v3.26.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/manchtools/power-manage-sdk v0.5.3-0.20260628153931-26c00aeaf006 h1:h
 github.com/manchtools/power-manage-sdk v0.5.3-0.20260628153931-26c00aeaf006/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
 github.com/manchtools/power-manage-sdk v0.5.3-0.20260702060415-6943c8ab7f4f h1:CNTNK2f1F07/rsGU+NvmeTF9WcX+KesGIWeJf52Fwuc=
 github.com/manchtools/power-manage-sdk v0.5.3-0.20260702060415-6943c8ab7f4f/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
+github.com/manchtools/power-manage-sdk v0.5.3 h1:x5GtlO0VwuzMV4NUyOBr+iCE3jSQpNG6DYWnVHxB9mk=
+github.com/manchtools/power-manage-sdk v0.5.3/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=


### PR DESCRIPTION
Repin the SDK from the pseudo-version (`6943c8ab`, the same commit v0.5.3 tags) to the tagged **v0.5.3** release so the upcoming agent rc consumes a clean tagged SDK. go.mod/go.sum only, no code change. Build green.