### PR TITLE
fix(ci): derive the container go.work version from agent/go.mod

### DIFF
--- a/test/Dockerfile.integration
+++ b/test/Dockerfile.integration
@@ -35,7 +35,7 @@ COPY agent/ ./agent/
 # Single-module go.work so `go test ./agent/...` works from /workspace
 # (CI invokes gotestsum from the container's default cwd). Without this
 # Go can't find a module rooted at /workspace.
-RUN printf 'go 1.25.11\n\nuse (\n\t./agent\n)\n' > go.work
+RUN printf 'go %s\n\nuse (\n\t./agent\n)\n' "$(sed -n 's/^go //p' agent/go.mod)" > go.work
 
 # Pre-download dependencies and install gotestsum for clear failure reporting
 RUN cd agent && go mod download

--- a/test/Dockerfile.integration.archlinux
+++ b/test/Dockerfile.integration.archlinux
@@ -4,7 +4,7 @@ WORKDIR /workspace
 COPY agent/ ./agent/
 # Single-module go.work so `go test ./agent/...` works from /workspace
 # (CI invokes gotestsum from the container's default cwd).
-RUN printf 'go 1.25.11\n\nuse (\n\t./agent\n)\n' > go.work
+RUN printf 'go %s\n\nuse (\n\t./agent\n)\n' "$(sed -n 's/^go //p' agent/go.mod)" > go.work
 RUN cd agent && go mod download
 RUN go install gotest.tools/gotestsum@latest
 

--- a/test/Dockerfile.integration.fedora
+++ b/test/Dockerfile.integration.fedora
@@ -4,7 +4,7 @@ WORKDIR /workspace
 COPY agent/ ./agent/
 # Single-module go.work so `go test ./agent/...` works from /workspace
 # (CI invokes gotestsum from the container's default cwd).
-RUN printf 'go 1.25.11\n\nuse (\n\t./agent\n)\n' > go.work
+RUN printf 'go %s\n\nuse (\n\t./agent\n)\n' "$(sed -n 's/^go //p' agent/go.mod)" > go.work
 RUN cd agent && go mod download
 RUN go install gotest.tools/gotestsum@latest
 

--- a/test/Dockerfile.integration.opensuse
+++ b/test/Dockerfile.integration.opensuse
@@ -4,7 +4,7 @@ WORKDIR /workspace
 COPY agent/ ./agent/
 # Single-module go.work so `go test ./agent/...` works from /workspace
 # (CI invokes gotestsum from the container's default cwd).
-RUN printf 'go 1.25.11\n\nuse (\n\t./agent\n)\n' > go.work
+RUN printf 'go %s\n\nuse (\n\t./agent\n)\n' "$(sed -n 's/^go //p' agent/go.mod)" > go.work
 RUN cd agent && go mod download
 RUN go install gotest.tools/gotestsum@latest
 


### PR DESCRIPTION
The integration Dockerfiles hardcoded `go 1.25.11` in the generated `go.work`, so the go1.25.12 toolchain bump (GO-2026-5856, merged in #182) broke `go mod download` in all five container lanes. The version is now derived from `agent/go.mod` at image-build time — the next toolchain bump can't re-break the lanes. Local `docker build` verified.

Also: I merged #182 while these lanes were red (my merge command didn't gate on the watch result — the failure was this Dockerfile issue, not the SDK bump itself). This PR restores green on main.