### PR TITLE
docs(handler): correct stale inventory-cadence comment (spec 22)

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -551,9 +551,10 @@ func (h *Handler) OnLogQuery(ctx context.Context, query *pb.LogQuery) (*pb.LogQu
 
 // OnRequestInventory handles a SERVER-originated inventory collection request.
 // Implements sdk.InventoryHandler. The request is verified fail-closed before
-// any osquery runs (WS4) — a compromised gateway cannot forge it. The
-// agent-initiated periodic path calls CollectInventory directly and needs no
-// signature.
+// any osquery runs (WS4) — a compromised gateway cannot forge it. All
+// inventory collection is server-initiated over this path (manual refresh and
+// the spec-22 server-side scheduler); the agent has no periodic collector of
+// its own.
 func (h *Handler) OnRequestInventory(ctx context.Context, req *pb.RequestInventory) *pb.DeviceInventory {
 	// WS4: a server-originated request runs osquery as root — verify the CA
 	// signature before collecting. Fail-closed (incl. nil verifier): a forged


### PR DESCRIPTION
Comment-only: the doc comment on `OnRequestInventory` referred to an "agent-initiated periodic path" that does not exist. Spec 22 pins inventory collection as server-initiated (manual `RefreshDeviceInventory` + the new server-side scheduler over the same signed path); the agent is otherwise untouched by that spec.

Refs manchtools/power-manage-server#500.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the request handling behavior for inventory collection, including that it runs only after a verified request and fails closed if verification does not pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->