### PR TITLE
fix(agent): operator SYNC = full reconcile; retry startup full sync

### DIFF
--- a/cmd/power-manage-agent/runtime.go
+++ b/cmd/power-manage-agent/runtime.go
@@ -117,8 +117,19 @@ func runAgent(ctx context.Context, credStore *credentials.Store, creds *credenti
 		// Send any results stored while offline (before syncing new actions)
 		syncPendingResults(sessionCtx, sched, client, logger)
 
-		// Sync actions from server (unary RPC — stream is connecting in parallel)
-		newInterval := syncActionsFromServer(sessionCtx, client, sched, firstSync, logger)
+		// Sync actions from server (unary RPC — the stream is connecting in
+		// parallel). The FIRST sync of a connection is a full reconcile, and
+		// it MUST land: a single transient failure (most commonly the unary
+		// sync racing ahead of the stream's device→gateway binding publish, so
+		// control returns "device not live on any gateway") would otherwise
+		// drop the agent into incremental-only mode, skipping every unchanged
+		// action and leaving any drift — e.g. an account locked by an older
+		// agent — uncorrected until the next reconnect. Retry until one full
+		// reconcile succeeds; the binding appears within the stream handshake,
+		// so a retry lands almost immediately.
+		newInterval := syncUntilFullReconcile(sessionCtx, logger, func() time.Duration {
+			return syncActionsFromServer(sessionCtx, client, sched, firstSync, logger)
+		})
 		if newInterval > 0 {
 			syncInterval = newInterval
 			firstSync = false
@@ -256,9 +267,16 @@ func periodicSync(
 
 	logger.Info("periodic sync started", "interval", syncInterval.String())
 
-	doSync := func(reason string) {
-		logger.Info("syncing actions", "reason", reason)
-		newInterval := syncActionsFromServer(ctx, client, sched, false, logger)
+	// full=true re-runs the FULL desired-state reconcile (every action),
+	// not just new/changed ones. An operator-triggered SYNC action means
+	// "re-apply desired state now" — the lever for correcting drift such as
+	// an account left locked by an older agent — so it must be a full sync,
+	// matching what a fresh connection does. The periodic ticker stays
+	// incremental so it doesn't re-run every action (including SHELL
+	// scripts) every interval.
+	doSync := func(reason string, full bool) {
+		logger.Info("syncing actions", "reason", reason, "full", full)
+		newInterval := syncActionsFromServer(ctx, client, sched, full, logger)
 		if newInterval > 0 && newInterval != syncInterval {
 			syncInterval = newInterval
 			ticker.Reset(syncInterval)
@@ -280,9 +298,10 @@ func periodicSync(
 			logger.Debug("periodic sync stopped")
 			return
 		case <-ticker.C:
-			doSync("periodic")
+			doSync("periodic", false)
 		case <-syncTrigger:
-			doSync("instant action trigger")
+			// Operator-dispatched SYNC action: full desired-state reconcile.
+			doSync("instant action trigger", true)
 		case override := <-intervalUpdates:
 			if override > 0 && override != syncInterval {
 				syncInterval = override
@@ -357,6 +376,59 @@ func sendScheduledResults(ctx context.Context, client *sdk.Client, sched *schedu
 			}
 		}
 	}
+}
+
+// firstSyncMaxAttempts bounds the initial full-sync retry so a genuinely
+// persistent failure doesn't block the connection setup forever; the
+// operator's manual SYNC (also a full reconcile) and the next reconnect remain
+// the fallbacks.
+const firstSyncMaxAttempts = 6
+
+// firstSyncBaseBackoff / firstSyncMaxBackoff bound the exponential backoff
+// between initial full-sync attempts. The dominant failure — the sync racing
+// the device→gateway binding publish — clears within the stream handshake, so
+// the first retry (after ~1s) almost always lands. Package vars, not consts, so
+// tests can shrink them (the retry loop is otherwise dominated by real sleeps).
+var (
+	firstSyncBaseBackoff = 1 * time.Second
+	firstSyncMaxBackoff  = 8 * time.Second
+)
+
+// syncUntilFullReconcile runs syncOnce (a full first-sync) and retries it on
+// failure with bounded exponential backoff until one succeeds, aborting early
+// if ctx is cancelled (the stream ended). syncOnce returns the sync interval
+// (>0) on success or 0 on failure — the same contract as syncActionsFromServer.
+// Returns the interval from the first success, or 0 if every attempt failed or
+// the ctx ended. Ensuring one full reconcile lands per connection is what keeps
+// a transient first-sync failure from stranding the agent in incremental-only
+// mode (see the caller).
+func syncUntilFullReconcile(ctx context.Context, logger *slog.Logger, syncOnce func() time.Duration) time.Duration {
+	backoff := firstSyncBaseBackoff
+	for attempt := 1; attempt <= firstSyncMaxAttempts; attempt++ {
+		if iv := syncOnce(); iv > 0 {
+			if attempt > 1 {
+				logger.Info("initial full sync succeeded after retry", "attempt", attempt)
+			}
+			return iv
+		}
+		if attempt == firstSyncMaxAttempts {
+			break
+		}
+		logger.Warn("initial full sync failed; retrying",
+			"attempt", attempt, "max_attempts", firstSyncMaxAttempts, "backoff", backoff.String())
+		select {
+		case <-ctx.Done():
+			return 0
+		case <-time.After(backoff):
+		}
+		if backoff < firstSyncMaxBackoff {
+			backoff *= 2
+		}
+	}
+	logger.Error("initial full sync did not succeed after retries; continuing with periodic sync",
+		"attempts", firstSyncMaxAttempts,
+		"note", "a manual Sync action or the next reconnect will retry the full reconcile")
+	return 0
 }
 
 // syncActionsFromServer fetches all assigned actions from the server and updates local store.

--- a/cmd/power-manage-agent/runtime_sync_retry_test.go
+++ b/cmd/power-manage-agent/runtime_sync_retry_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// fastBackoff shrinks the retry backoff so the bounded-retry tests don't sleep
+// out the real 1s→8s schedule. Restored after the test.
+func fastBackoff(t *testing.T) {
+	t.Helper()
+	base, max := firstSyncBaseBackoff, firstSyncMaxBackoff
+	t.Cleanup(func() { firstSyncBaseBackoff, firstSyncMaxBackoff = base, max })
+	firstSyncBaseBackoff = time.Millisecond
+	firstSyncMaxBackoff = time.Millisecond
+}
+
+// A first sync that fails a few times (the device→gateway binding race) then
+// succeeds must be retried until it lands, returning the success interval — so
+// the connection gets its one full reconcile instead of dropping to
+// incremental-only mode.
+func TestSyncUntilFullReconcile_RetriesUntilSuccess(t *testing.T) {
+	fastBackoff(t)
+	calls := 0
+	iv := syncUntilFullReconcile(context.Background(), quietLogger(), func() time.Duration {
+		calls++
+		if calls < 3 {
+			return 0 // transient failure
+		}
+		return 30 * time.Minute
+	})
+	if iv != 30*time.Minute {
+		t.Fatalf("interval = %v, want 30m (the first success)", iv)
+	}
+	if calls != 3 {
+		t.Fatalf("syncOnce called %d times, want 3 (2 failures + 1 success)", calls)
+	}
+}
+
+// A success on the first attempt returns immediately with no retry.
+func TestSyncUntilFullReconcile_FirstTrySucceeds(t *testing.T) {
+	calls := 0
+	iv := syncUntilFullReconcile(context.Background(), quietLogger(), func() time.Duration {
+		calls++
+		return 5 * time.Minute
+	})
+	if iv != 5*time.Minute || calls != 1 {
+		t.Fatalf("iv=%v calls=%d, want 5m and 1 call", iv, calls)
+	}
+}
+
+// A persistently-failing sync exhausts the bounded attempts and returns 0
+// (the caller then falls back to periodic/manual sync) rather than looping
+// forever.
+func TestSyncUntilFullReconcile_ExhaustsAndReturnsZero(t *testing.T) {
+	fastBackoff(t)
+	calls := 0
+	iv := syncUntilFullReconcile(context.Background(), quietLogger(), func() time.Duration {
+		calls++
+		return 0
+	})
+	if iv != 0 {
+		t.Fatalf("interval = %v, want 0 on persistent failure", iv)
+	}
+	if calls != firstSyncMaxAttempts {
+		t.Fatalf("syncOnce called %d times, want %d (bounded)", calls, firstSyncMaxAttempts)
+	}
+}
+
+// A cancelled context aborts the retry promptly (the stream ended) instead of
+// sleeping out the backoff.
+func TestSyncUntilFullReconcile_CtxCancelAborts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	done := make(chan time.Duration, 1)
+	go func() {
+		done <- syncUntilFullReconcile(ctx, quietLogger(), func() time.Duration {
+			calls++
+			return 0 // always fail so it would retry if not for ctx
+		})
+	}()
+	select {
+	case iv := <-done:
+		if iv != 0 {
+			t.Fatalf("interval = %v, want 0 on ctx cancel", iv)
+		}
+		if calls != 1 {
+			t.Fatalf("syncOnce called %d times, want 1 (aborted before the second attempt)", calls)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("syncUntilFullReconcile did not return promptly on ctx cancel")
+	}
+}


### PR DESCRIPTION
Two coupled reconciliation gaps (surfaced diagnosing a pm-tty account stuck locked on rc5):

1. **Operator SYNC was incremental.** The dispatched `ACTION_TYPE_SYNC` routed through `periodicSync`'s `doSync`, which hardcoded `first_sync=false` — so it only picked up new/changed actions and never re-applied desired state. `doSync` now takes a `full` flag: the SYNC trigger passes `true` (full reconcile — the lever for correcting drift), the periodic ticker stays incremental (so it doesn't re-run every action, incl. SHELL scripts, each interval).

2. **The startup full sync was fire-once.** The first sync of a connection is the full reconcile, but a single transient failure — most commonly the unary `SyncActions` racing ahead of the stream's `AttachDevice` device→gateway binding publish (control returns "device not live on any gateway" → gateway surfaces "failed to get assigned actions") — dropped the agent into incremental-only mode until the next reconnect, silently skipping every unchanged action. `syncUntilFullReconcile` retries the first sync with bounded exponential backoff (6 attempts, 1s→8s, ctx-aware) until one full reconcile lands. The binding appears within the stream handshake, so the first retry almost always succeeds.

Net: the initial full reconcile reliably lands, and an operator always has a full-reconcile lever from the UI — so drift from any cause (e.g. an account locked by an older agent) is recoverable instead of stranded until a reconnect.

Tests: `runtime_sync_retry_test.go` covers retries-until-success (red-checked against a neutered retry), first-try-success, the exhaustion bound, and prompt ctx-cancel abort. Backoff durations are package vars so tests don't sleep out the real schedule. Gate: gofmt/vet/staticcheck + full agent unit suite (9 pkgs) green; local CodeRabbit clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent startup syncing so it keeps retrying until a full desired-state reconcile succeeds.
  * Added clearer handling for transient failures, context cancellation, and retry limits during initial sync.
  * Updated sync behavior so periodic checks stay incremental, while an instant sync performs a full reconcile.
* **Tests**
  * Added unit coverage for successful retries, immediate success, retry exhaustion, and canceled sync attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->