### PR TITLE
fix: enforce signed target_device_id == self on the four non-action stream-RPCs (PMSEC-001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ The agent prevents actions from modifying its own infrastructure:
 
 ### Root Stream-RPC Verification (WS4)
 
-<!-- docref: begin src=internal/executor/executor.go#Executor.VerifyEnvelope:93e0873f,internal/handler/handler.go#Handler.OnRequestInventory:398d6189 -->
+<!-- docref: begin src=internal/executor/executor.go#Executor.VerifyEnvelope:7cba0124,internal/executor/verify_stream_rpc.go#Executor.enforceTargetDevice:f0a564e3,internal/handler/handler.go#Handler.OnRequestInventory:398d6189 -->
 The agent runs as root, and the Gateway/Valkey relay is **untrusted for
 origination**. So beyond signed actions, the four root stream-RPCs are verified
 fail-closed against the CA certificate **before any root work**:
@@ -667,11 +667,14 @@ one — the CA cert is required at startup). All inventory collection is
 server-initiated over this signed path (manual refresh and the spec-22
 server-side scheduler); the agent has no periodic collector of its own.
 
-Signed **actions** are additionally bound to the target device: `VerifyEnvelope`
-refuses an envelope whose signed `target_device_id` is not this agent's own id
-(and refuses when the agent's id is unset), so a compromised relay cannot replay
-one device's validly-signed, root-capable action onto another device that trusts
-the same CA (PMSEC-001).
+Every CA-signed surface — the signed **action** envelope and all four
+stream-RPCs above — is additionally bound to the target device through the
+shared `enforceTargetDevice` check: it refuses a message whose signed
+`target_device_id` is not this agent's own id (and refuses when the agent's id
+is unset), so a compromised relay cannot replay one device's validly-signed,
+root-capable message — an action, an osquery, a journalctl read, or the
+irreversible LUKS slot-7 wipe — onto another device that trusts the same CA
+(PMSEC-001).
 <!-- docref: end -->
 
 ### Package / Repository Argument Hardening (WS8)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.12
 
 require (
 	connectrpc.com/connect v1.18.1
-	github.com/manchtools/power-manage-sdk v0.5.4-0.20260714190355-330307f5e06e
+	github.com/manchtools/power-manage-sdk v0.5.4-0.20260717205410-7a6ce34c9fcc
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pressly/goose/v3 v3.26.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/manchtools/power-manage-sdk v0.5.4-0.20260714185552-e56ceaaeb2bd h1:z
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260714185552-e56ceaaeb2bd/go.mod h1:NQpkHZSQTJzGcQsdKsuE+EeQt7juWXVaN7b/i7NyjOQ=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260714190355-330307f5e06e h1:/dqrOB9xUQQmYAeQfBkxq7MtzAQG5G3TQTcTp1y+AS8=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260714190355-330307f5e06e/go.mod h1:NQpkHZSQTJzGcQsdKsuE+EeQt7juWXVaN7b/i7NyjOQ=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260717205410-7a6ce34c9fcc h1:6DHBeJEgg7abtTi6IRhPsubZIC476NZfxR+qZ0XHLRM=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260717205410-7a6ce34c9fcc/go.mod h1:NQpkHZSQTJzGcQsdKsuE+EeQt7juWXVaN7b/i7NyjOQ=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -303,16 +303,12 @@ func (e *Executor) VerifyEnvelope(envelopeBytes, signature []byte) (*pb.SignedAc
 	// (CA-covered) action onto another device that trusts the same CA
 	// (PMSEC-001). Verification alone proves the bytes are authentic, not that
 	// this device is their intended target — so make verification an
-	// authorization step. Fail closed: refuse if we do not know our own device id
-	// or the envelope targets a different (or empty) device. The control server's
-	// single signing seam (actionparams.BuildAndSignEnvelope) always binds the
-	// target device, so a legitimate envelope for this device always matches.
-	expected := e.getDeviceID()
-	if expected == "" {
-		return nil, fmt.Errorf("refusing to execute: agent device id not configured")
-	}
-	if target := env.GetTargetDeviceId(); target != expected {
-		return nil, fmt.Errorf("refusing to execute: action target device %q is not this device %q", target, expected)
+	// authorization step. The control server's single signing seam
+	// (actionparams.BuildAndSignEnvelope) always binds the target device, so a
+	// legitimate envelope for this device always matches. The same helper guards
+	// the four non-action stream-RPC surfaces (see enforceTargetDevice).
+	if err := e.enforceTargetDevice(env.GetTargetDeviceId()); err != nil {
+		return nil, err
 	}
 	return env, nil
 }

--- a/internal/executor/verify_stream_rpc.go
+++ b/internal/executor/verify_stream_rpc.go
@@ -21,7 +21,31 @@ import (
 // hole. The handler treats any error here as a hard refusal and never runs the
 // request.
 
-// VerifyOSQuery verifies the CA signature binding an OSQuery (table OR raw_sql).
+// enforceTargetDevice turns signature verification into an authorization step:
+// the signed target_device_id must name THIS device. The CA signature proves a
+// message is authentic, NOT that this device is its intended recipient — so a
+// compromised gateway/relay can take one device's validly-signed message and
+// forward it to another device that trusts the same CA. Binding + checking the
+// target closes that cross-device replay (PMSEC-001). It is the same guarantee
+// SignedActionEnvelope.target_device_id gives actions (see VerifyEnvelope),
+// extended to the four non-action stream-RPC surfaces.
+//
+// Fail closed: refuse if we do not know our own device id, or the message
+// targets a different (or empty) device. The message string contains "target
+// device" — asserted by execute_verified_envelope_test.go.
+func (e *Executor) enforceTargetDevice(target string) error {
+	expected := e.getDeviceID()
+	if expected == "" {
+		return fmt.Errorf("refusing: agent device id not configured")
+	}
+	if target != expected {
+		return fmt.Errorf("refusing: signed target device %q is not this device %q", target, expected)
+	}
+	return nil
+}
+
+// VerifyOSQuery verifies the CA signature binding an OSQuery (table OR raw_sql)
+// and that it is targeted at this device.
 func (e *Executor) VerifyOSQuery(q *pb.OSQuery) error {
 	if e.verifier == nil {
 		return fmt.Errorf("no verifier configured; refusing unverified osquery")
@@ -30,10 +54,14 @@ func (e *Executor) VerifyOSQuery(q *pb.OSQuery) error {
 	if err != nil {
 		return err
 	}
-	return e.verifier.VerifyDomain(verify.OSQuerySignatureDomain, canonical, q.GetSignature())
+	if err := e.verifier.VerifyDomain(verify.OSQuerySignatureDomain, canonical, q.GetSignature()); err != nil {
+		return err
+	}
+	return e.enforceTargetDevice(q.GetTargetDeviceId())
 }
 
-// VerifyLogQuery verifies the CA signature binding a LogQuery.
+// VerifyLogQuery verifies the CA signature binding a LogQuery and that it is
+// targeted at this device.
 func (e *Executor) VerifyLogQuery(q *pb.LogQuery) error {
 	if e.verifier == nil {
 		return fmt.Errorf("no verifier configured; refusing unverified log query")
@@ -42,11 +70,15 @@ func (e *Executor) VerifyLogQuery(q *pb.LogQuery) error {
 	if err != nil {
 		return err
 	}
-	return e.verifier.VerifyDomain(verify.LogQuerySignatureDomain, canonical, q.GetSignature())
+	if err := e.verifier.VerifyDomain(verify.LogQuerySignatureDomain, canonical, q.GetSignature()); err != nil {
+		return err
+	}
+	return e.enforceTargetDevice(q.GetTargetDeviceId())
 }
 
 // VerifyRevokeLuksDeviceKey verifies the CA signature binding a
-// RevokeLuksDeviceKey before the destructive, irreversible slot-7 wipe.
+// RevokeLuksDeviceKey and that it is targeted at this device, before the
+// destructive, irreversible slot-7 wipe.
 func (e *Executor) VerifyRevokeLuksDeviceKey(m *pb.RevokeLuksDeviceKey) error {
 	if e.verifier == nil {
 		return fmt.Errorf("no verifier configured; refusing unverified LUKS revoke")
@@ -55,11 +87,15 @@ func (e *Executor) VerifyRevokeLuksDeviceKey(m *pb.RevokeLuksDeviceKey) error {
 	if err != nil {
 		return err
 	}
-	return e.verifier.VerifyDomain(verify.LuksRevokeSignatureDomain, canonical, m.GetSignature())
+	if err := e.verifier.VerifyDomain(verify.LuksRevokeSignatureDomain, canonical, m.GetSignature()); err != nil {
+		return err
+	}
+	return e.enforceTargetDevice(m.GetTargetDeviceId())
 }
 
 // VerifyRequestInventory verifies the CA signature binding a server-originated
-// RequestInventory. (Agent-initiated periodic collection never reaches this.)
+// RequestInventory and that it is targeted at this device. (Agent-initiated
+// periodic collection never reaches this.)
 func (e *Executor) VerifyRequestInventory(m *pb.RequestInventory) error {
 	if e.verifier == nil {
 		return fmt.Errorf("no verifier configured; refusing unverified inventory request")
@@ -68,5 +104,8 @@ func (e *Executor) VerifyRequestInventory(m *pb.RequestInventory) error {
 	if err != nil {
 		return err
 	}
-	return e.verifier.VerifyDomain(verify.InventorySignatureDomain, canonical, m.GetSignature())
+	if err := e.verifier.VerifyDomain(verify.InventorySignatureDomain, canonical, m.GetSignature()); err != nil {
+		return err
+	}
+	return e.enforceTargetDevice(m.GetTargetDeviceId())
 }

--- a/internal/handler/stream_rpc_verify_test.go
+++ b/internal/handler/stream_rpc_verify_test.go
@@ -70,9 +70,16 @@ func noVerifierHandler(t *testing.T, oq osqueryRunner) *Handler {
 }
 
 // signOSQuery / signLogQuery / signRevoke / signInventory set the message's
-// signature to a valid control-server signature over its canonical bytes.
+// signature to a valid control-server signature over its canonical bytes. Each
+// defaults target_device_id to testDeviceID (this device) when the caller left
+// it unset, so a happy-path message is targeted at the verifying agent and the
+// PMSEC-001 target check passes — mirroring the action-envelope test helpers.
+// A cross-device test sets target_device_id to a DIFFERENT device explicitly.
 func signOSQuery(t *testing.T, s *verify.ActionSigner, q *pb.OSQuery) {
 	t.Helper()
+	if q.GetTargetDeviceId() == "" {
+		q.TargetDeviceId = testDeviceID
+	}
 	c, err := verify.OSQueryCanonical(q)
 	require.NoError(t, err)
 	sig, err := s.SignDomain(verify.OSQuerySignatureDomain, c)
@@ -82,6 +89,9 @@ func signOSQuery(t *testing.T, s *verify.ActionSigner, q *pb.OSQuery) {
 
 func signLogQuery(t *testing.T, s *verify.ActionSigner, q *pb.LogQuery) {
 	t.Helper()
+	if q.GetTargetDeviceId() == "" {
+		q.TargetDeviceId = testDeviceID
+	}
 	c, err := verify.LogQueryCanonical(q)
 	require.NoError(t, err)
 	sig, err := s.SignDomain(verify.LogQuerySignatureDomain, c)
@@ -91,6 +101,9 @@ func signLogQuery(t *testing.T, s *verify.ActionSigner, q *pb.LogQuery) {
 
 func signRevoke(t *testing.T, s *verify.ActionSigner, m *pb.RevokeLuksDeviceKey) {
 	t.Helper()
+	if m.GetTargetDeviceId() == "" {
+		m.TargetDeviceId = testDeviceID
+	}
 	c, err := verify.RevokeLuksDeviceKeyCanonical(m)
 	require.NoError(t, err)
 	sig, err := s.SignDomain(verify.LuksRevokeSignatureDomain, c)
@@ -100,6 +113,9 @@ func signRevoke(t *testing.T, s *verify.ActionSigner, m *pb.RevokeLuksDeviceKey)
 
 func signInventory(t *testing.T, s *verify.ActionSigner, m *pb.RequestInventory) {
 	t.Helper()
+	if m.GetTargetDeviceId() == "" {
+		m.TargetDeviceId = testDeviceID
+	}
 	c, err := verify.RequestInventoryCanonical(m)
 	require.NoError(t, err)
 	sig, err := s.SignDomain(verify.InventorySignatureDomain, c)
@@ -579,6 +595,71 @@ func TestOnRequestInventory_NoVerifierFailsClosed(t *testing.T) {
 	assert.Empty(t, oq.tableCalls)
 }
 
+// ---------------------------------------------------------------------------
+// Cross-device replay (H3 / PMSEC-001) — the agent-side enforcement half
+// ---------------------------------------------------------------------------
+
+// TestStreamRPC_RejectsCrossDeviceReplay is the H3 handler-level regression: on
+// every non-action stream-RPC surface, a message VALIDLY signed but bound to a
+// DIFFERENT device must be refused, and the root work (osquery, journalctl, the
+// destructive LUKS slot-7 wipe) must never run. The signature is authentic
+// (same CA), so ONLY the target==self check stops it — before target_device_id
+// was bound into the signed bytes and checked here, a compromised gateway
+// relaying device-A's signed message to this device would have executed it. The
+// canonical-bytes half of this defense is proven in the sdk
+// (verify.TestCrossDeviceReplay_RejectedAllSurfaces); this is the enforcement
+// half that turns the binding into a refusal.
+func TestStreamRPC_RejectsCrossDeviceReplay(t *testing.T) {
+	caPEM, signer := testCAAndSigner(t)
+	const otherDeviceID = "01OTHERDEVICE0000000000B" // NOT testDeviceID
+
+	t.Run("osquery", func(t *testing.T) {
+		oq := &fakeOsquery{}
+		h := verifierHandler(t, caPEM, oq)
+		q := &pb.OSQuery{QueryId: validULID(t), Table: "processes", TargetDeviceId: otherDeviceID}
+		signOSQuery(t, signer, q) // valid signature, but targets another device
+		res, err := h.OnQuery(context.Background(), q)
+		require.NoError(t, err)
+		assert.False(t, res.Success, "an osquery targeted at another device must be refused")
+		assert.Contains(t, res.Error, "refusing")
+		assert.Equal(t, 0, oq.queryCalls, "cross-device osquery must NOT reach osquery")
+	})
+
+	t.Run("logquery", func(t *testing.T) {
+		calls := fakeJournalctl(t)
+		h := verifierHandler(t, caPEM, nil)
+		q := &pb.LogQuery{QueryId: validULID(t), Unit: "nginx.service", Lines: 10, TargetDeviceId: otherDeviceID}
+		signLogQuery(t, signer, q)
+		res, err := h.OnLogQuery(context.Background(), q)
+		require.NoError(t, err)
+		assert.False(t, res.Success, "a log query targeted at another device must be refused")
+		assert.Contains(t, res.Error, "refusing")
+		assert.Empty(t, *calls, "cross-device log query must NOT invoke journalctl")
+	})
+
+	t.Run("luks_revoke", func(t *testing.T) {
+		h := verifierHandler(t, caPEM, nil)
+		m := &pb.RevokeLuksDeviceKey{ActionId: "01J0R00000000000000000000R", TargetDeviceId: otherDeviceID}
+		signRevoke(t, signer, m)
+		ok, msg := h.OnRevokeLuksDeviceKey(context.Background(), m)
+		assert.False(t, ok, "a revoke targeted at another device must be refused")
+		assert.Contains(t, msg, "refusing",
+			"a cross-device LUKS wipe must be refused at the gate, never reach the executor")
+		assert.NotContains(t, msg, "agent store not configured",
+			"a cross-device revoke must NOT enter the wipe path")
+	})
+
+	t.Run("inventory", func(t *testing.T) {
+		oq := &fakeOsquery{}
+		h := verifierHandler(t, caPEM, oq)
+		m := &pb.RequestInventory{QueryId: validULID(t), TargetDeviceId: otherDeviceID}
+		signInventory(t, signer, m)
+		inv := h.OnRequestInventory(context.Background(), m)
+		assert.Nil(t, inv, "a cross-device inventory request must return nil")
+		assert.Empty(t, oq.tableCalls, "cross-device inventory must NOT query osquery")
+	})
+}
+
 // TestCollectInventory_TableSetIsHardcoded pins that the osquery tables queried
 // are EXACTLY the hardcoded union of inventoryCoreTables + inventoryPackageTables
 // (self-discovering from the package vars), and that RequestInventory carries no
@@ -611,13 +692,16 @@ func TestCollectInventory_TableSetIsHardcoded(t *testing.T) {
 	}
 
 	// RequestInventory must carry NO field that could smuggle a table name: its
-	// fields are exactly query_id + signature. A new field fails here, forcing a
-	// review of whether it could carry a table name.
+	// fields are exactly query_id + signature + target_device_id. A new field
+	// fails here, forcing a review of whether it could carry a table name.
+	// target_device_id (PMSEC-001) is a device binding checked against this
+	// agent's own id — it never selects a table, so it is safe here; the
+	// hardcoded table set above remains the sole source of queried tables.
 	fields := (&pb.RequestInventory{}).ProtoReflect().Descriptor().Fields()
 	names := map[string]bool{}
 	for i := 0; i < fields.Len(); i++ {
 		names[string(fields.Get(i).Name())] = true
 	}
-	assert.Equal(t, map[string]bool{"query_id": true, "signature": true}, names,
+	assert.Equal(t, map[string]bool{"query_id": true, "signature": true, "target_device_id": true}, names,
 		"RequestInventory gained a field — confirm it cannot carry a table name")
 }


### PR DESCRIPTION
## Summary

Security fix (audit finding **H3 / PMSEC-001**), agent half — the enforcement point. The four root stream-RPCs (osquery, log query, LUKS revoke, server-originated inventory) verify a per-surface CA signature (WS4), but the signature proved only **authenticity**, not that this device was the intended recipient. A compromised gateway relaying for multiple devices could forward one device's validly-signed message to another device that trusts the same CA — a cross-device replay, most severely of the destructive, irreversible **LUKS slot-7 wipe**.

The action envelope already closed this in `VerifyEnvelope` via `SignedActionEnvelope.target_device_id`; these four sibling surfaces were the gap.

## Change

- Add `enforceTargetDevice(target)`: the signed `target_device_id` must name **this** device, fail-closed if the agent does not know its own id or the target mismatches. Route `VerifyEnvelope` (the action path) through the same helper, so all **five** CA-signed surfaces share one enforcement definition.
- Each `Verify*` now checks `target == self` after signature verification.
- Bump the sdk pin to the merged proto (adds `target_device_id` + auto-binds it in the canonical bytes).

The sign helpers in the test default `target_device_id` to this device (mirroring the action-envelope test helpers), so every happy-path message stays valid.

## Tests (regression)

`stream_rpc_verify_test.go` → **`TestStreamRPC_RejectsCrossDeviceReplay`**: on every surface, a message *validly signed for a different device* is refused and the root work (osquery, journalctl, LUKS wipe) never runs.

**Red-verified** by neutralizing `enforceTargetDevice` — all four stream surfaces **and** the action-envelope path fail, confirming the shared helper is load-bearing everywhere.

Depends on manchtools/power-manage-sdk#325 (merged).
