### PR TITLE
fix(executor): key superuser lock-only exemption on UID 0, not the name root

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,8 +331,8 @@ Create, modify, or remove system users.
 
 On creation, a temporary password is generated and returned in the `lps.rotations` metadata field. The `power-manage` system user is protected from deletion.
 
-<!-- docref: begin src=internal/executor/action_user.go#Executor.updateUser:318399bc -->
-`disabled: true` shadow-locks the account (`usermod -L`, a leading `!` on the password hash) and — for regular users — defaults the shell to `/usr/sbin/nologin` for offboarding. **Disabling `root` is deliberately lock-only**: the shell is left untouched, so `sudo -i` and key-based root SSH keep working while password login stops — the same posture as Ubuntu's locked-by-default root. This is an operator choice and has no effect on the agent itself (a running root service neither re-authenticates nor uses the login shell); the agent logs a warning when it locks root. An explicitly set `shell` is always honored, root included.
+<!-- docref: begin src=internal/executor/action_user.go#Executor.updateUser:50055ffa -->
+`disabled: true` shadow-locks the account (`usermod -L`, a leading `!` on the password hash) and — for regular users — defaults the shell to `/usr/sbin/nologin` for offboarding. **Disabling the superuser is deliberately lock-only**: for any UID-0 account (keyed on the UID, not the name `root`, so a renamed superuser is covered without a name list) the shell is left untouched, so `sudo -i` and key-based root SSH keep working while password login stops — the same posture as Ubuntu's locked-by-default root. This is an operator choice and has no effect on the agent itself (a running root service neither re-authenticates nor uses the login shell); the agent logs a warning when it locks a UID-0 account. An explicitly set `shell` is always honored, superuser included.
 <!-- docref: end -->
 
 **Desired State:**

--- a/internal/executor/action_user.go
+++ b/internal/executor/action_user.go
@@ -306,16 +306,19 @@ func (e *Executor) updateUser(ctx context.Context, params *pb.UserParams, output
 	// Determine desired shell
 	desiredShell := params.Shell
 	if desiredShell == "" {
-		// Disabling ROOT is lock-only (#169, operator decision 2026-07-08):
-		// the nologin default would break `sudo -i` and key-based root SSH
-		// (both run root's login shell), turning a reversible password lock
-		// into an emergency-access lockout. A password-locked root with an
-		// intact shell is exactly Ubuntu's default posture and has no
-		// effect on the agent (systemd services don't authenticate or use
-		// the login shell). Regular users keep the nologin-on-disable
-		// offboarding default; an operator may still set the shell
-		// explicitly for root.
-		if params.Disabled && params.Username != "root" {
+		// Disabling the SUPERUSER is lock-only (#169, operator decision
+		// 2026-07-08): the nologin default would break `sudo -i` and
+		// key-based root SSH (both run the login shell), turning a
+		// reversible password lock into an emergency-access lockout. A
+		// password-locked superuser with an intact shell is exactly
+		// Ubuntu's default posture and has no effect on the agent
+		// (systemd services don't authenticate or use the login shell).
+		// Keyed on UID 0 — the self-discovering superuser identity — not
+		// on the name "root", so a renamed superuser account is covered
+		// without a name list to maintain. Regular users keep the
+		// nologin-on-disable offboarding default; an operator may still
+		// set the shell explicitly.
+		if params.Disabled && currentInfo.UID != 0 {
 			desiredShell = "/usr/sbin/nologin"
 		}
 		// If not disabled and no shell specified, don't change the existing shell
@@ -398,14 +401,15 @@ func (e *Executor) updateUser(ctx context.Context, params *pb.UserParams, output
 			if err := userMgr.Lock(ctx, params.Username); err != nil {
 				output.WriteString(fmt.Sprintf("warning: failed to lock user: %v\n", err))
 			} else {
-				if params.Username == "root" {
+				if currentInfo.UID == 0 {
 					// Deliberate operator choice (#169) — loud in the
 					// journal, AFTER the lock succeeded (CR catch: warning
 					// on the attempt would falsely assert the state change
-					// when Lock fails): password login to root stops
-					// working; sudo and key-based SSH are unaffected
-					// (lock-only, shell preserved).
-					e.logger.Warn("locked the root account per USER action (password login disabled; sudo/key-SSH unaffected)")
+					// when Lock fails): password login to the superuser
+					// stops working; sudo and key-based SSH are unaffected
+					// (lock-only, shell preserved). UID-keyed, like the
+					// shell exemption above.
+					e.logger.Warn("locked the superuser account per USER action (password login disabled; sudo/key-SSH unaffected)", "username", params.Username)
 				}
 				output.WriteString("account locked (disabled)\n")
 				changed = true

--- a/internal/executor/action_user_root_disable_test.go
+++ b/internal/executor/action_user_root_disable_test.go
@@ -46,7 +46,7 @@ func swapUserMgr(t *testing.T, m sysuser.Manager) {
 // root SSH keep working (Ubuntu's default posture). The lock is loud
 // in the journal.
 func TestUpdateUser_DisableRoot_LockOnlyKeepsShell(t *testing.T) {
-	fake := &fakeRootDisableUser{info: sysuser.Info{Shell: "/bin/bash", Locked: false}}
+	fake := &fakeRootDisableUser{info: sysuser.Info{UID: 0, Shell: "/bin/bash", Locked: false}}
 	swapUserMgr(t, fake)
 
 	var logBuf bytes.Buffer
@@ -79,7 +79,7 @@ func TestUpdateUser_DisableRoot_LockOnlyKeepsShell(t *testing.T) {
 // Regression pin for the existing offboarding semantics: a REGULAR
 // user disabled without an explicit shell still defaults to nologin.
 func TestUpdateUser_DisableRegularUser_StillDefaultsNologin(t *testing.T) {
-	fake := &fakeRootDisableUser{info: sysuser.Info{Shell: "/bin/bash", Locked: false}}
+	fake := &fakeRootDisableUser{info: sysuser.Info{UID: 1000, Shell: "/bin/bash", Locked: false}}
 	swapUserMgr(t, fake)
 
 	e := &Executor{logger: slog.Default(), now: time.Now}
@@ -108,7 +108,7 @@ func TestUpdateUser_DisableRegularUser_StillDefaultsNologin(t *testing.T) {
 // An explicit shell on a root-disable is still honored — the exemption
 // only removes the DEFAULT, not the operator's stated intent.
 func TestUpdateUser_DisableRoot_ExplicitShellHonored(t *testing.T) {
-	fake := &fakeRootDisableUser{info: sysuser.Info{Shell: "/bin/bash", Locked: false}}
+	fake := &fakeRootDisableUser{info: sysuser.Info{UID: 0, Shell: "/bin/bash", Locked: false}}
 	swapUserMgr(t, fake)
 
 	e := &Executor{logger: slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)), now: time.Now}
@@ -129,5 +129,36 @@ func TestUpdateUser_DisableRoot_ExplicitShellHonored(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("an explicitly requested shell must still be applied to root")
+	}
+}
+
+// The exemption is keyed on UID 0, not the name "root": a renamed
+// superuser account (hardening setups, "toor", etc.) must get the same
+// lock-only treatment — no name list to maintain.
+func TestUpdateUser_DisableRenamedSuperuser_LockOnlyKeepsShell(t *testing.T) {
+	fake := &fakeRootDisableUser{info: sysuser.Info{UID: 0, Shell: "/bin/bash", Locked: false}}
+	swapUserMgr(t, fake)
+
+	var logBuf bytes.Buffer
+	e := &Executor{logger: slog.New(slog.NewTextHandler(&logBuf, nil)), now: time.Now}
+
+	var out strings.Builder
+	_, changed, err := e.updateUser(context.Background(), &pb.UserParams{
+		Username: "sysadm",
+		Disabled: true,
+	}, &out)
+	if err != nil {
+		t.Fatalf("updateUser: %v", err)
+	}
+	if !changed {
+		t.Fatal("locking the superuser must report changed")
+	}
+	for _, m := range fake.modified {
+		if m.Shell != "" {
+			t.Fatalf("disabling a UID-0 account must not touch the shell (lock-only), got Modify(Shell=%q)", m.Shell)
+		}
+	}
+	if !strings.Contains(logBuf.String(), "level=WARN") || !strings.Contains(logBuf.String(), "sysadm") {
+		t.Fatalf("locking a UID-0 account must warn loudly in the journal, got: %s", logBuf.String())
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #181 (the #169 rider). The disabled-superuser lock-only exemption was keyed on the literal username `root` — a hardcoded name that misses renamed superuser accounts and is a list to maintain. Both the shell-default exemption and the loud lock warning are now keyed on the target account's **UID 0**, the self-discovering superuser identity.

Division of responsibility stays as ruled: the SDK's `sys/user.Lock` remains pure mechanism (locks any account, no policy); the UID-0 policy lives in the agent's `updateUser`.

`createUser` needs no equivalent: `params.Uid > 0` means create can never allocate UID 0, and an existing UID-0 account always routes to `updateUser`.

## Tests

- New `TestUpdateUser_DisableRenamedSuperuser_LockOnlyKeepsShell` (UID 0, name `sysadm`) — red-checked against the old name-keyed code (fails there, passes now).
- Existing fixtures now carry explicit UIDs (`alice` = 1000) so the regular-user nologin-offboarding pin proves UID keying.
- Full gate green: go vet, staticcheck, `go test ./...`, docref check (README claim updated + re-approved), local CodeRabbit review: no findings.

Refs #169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account disabling now treats any superuser as such based on UID, so renamed UID 0 accounts are handled correctly.
  * Disabling a superuser remains lock-only, preserving the existing shell setting while stopping password login.
  * Warning messages now appear consistently when a superuser is locked.

* **Tests**
  * Added coverage for disabling a renamed superuser to confirm lock-only behavior and warning output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->