### PR TITLE
feat(handler): per-execution output streaming budget (audit A-02)

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -239,22 +239,10 @@ func (h *Handler) OnActionWithStreaming(ctx context.Context, envelope []byte, si
 		}
 	}
 
-	// Create output callback if sendChunk is provided
-	var outputCallback executor.OutputCallback
-	if sendChunk != nil {
-		executionID := actionID
-		outputCallback = func(streamType sysexec.StreamType, line string, seq int64) {
-			chunk := &pb.OutputChunk{
-				ExecutionId: executionID,
-				Stream:      pb.OutputStreamType(streamType),
-				Data:        []byte(line),
-				Sequence:    seq,
-			}
-			if err := sendChunk(chunk); err != nil {
-				h.logger.Warn("failed to send output chunk", "error", err)
-			}
-		}
-	}
+	// Streaming relay, wrapped in the per-execution budget (audit A-02,
+	// #170): one marker chunk on exhaustion, then silence — the action
+	// itself runs to completion regardless.
+	outputCallback := budgetedChunkCallback(actionID, sendChunk, h.logger)
 
 	// Execute the VERIFIED envelope with streaming support.
 	result := h.executor.ExecuteWithStreaming(ctx, env, outputCallback)

--- a/internal/handler/output_budget.go
+++ b/internal/handler/output_budget.go
@@ -32,8 +32,14 @@ const truncationMarker = "[output truncated by agent: per-execution streaming bu
 
 // budgetedChunkCallback wraps sendChunk in the per-execution budget.
 // Returns nil when sendChunk is nil (no streaming sink — matches the
-// prior wiring). Safe for concurrent use: the SDK executor pumps
-// stdout and stderr from separate goroutines.
+// prior wiring).
+//
+// The mutex is held across the send itself: the SDK executor currently
+// pumps stdout and stderr from ONE goroutine, but the OutputCallback
+// contract doesn't promise that, and the underlying stream sender is
+// not documented safe for concurrent writers — serializing here makes
+// both the send safety and the "marker is the LAST chunk" guarantee
+// unconditional (CR catch on the lock scope).
 func budgetedChunkCallback(executionID string, sendChunk func(*pb.OutputChunk) error, logger *slog.Logger) executor.OutputCallback {
 	if sendChunk == nil {
 		return nil
@@ -46,13 +52,12 @@ func budgetedChunkCallback(executionID string, sendChunk func(*pb.OutputChunk) e
 	)
 	return func(streamType sysexec.StreamType, line string, seq int64) {
 		mu.Lock()
+		defer mu.Unlock()
 		if truncated {
-			mu.Unlock()
 			return
 		}
 		if bytesSent+len(line) > maxStreamBytesPerExecution || chunks+1 > maxStreamChunksPerExecution {
 			truncated = true
-			mu.Unlock()
 			logger.Info("output streaming budget exceeded; truncating relay (action continues)",
 				"execution_id", executionID, "bytes", bytesSent, "chunks", chunks)
 			if err := sendChunk(&pb.OutputChunk{
@@ -67,7 +72,6 @@ func budgetedChunkCallback(executionID string, sendChunk func(*pb.OutputChunk) e
 		}
 		bytesSent += len(line)
 		chunks++
-		mu.Unlock()
 
 		if err := sendChunk(&pb.OutputChunk{
 			ExecutionId: executionID,

--- a/internal/handler/output_budget.go
+++ b/internal/handler/output_budget.go
@@ -1,0 +1,81 @@
+package handler
+
+import (
+	"log/slog"
+	"sync"
+
+	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	sysexec "github.com/manchtools/power-manage-sdk/sys/exec"
+
+	"github.com/manchtools/power-manage/agent/internal/executor"
+)
+
+// Per-execution streaming budget (audit A-02, issue #170 — the polite
+// companion to the server's trust-boundary inbox budget, server#509).
+// A well-behaved agent stops relaying OutputChunks once an execution
+// has streamed this much, emits exactly ONE truncation-marker chunk,
+// and lets the action run to completion. This bounds the per-execution
+// OutputChunk event rows on the server without touching the captured
+// Result (the SDK's 1 MiB cap) or the local log previews (F-32).
+const (
+	// maxStreamBytesPerExecution mirrors the SDK's captured-Result cap.
+	maxStreamBytesPerExecution = 1 << 20
+	// maxStreamChunksPerExecution bounds row count independently of
+	// size — a chatty one-byte-per-line action is as unwelcome as a
+	// large one.
+	maxStreamChunksPerExecution = 4096
+)
+
+// truncationMarker is the single final chunk an over-budget execution
+// streams; readers of the live output see why it went quiet.
+const truncationMarker = "[output truncated by agent: per-execution streaming budget exceeded; the action continues and its captured result is unaffected]"
+
+// budgetedChunkCallback wraps sendChunk in the per-execution budget.
+// Returns nil when sendChunk is nil (no streaming sink — matches the
+// prior wiring). Safe for concurrent use: the SDK executor pumps
+// stdout and stderr from separate goroutines.
+func budgetedChunkCallback(executionID string, sendChunk func(*pb.OutputChunk) error, logger *slog.Logger) executor.OutputCallback {
+	if sendChunk == nil {
+		return nil
+	}
+	var (
+		mu        sync.Mutex
+		bytesSent int
+		chunks    int
+		truncated bool
+	)
+	return func(streamType sysexec.StreamType, line string, seq int64) {
+		mu.Lock()
+		if truncated {
+			mu.Unlock()
+			return
+		}
+		if bytesSent+len(line) > maxStreamBytesPerExecution || chunks+1 > maxStreamChunksPerExecution {
+			truncated = true
+			mu.Unlock()
+			logger.Info("output streaming budget exceeded; truncating relay (action continues)",
+				"execution_id", executionID, "bytes", bytesSent, "chunks", chunks)
+			if err := sendChunk(&pb.OutputChunk{
+				ExecutionId: executionID,
+				Stream:      pb.OutputStreamType(streamType),
+				Data:        []byte(truncationMarker),
+				Sequence:    seq,
+			}); err != nil {
+				logger.Warn("failed to send truncation marker chunk", "error", err)
+			}
+			return
+		}
+		bytesSent += len(line)
+		chunks++
+		mu.Unlock()
+
+		if err := sendChunk(&pb.OutputChunk{
+			ExecutionId: executionID,
+			Stream:      pb.OutputStreamType(streamType),
+			Data:        []byte(line),
+			Sequence:    seq,
+		}); err != nil {
+			logger.Warn("failed to send output chunk", "error", err)
+		}
+	}
+}

--- a/internal/handler/output_budget_test.go
+++ b/internal/handler/output_budget_test.go
@@ -1,0 +1,119 @@
+package handler
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	sysexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Audit A-02 (issue #170): the streaming callback stops relaying output
+// chunks once an execution exhausts its budget, emits exactly ONE
+// truncation-marker chunk, and stays silent afterwards — while the
+// action itself keeps running (the callback never errors).
+
+func collectChunks() (*[]*pb.OutputChunk, func(*pb.OutputChunk) error, *sync.Mutex) {
+	var mu sync.Mutex
+	chunks := []*pb.OutputChunk{}
+	send := func(c *pb.OutputChunk) error {
+		mu.Lock()
+		defer mu.Unlock()
+		chunks = append(chunks, c)
+		return nil
+	}
+	return &chunks, send, &mu
+}
+
+func testLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func TestBudgetedChunkCallback_ForwardsUnderBudget(t *testing.T) {
+	chunks, send, _ := collectChunks()
+	cb := budgetedChunkCallback("exec-1", send, testLogger())
+
+	for i := 0; i < 10; i++ {
+		cb(sysexec.StreamStdout, fmt.Sprintf("line %d", i), int64(i))
+	}
+
+	require.Len(t, *chunks, 10)
+	assert.Equal(t, "exec-1", (*chunks)[0].ExecutionId)
+	assert.Equal(t, []byte("line 0"), (*chunks)[0].Data)
+	assert.Equal(t, int64(9), (*chunks)[9].Sequence)
+}
+
+func TestBudgetedChunkCallback_ByteBudget_OneMarkerThenSilence(t *testing.T) {
+	chunks, send, _ := collectChunks()
+	cb := budgetedChunkCallback("exec-1", send, testLogger())
+
+	// One line that fills the whole byte budget, then more lines that
+	// must all be swallowed behind a single marker.
+	big := strings.Repeat("x", maxStreamBytesPerExecution)
+	cb(sysexec.StreamStdout, big, 0)
+	cb(sysexec.StreamStderr, "over 1", 1)
+	cb(sysexec.StreamStdout, "over 2", 2)
+	cb(sysexec.StreamStdout, "over 3", 3)
+
+	require.Len(t, *chunks, 2, "big line + exactly one truncation marker")
+	marker := (*chunks)[1]
+	assert.Contains(t, string(marker.Data), "truncated by agent")
+	assert.Equal(t, int64(1), marker.Sequence, "marker replaces the first dropped line")
+	assert.Equal(t, pb.OutputStreamType(sysexec.StreamStderr), marker.Stream)
+}
+
+func TestBudgetedChunkCallback_ChunkBudget_OneMarkerThenSilence(t *testing.T) {
+	chunks, send, _ := collectChunks()
+	cb := budgetedChunkCallback("exec-1", send, testLogger())
+
+	for i := 0; i <= maxStreamChunksPerExecution+10; i++ {
+		cb(sysexec.StreamStdout, "ln", int64(i))
+	}
+
+	require.Len(t, *chunks, maxStreamChunksPerExecution+1, "budgeted chunks + one marker")
+	last := (*chunks)[len(*chunks)-1]
+	assert.Contains(t, string(last.Data), "truncated by agent")
+	for _, c := range (*chunks)[:len(*chunks)-1] {
+		assert.NotContains(t, string(c.Data), "truncated", "no premature marker")
+	}
+}
+
+func TestBudgetedChunkCallback_ConcurrentStreamsSafe(t *testing.T) {
+	chunks, send, mu := collectChunks()
+	cb := budgetedChunkCallback("exec-1", send, testLogger())
+
+	// stdout + stderr scanners run on separate goroutines in the SDK
+	// executor; the budget must be race-free and still emit exactly one
+	// marker. Enough volume to blow the byte budget from both sides.
+	line := strings.Repeat("y", 64*1024)
+	var wg sync.WaitGroup
+	for g := 0; g < 2; g++ {
+		wg.Add(1)
+		go func(stream sysexec.StreamType) {
+			defer wg.Done()
+			for i := 0; i < 20; i++ {
+				cb(stream, line, int64(i))
+			}
+		}(sysexec.StreamType(g + 1))
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	markers := 0
+	for _, c := range *chunks {
+		if strings.Contains(string(c.Data), "truncated by agent") {
+			markers++
+		}
+	}
+	assert.Equal(t, 1, markers, "exactly one truncation marker under concurrency")
+}
+
+func TestBudgetedChunkCallback_NilSendChunkReturnsNil(t *testing.T) {
+	assert.Nil(t, budgetedChunkCallback("exec-1", nil, testLogger()),
+		"no sink → no callback, matching the prior wiring")
+}

--- a/internal/handler/output_budget_test.go
+++ b/internal/handler/output_budget_test.go
@@ -111,6 +111,10 @@ func TestBudgetedChunkCallback_ConcurrentStreamsSafe(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 1, markers, "exactly one truncation marker under concurrency")
+	require.NotEmpty(t, *chunks)
+	last := (*chunks)[len(*chunks)-1]
+	assert.Contains(t, string(last.Data), "truncated by agent",
+		"the marker must be the LAST chunk — no admitted chunk may land after it")
 }
 
 func TestBudgetedChunkCallback_NilSendChunkReturnsNil(t *testing.T) {


### PR DESCRIPTION
Closes #170.

The streaming relay now stops after **1 MiB or 4096 chunks per execution**, emits exactly one truncation-marker chunk, and lets the action run to completion — the polite companion to the server's trust-boundary inbox budget (manchtools/power-manage-server#509), bounding per-execution `OutputChunk` event rows. The captured Result (SDK 1 MiB cap) and local log previews (F-32) are unaffected.

Sends are serialized under the budget mutex, so the marker-is-last guarantee and stream-sender safety hold even if the SDK's pump ever goes multi-goroutine (local CodeRabbit Critical, fixed + test-pinned).

Tests: under/over byte budget, over chunk budget, one-marker-then-silence, marker-is-last under concurrent callers (race detector), nil-sink passthrough. Full agent suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming output now has built-in limits, so overly long live logs are automatically truncated.
  * A clear truncation marker is sent when output exceeds the allowed budget.

* **Bug Fixes**
  * Improved handling of concurrent streaming output to keep chunk delivery ordered and consistent.
  * Prevents extra output from being relayed after truncation, avoiding noisy or duplicate stream data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->