### PR TITLE
fix(user): disabling root is lock-only — shell preserved (#169 rider)

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Create, modify, or remove system users.
 
 On creation, a temporary password is generated and returned in the `lps.rotations` metadata field. The `power-manage` system user is protected from deletion.
 
-<!-- docref: begin src=internal/executor/action_user.go#Executor.updateUser:07b6c675 -->
+<!-- docref: begin src=internal/executor/action_user.go#Executor.updateUser:318399bc -->
 `disabled: true` shadow-locks the account (`usermod -L`, a leading `!` on the password hash) and — for regular users — defaults the shell to `/usr/sbin/nologin` for offboarding. **Disabling `root` is deliberately lock-only**: the shell is left untouched, so `sudo -i` and key-based root SSH keep working while password login stops — the same posture as Ubuntu's locked-by-default root. This is an operator choice and has no effect on the agent itself (a running root service neither re-authenticates nor uses the login shell); the agent logs a warning when it locks root. An explicitly set `shell` is always honored, root included.
 <!-- docref: end -->
 

--- a/README.md
+++ b/README.md
@@ -331,6 +331,10 @@ Create, modify, or remove system users.
 
 On creation, a temporary password is generated and returned in the `lps.rotations` metadata field. The `power-manage` system user is protected from deletion.
 
+<!-- docref: begin src=internal/executor/action_user.go#Executor.updateUser:07b6c675 -->
+`disabled: true` shadow-locks the account (`usermod -L`, a leading `!` on the password hash) and — for regular users — defaults the shell to `/usr/sbin/nologin` for offboarding. **Disabling `root` is deliberately lock-only**: the shell is left untouched, so `sudo -i` and key-based root SSH keep working while password login stops — the same posture as Ubuntu's locked-by-default root. This is an operator choice and has no effect on the agent itself (a running root service neither re-authenticates nor uses the login shell); the agent logs a warning when it locks root. An explicitly set `shell` is always honored, root included.
+<!-- docref: end -->
+
 **Desired State:**
 - `PRESENT`: Create the user or update attributes (shell, groups, comment)
 - `ABSENT`: Delete the user and remove their home directory

--- a/internal/executor/action_user.go
+++ b/internal/executor/action_user.go
@@ -306,7 +306,16 @@ func (e *Executor) updateUser(ctx context.Context, params *pb.UserParams, output
 	// Determine desired shell
 	desiredShell := params.Shell
 	if desiredShell == "" {
-		if params.Disabled {
+		// Disabling ROOT is lock-only (#169, operator decision 2026-07-08):
+		// the nologin default would break `sudo -i` and key-based root SSH
+		// (both run root's login shell), turning a reversible password lock
+		// into an emergency-access lockout. A password-locked root with an
+		// intact shell is exactly Ubuntu's default posture and has no
+		// effect on the agent (systemd services don't authenticate or use
+		// the login shell). Regular users keep the nologin-on-disable
+		// offboarding default; an operator may still set the shell
+		// explicitly for root.
+		if params.Disabled && params.Username != "root" {
 			desiredShell = "/usr/sbin/nologin"
 		}
 		// If not disabled and no shell specified, don't change the existing shell
@@ -386,6 +395,12 @@ func (e *Executor) updateUser(ctx context.Context, params *pb.UserParams, output
 	desiredLocked := desiredAccountLocked(params)
 	if desiredLocked != currentInfo.Locked {
 		if desiredLocked {
+			if params.Username == "root" {
+				// Deliberate operator choice (#169) — loud in the journal:
+				// password login to root stops working; sudo and key-based
+				// SSH are unaffected (lock-only, shell preserved).
+				e.logger.Warn("locking the root account per USER action (password login disabled; sudo/key-SSH unaffected)")
+			}
 			if err := userMgr.Lock(ctx, params.Username); err != nil {
 				output.WriteString(fmt.Sprintf("warning: failed to lock user: %v\n", err))
 			} else {

--- a/internal/executor/action_user.go
+++ b/internal/executor/action_user.go
@@ -395,15 +395,18 @@ func (e *Executor) updateUser(ctx context.Context, params *pb.UserParams, output
 	desiredLocked := desiredAccountLocked(params)
 	if desiredLocked != currentInfo.Locked {
 		if desiredLocked {
-			if params.Username == "root" {
-				// Deliberate operator choice (#169) — loud in the journal:
-				// password login to root stops working; sudo and key-based
-				// SSH are unaffected (lock-only, shell preserved).
-				e.logger.Warn("locking the root account per USER action (password login disabled; sudo/key-SSH unaffected)")
-			}
 			if err := userMgr.Lock(ctx, params.Username); err != nil {
 				output.WriteString(fmt.Sprintf("warning: failed to lock user: %v\n", err))
 			} else {
+				if params.Username == "root" {
+					// Deliberate operator choice (#169) — loud in the
+					// journal, AFTER the lock succeeded (CR catch: warning
+					// on the attempt would falsely assert the state change
+					// when Lock fails): password login to root stops
+					// working; sudo and key-based SSH are unaffected
+					// (lock-only, shell preserved).
+					e.logger.Warn("locked the root account per USER action (password login disabled; sudo/key-SSH unaffected)")
+				}
 				output.WriteString("account locked (disabled)\n")
 				changed = true
 			}

--- a/internal/executor/action_user_root_disable_test.go
+++ b/internal/executor/action_user_root_disable_test.go
@@ -1,0 +1,133 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	sysuser "github.com/manchtools/power-manage-sdk/sys/user"
+)
+
+// fakeRootDisableUser records the Lock/Modify traffic updateUser emits.
+// The embedded nil Manager panics on any unlisted method — the guard
+// that a new updateUser dependency shows up loudly here.
+type fakeRootDisableUser struct {
+	sysuser.Manager
+	info     sysuser.Info
+	locked   []string
+	modified []sysuser.ModifyOptions
+}
+
+func (f *fakeRootDisableUser) Get(context.Context, string) (sysuser.Info, error) {
+	return f.info, nil
+}
+func (f *fakeRootDisableUser) Lock(_ context.Context, name string) error {
+	f.locked = append(f.locked, name)
+	return nil
+}
+func (f *fakeRootDisableUser) Modify(_ context.Context, _ string, opts sysuser.ModifyOptions) error {
+	f.modified = append(f.modified, opts)
+	return nil
+}
+
+func swapUserMgr(t *testing.T, m sysuser.Manager) {
+	t.Helper()
+	prev := userMgr
+	t.Cleanup(func() { userMgr = prev })
+	userMgr = m
+}
+
+// #169 rider (operator decision 2026-07-08): disabling ROOT is
+// lock-only — the shell must stay untouched so `sudo -i` and key-based
+// root SSH keep working (Ubuntu's default posture). The lock is loud
+// in the journal.
+func TestUpdateUser_DisableRoot_LockOnlyKeepsShell(t *testing.T) {
+	fake := &fakeRootDisableUser{info: sysuser.Info{Shell: "/bin/bash", Locked: false}}
+	swapUserMgr(t, fake)
+
+	var logBuf bytes.Buffer
+	e := &Executor{logger: slog.New(slog.NewTextHandler(&logBuf, nil)), now: time.Now}
+
+	var out strings.Builder
+	_, changed, err := e.updateUser(context.Background(), &pb.UserParams{
+		Username: "root",
+		Disabled: true,
+	}, &out)
+	if err != nil {
+		t.Fatalf("updateUser: %v", err)
+	}
+	if !changed {
+		t.Fatal("locking root must report changed")
+	}
+	if len(fake.locked) != 1 || fake.locked[0] != "root" {
+		t.Fatalf("root must be locked exactly once, got %v", fake.locked)
+	}
+	for _, m := range fake.modified {
+		if m.Shell != "" {
+			t.Fatalf("disabling root must not touch the shell (lock-only), got Modify(Shell=%q)", m.Shell)
+		}
+	}
+	if !strings.Contains(logBuf.String(), "level=WARN") || !strings.Contains(logBuf.String(), "root") {
+		t.Fatalf("locking root must warn loudly in the journal, got: %s", logBuf.String())
+	}
+}
+
+// Regression pin for the existing offboarding semantics: a REGULAR
+// user disabled without an explicit shell still defaults to nologin.
+func TestUpdateUser_DisableRegularUser_StillDefaultsNologin(t *testing.T) {
+	fake := &fakeRootDisableUser{info: sysuser.Info{Shell: "/bin/bash", Locked: false}}
+	swapUserMgr(t, fake)
+
+	e := &Executor{logger: slog.Default(), now: time.Now}
+	var out strings.Builder
+	_, _, err := e.updateUser(context.Background(), &pb.UserParams{
+		Username: "alice",
+		Disabled: true,
+	}, &out)
+	if err != nil {
+		t.Fatalf("updateUser: %v", err)
+	}
+	found := false
+	for _, m := range fake.modified {
+		if m.Shell == "/usr/sbin/nologin" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("a disabled regular user must still default to the nologin shell, got %v", fake.modified)
+	}
+	if len(fake.locked) != 1 || fake.locked[0] != "alice" {
+		t.Fatalf("alice must be locked, got %v", fake.locked)
+	}
+}
+
+// An explicit shell on a root-disable is still honored — the exemption
+// only removes the DEFAULT, not the operator's stated intent.
+func TestUpdateUser_DisableRoot_ExplicitShellHonored(t *testing.T) {
+	fake := &fakeRootDisableUser{info: sysuser.Info{Shell: "/bin/bash", Locked: false}}
+	swapUserMgr(t, fake)
+
+	e := &Executor{logger: slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)), now: time.Now}
+	var out strings.Builder
+	_, _, err := e.updateUser(context.Background(), &pb.UserParams{
+		Username: "root",
+		Disabled: true,
+		Shell:    "/usr/sbin/nologin",
+	}, &out)
+	if err != nil {
+		t.Fatalf("updateUser: %v", err)
+	}
+	found := false
+	for _, m := range fake.modified {
+		if m.Shell == "/usr/sbin/nologin" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("an explicitly requested shell must still be applied to root")
+	}
+}


### PR DESCRIPTION
Implements the #169 rider per the operator decision (2026-07-08): **disabling `root` via the USER action is allowed, as a lock-only operation.**

- `disabled: true` on root shadow-locks the password (`usermod -L`) but no longer defaults the shell to `/usr/sbin/nologin` — that default would break `sudo -i` and key-based root SSH (both run root's login shell), turning a reversible password lock into an emergency-access lockout. A password-locked root with an intact shell is Ubuntu's default posture and has no effect on the agent (systemd `User=root` services neither authenticate nor use the login shell).
- Regular users keep the nologin-on-disable offboarding default; an explicit `shell` is always honored, root included.
- The root lock warns in the journal **after the lock succeeds** (local CodeRabbit catch — warning on the attempt would falsely assert the state change on a failed lock).
- Semantics documented in the README, docref-anchored to `updateUser`.

Tests: lock-only-keeps-shell (red-checked by reverting the exemption), regular-user nologin regression pin, explicit-shell-honored. Suite green; docref green.

Refs #169 (the issue stays open for its cross-repo backend-enum body).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabling the `root` account now keeps the existing shell unchanged, so lock-only behavior is preserved.
  * A warning is now logged when `root` is locked.
  * Non-root disabled accounts still default to a non-login shell.
  * Any explicitly set shell is now honored when disabling an account.
* **Tests**
  * Added coverage for root lock-only behavior, non-root disabling, and explicit shell handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->