### PR TITLE
fix(executor): version comparator accepts the real release-tag scheme (-rcN, 2-part)

### DIFF
--- a/internal/executor/agent_update.go
+++ b/internal/executor/agent_update.go
@@ -288,11 +288,27 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 	return &pb.CommandOutput{Stdout: stdout}, true, nil
 }
 
-// compareAgentVersion compares two vYYYY.MM.PP version strings and returns
-// -1 if a < b, 0 if equal, +1 if a > b. The leading "v" is optional. A
-// version that does not parse to exactly three numeric components is an
-// error — callers MUST treat that as fail-closed (never "newer"), so a
-// malformed candidate cannot bypass anti-rollback (WS7 #7).
+// agentVersion is a parsed agent release version: a 2- or 3-component numeric
+// core (year.month[.patch], missing patch = 0) plus an optional pre-release
+// suffix (e.g. "-rc4"). This matches the ACTUAL release-tag scheme — both
+// vYYYY.MM (major/minor) and vYYYY.MM.PP-rcN (patch RCs) — which the earlier
+// strict "exactly three numeric components" parser rejected, silently breaking
+// self-update between every real version (the -rcN suffix failed Atoi; a
+// 2-component tag failed the length check).
+type agentVersion struct {
+	core   [3]int // year, month, patch
+	pre    bool   // has a pre-release suffix (…-rcN)
+	preNum int    // N in -rcN; 0 when the suffix is not rc<number>
+	preRaw string // raw suffix, for a lexical fallback when it is not rc<number>
+}
+
+// compareAgentVersion compares two release versions and returns -1 if a < b,
+// 0 if equal, +1 if a > b. The leading "v" is optional. Ordering: the numeric
+// core wins first; for an equal core a final release outranks any pre-release
+// of it (2026.07.01 > 2026.07.01-rc4), and two rc pre-releases order by their
+// number (rc4 > rc3, rc10 > rc9). A version that does not parse is an error —
+// callers MUST treat that as fail-closed (never "newer"), so a malformed
+// candidate cannot bypass anti-rollback (WS7 #7).
 func compareAgentVersion(a, b string) (int, error) {
 	pa, err := parseAgentVersion(a)
 	if err != nil {
@@ -302,34 +318,88 @@ func compareAgentVersion(a, b string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	for i := 0; i < len(pa); i++ {
-		if pa[i] != pb[i] {
-			if pa[i] < pb[i] {
+	for i := 0; i < len(pa.core); i++ {
+		if pa.core[i] != pb.core[i] {
+			if pa.core[i] < pb.core[i] {
 				return -1, nil
 			}
 			return 1, nil
 		}
 	}
+	// Equal core. A release (no suffix) is newer than a pre-release of it.
+	if pa.pre != pb.pre {
+		if pa.pre {
+			return -1, nil // a is a pre-release, b is the final release
+		}
+		return 1, nil
+	}
+	if !pa.pre {
+		return 0, nil // both final releases with equal cores
+	}
+	// Both pre-releases: order by rc number, then lexically as a fallback.
+	if pa.preNum != pb.preNum {
+		if pa.preNum < pb.preNum {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	if pa.preRaw < pb.preRaw {
+		return -1, nil
+	}
+	if pa.preRaw > pb.preRaw {
+		return 1, nil
+	}
 	return 0, nil
 }
 
-// parseAgentVersion parses "vYYYY.MM.PP" (leading v optional) into its
-// three numeric components.
-func parseAgentVersion(v string) ([3]int, error) {
-	var out [3]int
+// parseAgentVersion parses "vYYYY.MM[.PP][-<pre>]" (leading v optional). The
+// core must be 2 or 3 dot-separated numeric components; a present pre-release
+// suffix must be non-empty. Anything else is an error so a malformed version
+// fails CLOSED in the anti-rollback gate (never treated as newer).
+func parseAgentVersion(v string) (agentVersion, error) {
+	var out agentVersion
 	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
-	parts := strings.Split(v, ".")
-	if len(parts) != 3 {
-		return out, fmt.Errorf("invalid version %q: want vYYYY.MM.PP", v)
+	if v == "" {
+		return out, fmt.Errorf("empty version")
+	}
+	core := v
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		core = v[:i]
+		suffix := v[i+1:]
+		if suffix == "" {
+			return out, fmt.Errorf("invalid version %q: empty pre-release suffix", v)
+		}
+		out.pre = true
+		out.preRaw = suffix
+		if n, ok := parseRCNumber(suffix); ok {
+			out.preNum = n
+		}
+	}
+	parts := strings.Split(core, ".")
+	if len(parts) < 2 || len(parts) > 3 {
+		return out, fmt.Errorf("invalid version %q: want vYYYY.MM[.PP][-rcN]", v)
 	}
 	for i, p := range parts {
 		n, err := strconv.Atoi(p)
 		if err != nil {
 			return out, fmt.Errorf("invalid version component %q in %q: %w", p, v, err)
 		}
-		out[i] = n
+		out.core[i] = n
 	}
 	return out, nil
+}
+
+// parseRCNumber extracts N from an "rcN" pre-release suffix, so rc numbers
+// order numerically (rc10 > rc9) rather than lexically.
+func parseRCNumber(suffix string) (int, bool) {
+	if !strings.HasPrefix(suffix, "rc") {
+		return 0, false
+	}
+	n, err := strconv.Atoi(suffix[2:])
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
 }
 
 // extractFilename returns the filename from a URL, stripping query parameters.

--- a/internal/executor/anti_rollback_test.go
+++ b/internal/executor/anti_rollback_test.go
@@ -19,6 +19,21 @@ func TestCompareAgentVersion_Table(t *testing.T) {
 		{"v2026.10.00", "v2026.09.99", 1},
 		{"v2027.01.00", "v2026.12.31", 1},
 		{"v2026.06.10", "v2026.06.09", 1},
+
+		// Real release-tag scheme: 2-component cores (vYYYY.MM) and
+		// -rcN pre-release suffixes must compare (they are the actual tags
+		// operators run — the strict 3-numeric parser refused them, which
+		// is what broke self-update between RCs).
+		{"2026.07.01-rc3", "2026.07.01-rc4", -1}, // the reported failure: rc3 → rc4 is an UPGRADE
+		{"2026.07.01-rc4", "2026.07.01-rc3", 1},
+		{"2026.07.01-rc4", "2026.07.01-rc4", 0},
+		{"2026.07.01-rc4", "2026.07.01", -1}, // a pre-release is older than its final release
+		{"2026.07.01", "2026.07.01-rc4", 1},
+		{"2026.07.01-rc10", "2026.07.01-rc9", 1}, // rc numbers order numerically, not lexically
+		{"v2026.06", "v2026.06.00", 0},           // 2-part core == 3-part with .00 patch
+		{"v2026.06", "v2026.07.01-rc1", -1},      // 2026.06 predates any 2026.07 pre-release
+		{"v2026.06-rc1", "v2026.06", -1},         // pre-release older than release, 2-part core
+		{"v2026.06-rc1", "v2026.06-rc2", -1},
 	}
 	for _, tc := range cases {
 		got, err := compareAgentVersion(tc.a, tc.b)
@@ -31,8 +46,11 @@ func TestCompareAgentVersion_Table(t *testing.T) {
 		}
 	}
 
-	// Malformed → error (never silently treated as comparable).
-	for _, bad := range []string{"", "garbage", "v2026.06", "v2026.06.01.02", "vYYYY.MM.PP", "2026-06-01"} {
+	// Malformed → error (never silently treated as comparable). v2026.06 is
+	// NO LONGER here — a 2-component core is a valid release tag. Genuine
+	// garbage, a 1-component core, a >3-component core, non-numeric parts, and
+	// an empty pre-release suffix all still fail closed.
+	for _, bad := range []string{"", "garbage", "v2026", "v2026.06.01.02", "vYYYY.MM.PP", "2026-06-01", "2026.07.01-"} {
 		if _, err := compareAgentVersion("v2026.06.01", bad); err == nil {
 			t.Errorf("compareAgentVersion with malformed %q must error", bad)
 		}


### PR DESCRIPTION
## What broke
The anti-rollback version check (WS7 #109) required **exactly three numeric components** (`vYYYY.MM.PP`), but the real release tags are `vYYYY.MM` (major/minor) and `vYYYY.MM.PP-rcN` (patch RCs). So `parseAgentVersion` failed on both the `-rcN` suffix (`strconv.Atoi "01-rc3"`) and 2-component cores. It runs on the running **and** candidate version and fails closed, so the in-app self-update version comparison could never pass for any real version.

Verified: the parser is byte-identical across rc1..rc4, all contain the comparator commit (43eec4d, 2026-06-14), and the agent-update form has no `allow_downgrade` toggle — so there's no UI bypass. `rc3→rc4` is just the first in-app self-update anyone drove against an rc candidate; nothing regressed in rc4 specifically.

## Fix
`parseAgentVersion` now parses a 2- or 3-component numeric core (missing patch = 0) plus an optional pre-release suffix. Ordering: core first; an equal-core final release outranks any pre-release of it (`2026.07.01 > 2026.07.01-rc4`); two rc pre-releases order by number (`rc10 > rc9`, not lexically). Genuine garbage / 1-part / >3-part / non-numeric / empty-suffix still fail closed, so anti-rollback keeps its guarantee.

## Tests
`TestCompareAgentVersion_Table` gains rc3<rc4 (the reported failure), rc<final, rc-number ordering, and 2-component cores; red-verified against the old parser. Malformed list drops `v2026.06` (now valid) and keeps the real garbage cases. Gate: gofmt/vet/staticcheck + full executor suite green; local CodeRabbit clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent version comparison to match real release-tag formats, including versions with two or three numeric components and optional pre-release suffixes.
  * Final releases are now correctly treated as newer than matching pre-releases, and release candidate versions are ordered numerically when possible.
  * Invalid version strings still fail safely, with broader coverage for malformed inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->