### PR TITLE
docs: docref anchoring + CONTRIBUTING.md (audit A-05)

### DIFF
--- a/.github/workflows/docref.yml
+++ b/.github/workflows/docref.yml
@@ -1,0 +1,38 @@
+name: docref
+
+# Docs-anchored-to-code gate (audit A-05, issue #172). Fails when an
+# anchored snippet or claim in README.md / docs/ drifts from the code
+# symbol it points at. Runs on code changes too — moving or editing an
+# anchored symbol is exactly the drift this catches.
+
+on:
+  pull_request:
+    paths:
+      - '**.md'
+      - '**.go'
+      - 'docref.toml'
+      - 'docref.lock'
+      - '.github/workflows/docref.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**.md'
+      - '**.go'
+      - 'docref.toml'
+      - 'docref.lock'
+      - '.github/workflows/docref.yml'
+
+concurrency:
+  group: docref-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docref-check:
+    name: docref (docs anchored to code)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Purpose-built docref CI image (docref + git on Alpine); nothing to build.
+      - name: docref check (docs match the code they describe)
+        run: docker run --rm -v "${{ github.workspace }}:/repo" ghcr.io/manchtools/open-docref:v0.1.0 check

--- a/.github/workflows/docref.yml
+++ b/.github/workflows/docref.yml
@@ -26,10 +26,14 @@ concurrency:
   group: docref-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   docref-check:
     name: docref (docs anchored to code)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to the Power Manage Agent
+
+The agent runs as root on managed devices and delegates OS work to the [SDK](https://github.com/manchtools/power-manage-sdk) (`sys/*`, `pkg`, `verify`) — the agent must not reimplement OS features the SDK provides. Shared idioms, branch naming, and commit conventions are the SDK's: see its [CONTRIBUTING](https://github.com/manchtools/power-manage-sdk/blob/main/CONTRIBUTING.md). Use an issue first; branch as `<prefix>/issue-<number>-<short-description>`.
+
+## Test tiers
+
+| Tier | Selector | Where it runs |
+|---|---|---|
+| Unit + arch | `go test -race ./...` (no tags) | host, every PR (`unit-test.yml`) |
+| Integration | `//go:build integration` files, functions named `TestIntegration_*` | 4-distro container matrix (`integration-test.yml`) |
+| Privileged edge | same tag, functions named `TestEdgeCase_*` | privileged container lane |
+
+Rules the CI enforces (self-discovering guards in `internal/archtest/`):
+- Every integration-tagged test must live in a package the workflow tests **and** match a `-run` selector (`TestIntegration_*` / `TestEdgeCase_*`) — anything else never runs anywhere and the guard fails the build.
+- Executor tests that touch the OS belong in the integration tier; unit tests use the seams (`FakeRunner`, `SetNowForTest`, backend fakes) — see `docs/container-test-strategy.md` for the full strategy and the dormant-test trap it prevents.
+
+## Running the container lanes locally
+
+```bash
+# Distro matrix lane (debian; swap the Dockerfile suffix for fedora/opensuse/archlinux)
+cd .. && docker build -f agent/test/Dockerfile.integration -t pm-agent-test .
+docker run --rm pm-agent-test \
+  go test -tags=integration -count=1 -timeout=10m ./agent/internal/executor/ -run Integration
+
+# Privileged edge lane
+docker run --rm --privileged pm-agent-test \
+  go test -tags=integration -count=1 -timeout=10m ./agent/internal/executor/ -run EdgeCase
+```
+
+The build context is the **parent** directory: CI checks the repo out into `agent/` and optionally overlays a same-named SDK branch into `sdk/` (the go.mod pin is used otherwise).
+
+## Docs
+
+`README.md` and `docs/` are docref-anchored: run `docker run --rm -v "$PWD:/repo" ghcr.io/manchtools/open-docref:v0.1.0 check` before pushing doc or code changes that touch anchored symbols; CI fails on drift. Update the prose *and* re-approve the claim — never delete an anchor to silence the check.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The agent supports two enrollment methods:
 6. The Control Server validates the token, signs the certificate, and returns credentials
 7. The agent saves credentials, closes the enrollment socket, starts the auth socket, and connects to the gateway
 
+<!-- docref: begin src=internal/deviceauth/enroll_server.go#EnrollSocketPath:9838543e -->
 > **Trust boundary (deliberate self-service design).** The enrollment
 > socket is intentionally world-accessible (mode `0666`) so a **non-root
 > user can enroll their own corporate/BYOD device without sudo** — that
@@ -63,6 +64,7 @@ The agent supports two enrollment methods:
 > of 5 enrollment attempts per minute, so a local user can briefly
 > disrupt a legitimate enrollment by flooding bad tokens — acceptable for
 > a self-hosted MDM, not for adversarial multi-tenant hosts.
+<!-- docref: end -->
 >
 > **Hardening (WS9).** `server_url` must be **https** (cleartext/opaque
 > URLs are refused before any network call). Token delivery is via
@@ -633,12 +635,15 @@ The agent prevents actions from modifying its own infrastructure:
 
 - **Registration**: Agent registers with the Control Server over HTTPS, authenticating with a registration token
 - **mTLS**: After registration, the agent connects to the Gateway using mutual TLS with certificates signed by the Control Server CA
+<!-- docref: begin src=cmd/power-manage-agent/cert_rotation.go#renewAt:211ccaeb -->
 - **Certificate Rotation**: The agent automatically renews its mTLS certificate at 80% of its lifetime (~292 days for a 1-year cert). Renewal uses the existing private key to generate a new CSR and calls the Control Server's `RenewCertificate` RPC, presenting the current certificate for identity verification. The response includes the active CA certificate, which the agent stores locally — this enables seamless CA rotation without re-registration. On failure, the agent retries hourly.
 - **Trust roots — control server vs gateway asymmetry**: Every gateway-bound RPC validates the gateway certificate against the **internal CA** that signed the agent's own certificate (i.e., `WithMTLSFromPEM`). The Control Server's `RenewCertificate` RPC is the one exception: it validates against the **host system trust roots** (`WithMTLSFromPEMAndSystemRoots`), because the control server typically sits behind a public CA (Let's Encrypt, an enterprise CA, etc.). If you front the control server with a corporate-CA proxy, the host's CA bundle must include that proxy's root — otherwise certificate renewal will fail with a TLS verification error even though every other RPC keeps working.
+<!-- docref: end -->
 - **Certificate Storage**: Credentials are encrypted at rest using AES-256-GCM with a key derived from the machine ID via Argon2id (plus a per-store random salt), written `0600` in a `0700` owner-only directory. The store fails closed if its directory is group/world-**writable** (a non-owner could otherwise forge the salt/ciphertext), and Save tightens an existing directory to `0700`. The machine-ID binding means the ciphertext will not decrypt if copied to another host, but it is **not** protection against offline theft of the disk or a backup (the machine ID lives on the same disk) — use **full-disk encryption** for that. A same-disk key file would add no real defense, so it is intentionally not used (WS10 accepted residual; see ADR 0014).
 
 ### Root Stream-RPC Verification (WS4)
 
+<!-- docref: begin src=internal/executor/executor.go#Executor.VerifyEnvelope:ea44180f,internal/handler/handler.go#Handler.OnRequestInventory:398d6189 -->
 The agent runs as root, and the Gateway/Valkey relay is **untrusted for
 origination**. So beyond signed actions, the four root stream-RPCs are verified
 fail-closed against the CA certificate **before any root work**:
@@ -654,8 +659,10 @@ Each verifies the Control Server's signature over the message's canonical bytes
 under that surface's disjoint domain. **Raw SQL is permitted only when signed**
 (an unsigned/tampered raw query never reaches osquery); the message is validated
 at the boundary first. A missing verifier fails closed (production always has
-one — the CA cert is required at startup). Agent-initiated periodic inventory
-collection is the agent's own decision and needs no signature.
+one — the CA cert is required at startup). All inventory collection is
+server-initiated over this signed path (manual refresh and the spec-22
+server-side scheduler); the agent has no periodic collector of its own.
+<!-- docref: end -->
 
 ### Package / Repository Argument Hardening (WS8)
 

--- a/docref.toml
+++ b/docref.toml
@@ -1,0 +1,6 @@
+# docref keeps README.md and docs/ honest against the code they describe
+# (audit A-05, issue #172). `docref check` (run in CI) fails when an
+# anchored snippet or claim drifts from the symbol/region it points at.
+# Anchor liberally: an un-anchored statement about code is a latent bug.
+[scan]
+include = ["README.md", "docs/**/*.md"]


### PR DESCRIPTION
Closes #172.

- **docref.toml** scanning `README.md` + `docs/`; the load-bearing security claims are anchored: the WS4 verify chain (`Executor.VerifyEnvelope` / `Handler.OnRequestInventory`), the 0666 enrollment-socket trust boundary (`EnrollSocketPath`), and the 80%-lifetime cert rotation (`renewAt`). `docref check`: 3 refs, 0 stale, 0 broken.
- **README WS4 fix**: the 'agent-initiated periodic inventory collection' sentence was the same false premise spec 22 removed — corrected to server-initiated-only (matches the #175 comment fix).
- **CONTRIBUTING.md** (~35 lines): the test tiers with the exact selectors the archtest lane guard enforces (#171 pairs with this), how to run the container lanes locally with the parent-dir build context, the docref workflow, and a pointer to the SDK's CONTRIBUTING for shared idioms.
- **docref.yml** CI gate (same `open-docref` image as sdk/server), least-privilege token + 10-min timeout (local CodeRabbit findings, applied).

Part of the cross-repo doc-truth sweep (server#510, sdk#271).