### PR TITLE
fix(security): enforce signed target_device_id binding (PMSEC-001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ The agent prevents actions from modifying its own infrastructure:
 
 ### Root Stream-RPC Verification (WS4)
 
-<!-- docref: begin src=internal/executor/executor.go#Executor.VerifyEnvelope:ea44180f,internal/handler/handler.go#Handler.OnRequestInventory:398d6189 -->
+<!-- docref: begin src=internal/executor/executor.go#Executor.VerifyEnvelope:93e0873f,internal/handler/handler.go#Handler.OnRequestInventory:398d6189 -->
 The agent runs as root, and the Gateway/Valkey relay is **untrusted for
 origination**. So beyond signed actions, the four root stream-RPCs are verified
 fail-closed against the CA certificate **before any root work**:
@@ -666,6 +666,12 @@ at the boundary first. A missing verifier fails closed (production always has
 one — the CA cert is required at startup). All inventory collection is
 server-initiated over this signed path (manual refresh and the spec-22
 server-side scheduler); the agent has no periodic collector of its own.
+
+Signed **actions** are additionally bound to the target device: `VerifyEnvelope`
+refuses an envelope whose signed `target_device_id` is not this agent's own id
+(and refuses when the agent's id is unset), so a compromised relay cannot replay
+one device's validly-signed, root-capable action onto another device that trusts
+the same CA (PMSEC-001).
 <!-- docref: end -->
 
 ### Package / Repository Argument Hardening (WS8)

--- a/internal/executor/execute_verified_envelope_test.go
+++ b/internal/executor/execute_verified_envelope_test.go
@@ -13,19 +13,34 @@ import (
 	"github.com/manchtools/power-manage-sdk/verify"
 )
 
+// testDeviceID is the device id the test executor is configured with, and the
+// default target every signed test envelope is bound to (see signEnv), so the
+// PMSEC-001 target check passes for a matching envelope. Cross-device tests set
+// a different TargetDeviceId explicitly.
+const testDeviceID = "01TESTDEVICE0000000000000A"
+
 // testVerifierAndSigner returns an Executor whose verifier is built from a
-// fresh self-signed CA, plus the matching ActionSigner. A signature minted
-// by this signer verifies; anything else (or nothing) is refused.
+// fresh self-signed CA and whose device id is testDeviceID, plus the matching
+// ActionSigner. A signature minted by this signer verifies; anything else (or
+// nothing) is refused.
 func testVerifierAndSigner(t *testing.T) (*Executor, *verify.ActionSigner) {
 	t.Helper()
 	caPEM, key, _ := cryptotest.GenCA(t, "test-ca")
 	verifier, err := verify.NewActionVerifier(caPEM)
 	require.NoError(t, err)
-	return NewExecutor(verifier, nil), verify.NewActionSigner(key)
+	exec := NewExecutor(verifier, nil)
+	exec.SetDeviceID(testDeviceID)
+	return exec, verify.NewActionSigner(key)
 }
 
 func signEnv(t *testing.T, signer *verify.ActionSigner, env *pb.SignedActionEnvelope) (envelope []byte, signature []byte) {
 	t.Helper()
+	// Default the signed target to this test device so a plain envelope passes
+	// the PMSEC-001 target check; a test that wants a cross-device envelope sets
+	// TargetDeviceId itself before calling.
+	if env.GetTargetDeviceId() == "" {
+		env.TargetDeviceId = testDeviceID
+	}
 	b, err := verify.MarshalEnvelope(env)
 	require.NoError(t, err)
 	sig, err := signer.Sign(b)
@@ -137,6 +152,69 @@ func TestExecutor_VerifyEnvelopeFailClosed(t *testing.T) {
 		noVerifier := NewExecutor(nil, nil)
 		_, err := noVerifier.VerifyEnvelope(envBytes, sig)
 		assert.Error(t, err, "an executor with no verifier must refuse, not pass")
+	})
+}
+
+// TestExecutor_VerifyEnvelope_EnforcesTargetBinding is the PMSEC-001 regression:
+// verification is an AUTHORIZATION step, not just an authenticity check. A
+// compromised gateway/relay that captures device A's validly-signed (same-CA)
+// envelope and routes it to device B must be refused, even though the signature
+// is genuine — because the SIGNED target_device_id does not match B. Fail closed
+// on an empty target and on an agent that does not know its own device id.
+func TestExecutor_VerifyEnvelope_EnforcesTargetBinding(t *testing.T) {
+	exec, signer := testVerifierAndSigner(t) // exec device id == testDeviceID
+
+	shell := func(id, target string) *pb.SignedActionEnvelope {
+		return &pb.SignedActionEnvelope{
+			ActionId:       &pb.ActionId{Value: id},
+			ActionType:     pb.ActionType_ACTION_TYPE_SHELL,
+			TargetDeviceId: target,
+			Params:         &pb.SignedActionEnvelope_Shell{Shell: &pb.ShellParams{Script: "echo hi", RunAsRoot: true}},
+		}
+	}
+	signRaw := func(env *pb.SignedActionEnvelope) (b, sig []byte) {
+		var err error
+		b, err = verify.MarshalEnvelope(env) // no defaulting: sign exactly what's given
+		require.NoError(t, err)
+		sig, err = signer.Sign(b)
+		require.NoError(t, err)
+		return b, sig
+	}
+
+	t.Run("matching target verifies", func(t *testing.T) {
+		b, sig := signRaw(shell("01HMATCH", testDeviceID))
+		got, err := exec.VerifyEnvelope(b, sig)
+		require.NoError(t, err)
+		require.Equal(t, testDeviceID, got.GetTargetDeviceId())
+	})
+
+	t.Run("cross-device target is refused", func(t *testing.T) {
+		// Genuine signature (same CA), only the target differs — the exact
+		// compromised-relay cross-device replay PMSEC-001 describes.
+		b, sig := signRaw(shell("01HOTHERDEV", "01OTHERDEVICE0000000000B"))
+		_, err := exec.VerifyEnvelope(b, sig)
+		require.Error(t, err, "a validly-signed envelope for a DIFFERENT device must be refused")
+		require.Contains(t, err.Error(), "target device")
+	})
+
+	t.Run("empty signed target is refused (fail closed)", func(t *testing.T) {
+		b, sig := signRaw(shell("01HNOTARGET", ""))
+		_, err := exec.VerifyEnvelope(b, sig)
+		require.Error(t, err, "an envelope that binds no target device must be refused")
+	})
+
+	t.Run("agent without a configured device id fails closed", func(t *testing.T) {
+		caPEM, key, _ := cryptotest.GenCA(t, "test-ca-2")
+		verifier, err := verify.NewActionVerifier(caPEM)
+		require.NoError(t, err)
+		noID := NewExecutor(verifier, nil) // deliberately no SetDeviceID
+		s := verify.NewActionSigner(key)
+		b, err := verify.MarshalEnvelope(shell("01HNOID", testDeviceID))
+		require.NoError(t, err)
+		sig, err := s.Sign(b)
+		require.NoError(t, err)
+		_, verr := noID.VerifyEnvelope(b, sig)
+		require.Error(t, verr, "an agent that does not know its own device id must refuse to execute")
 	})
 }
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -298,6 +298,22 @@ func (e *Executor) VerifyEnvelope(envelopeBytes, signature []byte) (*pb.SignedAc
 	if err := proto.Unmarshal(envelopeBytes, env); err != nil {
 		return nil, fmt.Errorf("unmarshal verified envelope: %w", err)
 	}
+	// Enforce the SIGNED target binding. target_device_id exists precisely to
+	// stop a compromised gateway/relay from replaying one device's validly-signed
+	// (CA-covered) action onto another device that trusts the same CA
+	// (PMSEC-001). Verification alone proves the bytes are authentic, not that
+	// this device is their intended target — so make verification an
+	// authorization step. Fail closed: refuse if we do not know our own device id
+	// or the envelope targets a different (or empty) device. The control server's
+	// single signing seam (actionparams.BuildAndSignEnvelope) always binds the
+	// target device, so a legitimate envelope for this device always matches.
+	expected := e.getDeviceID()
+	if expected == "" {
+		return nil, fmt.Errorf("refusing to execute: agent device id not configured")
+	}
+	if target := env.GetTargetDeviceId(); target != expected {
+		return nil, fmt.Errorf("refusing to execute: action target device %q is not this device %q", target, expected)
+	}
 	return env, nil
 }
 

--- a/internal/handler/stream_rpc_verify_test.go
+++ b/internal/handler/stream_rpc_verify_test.go
@@ -50,7 +50,9 @@ func verifierHandler(t *testing.T, caPEM []byte, oq osqueryRunner) *Handler {
 	t.Helper()
 	verifier, err := verify.NewActionVerifier(caPEM)
 	require.NoError(t, err)
-	h := NewHandler(slog.Default(), executor.NewExecutor(verifier, nil), nil, nil, make(chan struct{}, 1))
+	exec := executor.NewExecutor(verifier, nil)
+	exec.SetDeviceID(testDeviceID)
+	h := NewHandler(slog.Default(), exec, nil, nil, make(chan struct{}, 1))
 	if oq != nil {
 		h.setOsqueryForTest(oq)
 	}

--- a/internal/handler/sync_verify_test.go
+++ b/internal/handler/sync_verify_test.go
@@ -28,8 +28,17 @@ func testCAAndSigner(t *testing.T) ([]byte, *verify.ActionSigner) {
 // those bytes with the CA signer, returning the bytes the agent receives
 // (envelope) and the CA signature over them. The agent MUST verify over,
 // and unmarshal-then-execute, THESE SAME bytes (sdk#82).
+// testDeviceID is the device id the verifier handlers are configured with, and
+// the default target every signed test envelope is bound to (see signEnvelope),
+// so the PMSEC-001 target check passes. Cross-device tests set TargetDeviceId
+// explicitly.
+const testDeviceID = "01TESTDEVICE0000000000000A"
+
 func signEnvelope(t *testing.T, signer *verify.ActionSigner, env *pb.SignedActionEnvelope) (envelope []byte, signature []byte) {
 	t.Helper()
+	if env.GetTargetDeviceId() == "" {
+		env.TargetDeviceId = testDeviceID
+	}
 	envBytes, err := verify.MarshalEnvelope(env)
 	require.NoError(t, err)
 	sig, err := signer.Sign(envBytes)
@@ -45,7 +54,9 @@ func newVerifierHandler(t *testing.T, caPEM []byte) (*Handler, chan struct{}) {
 	verifier, err := verify.NewActionVerifier(caPEM)
 	require.NoError(t, err)
 	syncTrigger := make(chan struct{}, 1)
-	h := NewHandler(slog.Default(), executor.NewExecutor(verifier, nil), nil, nil, syncTrigger)
+	exec := executor.NewExecutor(verifier, nil)
+	exec.SetDeviceID(testDeviceID)
+	h := NewHandler(slog.Default(), exec, nil, nil, syncTrigger)
 	return h, syncTrigger
 }
 
@@ -160,6 +171,28 @@ func TestOnAction_ParamsTamperRefused(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, pb.ExecutionStatus_EXECUTION_STATUS_FAILED, res.Status,
 		"tampered envelope bytes must be refused before any execution")
+}
+
+// TestOnAction_CrossDeviceEnvelopeRefused is the push-path half of the PMSEC-001
+// regression: a validly-signed (same-CA) envelope whose target_device_id is a
+// DIFFERENT device — the compromised-relay cross-device replay — must be refused
+// end-to-end (FAILED, nothing executes), even though the signature is genuine.
+func TestOnAction_CrossDeviceEnvelopeRefused(t *testing.T) {
+	caPEM, signer := testCAAndSigner(t)
+	h, _ := newVerifierHandler(t, caPEM) // handler device id == testDeviceID
+
+	env := &pb.SignedActionEnvelope{
+		ActionId:       &pb.ActionId{Value: "01HXDEV"},
+		ActionType:     pb.ActionType_ACTION_TYPE_SHELL,
+		TargetDeviceId: "01OTHERDEVICE0000000000B", // NOT this device
+		Params:         &pb.SignedActionEnvelope_Shell{Shell: &pb.ShellParams{Script: "true", RunAsRoot: true}},
+	}
+	envBytes, sig := signEnvelope(t, signer, env) // target set, so not defaulted
+
+	res, err := h.OnAction(context.Background(), envBytes, sig)
+	require.NoError(t, err)
+	assert.Equal(t, pb.ExecutionStatus_EXECUTION_STATUS_FAILED, res.Status,
+		"a validly-signed envelope for a DIFFERENT device must be refused, not executed")
 }
 
 // TestOnAction_NoVerifierIsFailClosed pins that an executor with no verifier


### PR DESCRIPTION
## Enforce the signed `target_device_id` binding (PMSEC-001)

A Codex security scan reported, and I independently verified against this exact commit, that the agent verified an action's CA signature but **never checked `SignedActionEnvelope.target_device_id`** against its own device id.

### The flaw
From the explicitly-modelled **compromised gateway/relay** position (no CA key needed), a validly-signed root action for device A could be routed unchanged to device B (both trust the same signing CA), and B would execute it. The `target_device_id` field exists precisely to prevent this (`actions.proto`: "binds the action to one device — no cross-device replay"), and the executor already knows its own id (`SetDeviceID` from enrollment creds, `main.go:280`), but `VerifyEnvelope` did signature+unmarshal only, and none of its three callers (push `OnActionWithStreaming`, scheduler `verifyAndExecute`, `revertAction`) compared the target. Zero non-test references to the field existed.

### The fix
Make verification an **authorization** step. After signature + unmarshal, `VerifyEnvelope` now refuses when the agent's device id is unset (fail closed) or the envelope's `target_device_id` does not match it. This is the single seam every execution path routes through, so all are covered at one choke point. Safe because the control server's sole signing seam (`BuildAndSignEnvelope`) always binds the real target device (verified: all 5 call sites pass a real device id), so a legitimate envelope for this device always matches.

### Tests
- **Executor seam** (`TestExecutor_VerifyEnvelope_EnforcesTargetBinding`): matching → verifies; cross-device (genuine same-CA signature, different target) → refused; empty target → refused; unconfigured-agent → refused. **Red-checked** — with the guard disabled, cross-device/empty/unconfigured all execute.
- **Push path** (`TestOnAction_CrossDeviceEnvelopeRefused`): a cross-device envelope through `OnAction` → `FAILED`, nothing executes.
- Test helpers now configure a device id and default the signed target, so the existing envelope tests needed no per-site edits.

The scheduler paths (`verifyAndExecute`, `revertAction`) call the same `VerifyEnvelope` seam, so they inherit the check.

Full agent suite green; `gofmt`/`vet` clean; local CodeRabbit: no findings.

*(Companion finding PMSEC-002 — unsigned sync orchestration metadata — is being handled as a separate signed-sync-manifest spec.)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Signed actions are now restricted to their intended device.
  * Envelopes with missing, mismatched, or unconfigured device targets are rejected.
  * Prevented valid signed actions from being replayed on another device.

* **Bug Fixes**
  * Handlers now correctly enforce device-specific authorization before executing actions.

* **Tests**
  * Added coverage for matching targets, cross-device replay attempts, empty targets, and missing device configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->