### PR TITLE
fix(crl): cancel the live gateway session when its peer is revoked or the CRL expires (spec 31 AC 11)

### DIFF
--- a/cmd/power-manage-agent/runtime.go
+++ b/cmd/power-manage-agent/runtime.go
@@ -128,6 +128,13 @@ func runAgent(ctx context.Context, credStore *credentials.Store, creds *credenti
 		// Create a child context for this connection session
 		sessionCtx, cancelSession := context.WithCancel(ctx)
 
+		// Register this session's canceler with the CRL cache so a mid-stream
+		// revocation of the connected gateway (learned on a later refresh) — or the
+		// cached CRL expiring while still connected — tears the session down instead
+		// of streaming to a revoked gateway until natural disconnect (spec 31 AC 11).
+		// The peer fingerprint is recorded by crlCache.Check at handshake.
+		crlCache.WatchSession(cancelSession)
+
 		// Wire LUKS key store to the current client for this connection session
 		h.Executor().SetLuksKeyStore(&clientLuksKeyStore{client: client})
 
@@ -208,6 +215,7 @@ func runAgent(ctx context.Context, credStore *credentials.Store, creds *credenti
 
 		// Stop the goroutines and clear connection-dependent state
 		cancelSession()
+		crlCache.WatchSession(nil) // unregister; next iteration re-registers the new session
 		h.Executor().SetLuksKeyStore(nil)
 		if luksDaemon != nil {
 			luksDaemon.ClearSession()

--- a/cmd/power-manage-agent/runtime.go
+++ b/cmd/power-manage-agent/runtime.go
@@ -115,7 +115,21 @@ func runAgent(ctx context.Context, credStore *credentials.Store, creds *credenti
 				"gateway", creds.GatewayAddr, "error", err)
 			os.Exit(1)
 		}
-		mtlsOpt, err := sdk.WithMTLSFromPEMAndRevocationCheck(creds.Certificate, creds.PrivateKey, creds.CACert, crlCache.Check)
+		// Create a child context for this connection session
+		sessionCtx, cancelSession := context.WithCancel(ctx)
+
+		// Register this session's canceler with the CRL cache so a mid-stream
+		// revocation of the connected gateway (learned on a later refresh) — or the
+		// cached CRL expiring while still connected — tears the session down instead
+		// of streaming to a revoked gateway until natural disconnect (spec 31 AC 11).
+		// The returned token binds this session's handshake gate (below) and its
+		// teardown to THIS registration: a previous client's transport can still
+		// complete an in-flight dial handshake after we registered, and untokened
+		// it would overwrite this session's recorded peer fingerprint.
+		crlSession := crlCache.WatchSession(cancelSession)
+
+		mtlsOpt, err := sdk.WithMTLSFromPEMAndRevocationCheck(creds.Certificate, creds.PrivateKey, creds.CACert,
+			func(fingerprint string) error { return crlCache.CheckSession(crlSession, fingerprint) })
 		if err != nil {
 			logger.Error("failed to configure mTLS", "error", err)
 			os.Exit(1)
@@ -124,16 +138,6 @@ func runAgent(ctx context.Context, credStore *credentials.Store, creds *credenti
 			mtlsOpt,
 			sdk.WithAuth(creds.DeviceID, ""),
 		)
-
-		// Create a child context for this connection session
-		sessionCtx, cancelSession := context.WithCancel(ctx)
-
-		// Register this session's canceler with the CRL cache so a mid-stream
-		// revocation of the connected gateway (learned on a later refresh) — or the
-		// cached CRL expiring while still connected — tears the session down instead
-		// of streaming to a revoked gateway until natural disconnect (spec 31 AC 11).
-		// The peer fingerprint is recorded by crlCache.Check at handshake.
-		crlCache.WatchSession(cancelSession)
 
 		// Wire LUKS key store to the current client for this connection session
 		h.Executor().SetLuksKeyStore(&clientLuksKeyStore{client: client})
@@ -215,7 +219,7 @@ func runAgent(ctx context.Context, credStore *credentials.Store, creds *credenti
 
 		// Stop the goroutines and clear connection-dependent state
 		cancelSession()
-		crlCache.WatchSession(nil) // unregister; next iteration re-registers the new session
+		crlCache.UnwatchSession(crlSession)
 		h.Executor().SetLuksKeyStore(nil)
 		if luksDaemon != nil {
 			luksDaemon.ClearSession()

--- a/internal/crl/crl.go
+++ b/internal/crl/crl.go
@@ -44,6 +44,16 @@ type Cache struct {
 	revoked  map[string]struct{}
 	notAfter time.Time
 	loaded   bool
+
+	// Live-session revocation (AC 11): the leaf fingerprint the currently
+	// connected gateway authenticated with (recorded by Check on a successful
+	// handshake) and the canceler that tears that session down. A later refresh
+	// that newly revokes watchedFP, or the cached list ageing past notAfter while
+	// the session is still up, cancels the session so it re-handshakes through the
+	// (now-failing) Check — handshake-only revocation would otherwise let an
+	// in-flight stream to a revoked gateway run until natural disconnect.
+	watchedFP     string
+	cancelSession context.CancelFunc
 }
 
 // New builds a Cache. A nil logger is replaced with the default logger; a nil
@@ -64,8 +74,8 @@ func New(fetch FetchFunc, logger *slog.Logger, opts ...Option) *Cache {
 // every gateway TLS handshake with the gateway's hex SHA-256 leaf fingerprint.
 // A non-nil return fails the handshake.
 func (c *Cache) Check(fingerprint string) error {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	if !c.loaded {
 		return errors.New("gateway CRL not yet loaded — refusing until the first list is fetched")
@@ -76,7 +86,58 @@ func (c *Cache) Check(fingerprint string) error {
 	if _, ok := c.revoked[fingerprint]; ok {
 		return fmt.Errorf("gateway certificate %s is revoked", fingerprint)
 	}
+	// Approved: this is the peer of the live session. Record it (under the write
+	// lock) so a later refresh/expiry that condemns it can cancel the session
+	// (AC 11). Only meaningful once WatchSession has registered a canceler.
+	c.watchedFP = fingerprint
 	return nil
+}
+
+// WatchSession registers the active gateway session's context canceler so a
+// later CRL refresh that revokes the connected gateway — or the cached list
+// expiring while the session is still up — can tear the session down (AC 11).
+// runAgent calls this for each new connection; the peer fingerprint is filled in
+// by Check when that connection's handshake completes. A new registration
+// forgets the prior peer so a refresh in the gap between sessions cannot cancel
+// the wrong one. Pass nil to unregister when a session ends.
+func (c *Cache) WatchSession(cancel context.CancelFunc) {
+	c.mu.Lock()
+	c.cancelSession = cancel
+	c.watchedFP = ""
+	c.mu.Unlock()
+}
+
+// enforceSessionRevocation cancels the live gateway session when its
+// authenticated peer is now revoked, or the cached CRL has aged past not_after
+// while the session is still up (AC 11 — fail closed for the in-flight session,
+// not only at the next handshake). Called after every refresh attempt and on the
+// staleness ticker; a no-op until a session is registered and its handshake has
+// recorded a peer fingerprint. Cancels at most once per registration — the
+// session tears down and re-registers on reconnect.
+func (c *Cache) enforceSessionRevocation() {
+	c.mu.Lock()
+	cancel := c.cancelSession
+	fp := c.watchedFP
+	reason := ""
+	if cancel != nil && fp != "" {
+		_, revoked := c.revoked[fp]
+		switch {
+		case c.loaded && !c.now().Before(c.notAfter):
+			reason = "cached gateway CRL expired while the session was live"
+		case revoked:
+			reason = "connected gateway certificate was revoked"
+		}
+	}
+	if reason != "" {
+		c.cancelSession = nil
+		c.watchedFP = ""
+	}
+	c.mu.Unlock()
+
+	if reason != "" {
+		c.logger.Warn("cancelling live gateway session (spec 31 AC 11): "+reason, "fingerprint", fp)
+		cancel()
+	}
 }
 
 // Refresh fetches a new snapshot and atomically swaps it in. On fetch failure
@@ -105,6 +166,10 @@ func (c *Cache) Refresh(ctx context.Context) error {
 	c.notAfter = snap.NotAfter
 	c.loaded = true
 	c.mu.Unlock()
+
+	// A refresh that newly revokes the connected gateway must cancel the live
+	// session, not wait for its next handshake (AC 11).
+	c.enforceSessionRevocation()
 	return nil
 }
 
@@ -122,6 +187,10 @@ func (c *Cache) Run(ctx context.Context, interval time.Duration) {
 		case <-t.C:
 			if err := c.Refresh(ctx); err != nil {
 				c.logger.Warn("gateway CRL refresh failed; using last snapshot until not_after", "error", err)
+				// A failed refresh may have let the cached list age past not_after
+				// while a session is live; enforce staleness here too (AC 11/12).
+				// Refresh already enforced on its success path.
+				c.enforceSessionRevocation()
 			}
 		}
 	}

--- a/internal/crl/crl.go
+++ b/internal/crl/crl.go
@@ -46,12 +46,18 @@ type Cache struct {
 	loaded   bool
 
 	// Live-session revocation (AC 11): the leaf fingerprint the currently
-	// connected gateway authenticated with (recorded by Check on a successful
-	// handshake) and the canceler that tears that session down. A later refresh
-	// that newly revokes watchedFP, or the cached list ageing past notAfter while
-	// the session is still up, cancels the session so it re-handshakes through the
-	// (now-failing) Check — handshake-only revocation would otherwise let an
-	// in-flight stream to a revoked gateway run until natural disconnect.
+	// connected gateway authenticated with (recorded by CheckSession on a
+	// successful handshake) and the canceler that tears that session down. A
+	// later refresh that newly revokes watchedFP, or the cached list ageing past
+	// notAfter while the session is still up, cancels the session so it
+	// re-handshakes through the (now-failing) check — handshake-only revocation
+	// would otherwise let an in-flight stream to a revoked gateway run until
+	// natural disconnect. sessionID tokens the registration: a torn-down
+	// client's transport can still complete an in-flight dial handshake after
+	// the next session registered, and without the token that stale handshake
+	// would overwrite the live session's fingerprint (missing its later
+	// revocation) or its teardown would clear the live canceler.
+	sessionID     uint64
 	watchedFP     string
 	cancelSession context.CancelFunc
 }
@@ -74,9 +80,13 @@ func New(fetch FetchFunc, logger *slog.Logger, opts ...Option) *Cache {
 // every gateway TLS handshake with the gateway's hex SHA-256 leaf fingerprint.
 // A non-nil return fails the handshake.
 func (c *Cache) Check(fingerprint string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.checkLocked(fingerprint)
+}
 
+// checkLocked is the CRL policy; callers hold c.mu (read or write).
+func (c *Cache) checkLocked(fingerprint string) error {
 	if !c.loaded {
 		return errors.New("gateway CRL not yet loaded — refusing until the first list is fetched")
 	}
@@ -86,24 +96,53 @@ func (c *Cache) Check(fingerprint string) error {
 	if _, ok := c.revoked[fingerprint]; ok {
 		return fmt.Errorf("gateway certificate %s is revoked", fingerprint)
 	}
-	// Approved: this is the peer of the live session. Record it (under the write
-	// lock) so a later refresh/expiry that condemns it can cancel the session
-	// (AC 11). Only meaningful once WatchSession has registered a canceler.
-	c.watchedFP = fingerprint
+	return nil
+}
+
+// CheckSession is the per-handshake gate for the session registered as id: the
+// same policy as Check, plus — while id is still the active registration —
+// recording the approved fingerprint as the watched session peer so a later
+// refresh/expiry that condemns it can cancel the session (AC 11). A stale
+// client's late handshake (its registration already replaced) still gets the
+// policy verdict but must NOT overwrite the live session's fingerprint.
+func (c *Cache) CheckSession(id uint64, fingerprint string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.checkLocked(fingerprint); err != nil {
+		return err
+	}
+	if c.sessionID == id {
+		c.watchedFP = fingerprint
+	}
 	return nil
 }
 
 // WatchSession registers the active gateway session's context canceler so a
 // later CRL refresh that revokes the connected gateway — or the cached list
 // expiring while the session is still up — can tear the session down (AC 11).
-// runAgent calls this for each new connection; the peer fingerprint is filled in
-// by Check when that connection's handshake completes. A new registration
-// forgets the prior peer so a refresh in the gap between sessions cannot cancel
-// the wrong one. Pass nil to unregister when a session ends.
-func (c *Cache) WatchSession(cancel context.CancelFunc) {
+// runAgent calls this for each new connection; the peer fingerprint is filled
+// in by CheckSession when that connection's handshake completes. The returned
+// token binds CheckSession/UnwatchSession to THIS registration so a torn-down
+// session's lingering handshake or teardown cannot touch a newer session's
+// state. A new registration forgets the prior peer.
+func (c *Cache) WatchSession(cancel context.CancelFunc) uint64 {
 	c.mu.Lock()
+	c.sessionID++
+	id := c.sessionID
 	c.cancelSession = cancel
 	c.watchedFP = ""
+	c.mu.Unlock()
+	return id
+}
+
+// UnwatchSession unregisters the session registered as id; a no-op when a
+// newer session has already replaced the registration.
+func (c *Cache) UnwatchSession(id uint64) {
+	c.mu.Lock()
+	if c.sessionID == id {
+		c.cancelSession = nil
+		c.watchedFP = ""
+	}
 	c.mu.Unlock()
 }
 

--- a/internal/crl/crl_test.go
+++ b/internal/crl/crl_test.go
@@ -92,3 +92,83 @@ func TestRefresh_RetainsLastSnapshotOnError(t *testing.T) {
 		t.Errorf("last-good snapshot should still allow an unrevoked fingerprint: %v", err)
 	}
 }
+
+// TestRefresh_CancelsLiveSessionWhenPeerRevoked pins AC 11: after a gateway
+// handshake records the connected peer's fingerprint, a later refresh that newly
+// revokes that fingerprint cancels the live session — handshake-only revocation
+// would let the in-flight stream run to a revoked gateway until natural
+// disconnect.
+func TestRefresh_CancelsLiveSessionWhenPeerRevoked(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	snaps := []*sdk.GatewayCRL{
+		{NotAfter: now.Add(time.Hour), RefreshedAt: now},                                          // fresh, nothing revoked
+		{RevokedFingerprints: []string{"peerfp"}, NotAfter: now.Add(time.Hour), RefreshedAt: now}, // revokes the peer
+	}
+	call := 0
+	fetch := func(context.Context) (*sdk.GatewayCRL, error) {
+		s := snaps[call]
+		if call < len(snaps)-1 {
+			call++
+		}
+		return s, nil
+	}
+	c := New(fetch, nil, WithClock(fixedClock(now)))
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("first refresh: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.WatchSession(cancel)
+	// Simulate the gateway handshake: Check approves and records the peer.
+	if err := c.Check("peerfp"); err != nil {
+		t.Fatalf("handshake check should pass for an unrevoked peer: %v", err)
+	}
+
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("second refresh: %v", err)
+	}
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("live session was not cancelled after its gateway was revoked (AC 11)")
+	}
+}
+
+// TestEnforce_CancelsLiveSessionWhenCRLExpires pins the other AC 11 trigger: a
+// cached CRL ageing past not_after while a session is still up fails closed for
+// the in-flight session too, not only at the next handshake. Mirrors what Run
+// does on the failed-refresh path.
+func TestEnforce_CancelsLiveSessionWhenCRLExpires(t *testing.T) {
+	load := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	clk := load
+	snap := &sdk.GatewayCRL{NotAfter: load.Add(time.Hour), RefreshedAt: load}
+	c := New(func(context.Context) (*sdk.GatewayCRL, error) { return snap, nil }, nil, WithClock(func() time.Time { return clk }))
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.WatchSession(cancel)
+	if err := c.Check("peerfp"); err != nil {
+		t.Fatalf("handshake check: %v", err)
+	}
+
+	// Still fresh: enforcing must NOT cancel a healthy live session.
+	c.enforceSessionRevocation()
+	select {
+	case <-ctx.Done():
+		t.Fatal("session cancelled while the CRL was still fresh")
+	default:
+	}
+
+	// Past not_after: a live session on a now-stale CRL fails closed.
+	clk = load.Add(2 * time.Hour)
+	c.enforceSessionRevocation()
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("live session was not cancelled when the cached CRL expired (AC 11/12)")
+	}
+}

--- a/internal/crl/crl_test.go
+++ b/internal/crl/crl_test.go
@@ -173,6 +173,64 @@ func TestEnforce_CancelsLiveSessionWhenCRLExpires(t *testing.T) {
 	}
 }
 
+// TestRefresh_SuccessAfterStalenessReverifiesInsteadOfCancel pins the deliberate
+// ordering in Refresh: when the cached CRL ages past not_after mid-interval and
+// the NEXT tick's refresh SUCCEEDS, the live session is re-verified against the
+// fresh snapshot rather than cancelled for the transient staleness — an
+// unrevoked peer keeps its session (cancelling would be a pure availability hit
+// after trust was just re-established), while a revoked peer is still cancelled
+// within the same refresh cycle. The expiry-cancel path is for staleness that
+// canNOT be resolved (failed refresh — see TestEnforce_CancelsLiveSessionWhenCRLExpires).
+func TestRefresh_SuccessAfterStalenessReverifiesInsteadOfCancel(t *testing.T) {
+	load := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	clk := load
+	snaps := []*sdk.GatewayCRL{
+		{NotAfter: load.Add(time.Hour), RefreshedAt: load},                                                                 // initial, expires at +1h
+		{NotAfter: load.Add(3 * time.Hour), RefreshedAt: load.Add(2 * time.Hour)},                                          // fresh after staleness, peer not revoked
+		{RevokedFingerprints: []string{"peerfp"}, NotAfter: load.Add(3 * time.Hour), RefreshedAt: load.Add(2 * time.Hour)}, // now revokes the peer
+	}
+	call := 0
+	fetch := func(context.Context) (*sdk.GatewayCRL, error) {
+		s := snaps[call]
+		if call < len(snaps)-1 {
+			call++
+		}
+		return s, nil
+	}
+	c := New(fetch, nil, WithClock(func() time.Time { return clk }))
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("first refresh: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	id := c.WatchSession(cancel)
+	if err := c.CheckSession(id, "peerfp"); err != nil {
+		t.Fatalf("handshake check: %v", err)
+	}
+
+	// The cached CRL expires mid-interval; the next tick's refresh succeeds.
+	clk = load.Add(2 * time.Hour)
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("refresh after staleness: %v", err)
+	}
+	select {
+	case <-ctx.Done():
+		t.Fatal("session cancelled although a successful refresh re-verified the unrevoked peer")
+	default:
+	}
+
+	// The security half stays intact: a fresh snapshot revoking the peer cancels.
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("revoking refresh: %v", err)
+	}
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("live session was not cancelled after its gateway was revoked (AC 11)")
+	}
+}
+
 // TestCheckSession_StaleRegistrationCannotHijackWatch pins the registration
 // token: a torn-down session's transport can complete an in-flight dial
 // handshake AFTER the next session registered, and its teardown can run late

--- a/internal/crl/crl_test.go
+++ b/internal/crl/crl_test.go
@@ -119,9 +119,9 @@ func TestRefresh_CancelsLiveSessionWhenPeerRevoked(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c.WatchSession(cancel)
-	// Simulate the gateway handshake: Check approves and records the peer.
-	if err := c.Check("peerfp"); err != nil {
+	id := c.WatchSession(cancel)
+	// Simulate the gateway handshake: CheckSession approves and records the peer.
+	if err := c.CheckSession(id, "peerfp"); err != nil {
 		t.Fatalf("handshake check should pass for an unrevoked peer: %v", err)
 	}
 
@@ -150,8 +150,8 @@ func TestEnforce_CancelsLiveSessionWhenCRLExpires(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c.WatchSession(cancel)
-	if err := c.Check("peerfp"); err != nil {
+	id := c.WatchSession(cancel)
+	if err := c.CheckSession(id, "peerfp"); err != nil {
 		t.Fatalf("handshake check: %v", err)
 	}
 
@@ -170,5 +170,77 @@ func TestEnforce_CancelsLiveSessionWhenCRLExpires(t *testing.T) {
 	case <-ctx.Done():
 	default:
 		t.Fatal("live session was not cancelled when the cached CRL expired (AC 11/12)")
+	}
+}
+
+// TestCheckSession_StaleRegistrationCannotHijackWatch pins the registration
+// token: a torn-down session's transport can complete an in-flight dial
+// handshake AFTER the next session registered, and its teardown can run late
+// too. Neither may touch the live session's watch state — a stale handshake
+// overwriting the fingerprint would make the live session miss its own
+// revocation, and a stale unregister would clear the live canceler.
+func TestCheckSession_StaleRegistrationCannotHijackWatch(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	fresh := &sdk.GatewayCRL{NotAfter: now.Add(time.Hour), RefreshedAt: now}
+	revokesA := &sdk.GatewayCRL{RevokedFingerprints: []string{"fpA"}, NotAfter: now.Add(time.Hour), RefreshedAt: now}
+	revokesB := &sdk.GatewayCRL{RevokedFingerprints: []string{"fpB"}, NotAfter: now.Add(time.Hour), RefreshedAt: now}
+	snaps := []*sdk.GatewayCRL{fresh, revokesA, revokesB}
+	call := 0
+	fetch := func(context.Context) (*sdk.GatewayCRL, error) {
+		s := snaps[call]
+		if call < len(snaps)-1 {
+			call++
+		}
+		return s, nil
+	}
+	c := New(fetch, nil, WithClock(fixedClock(now)))
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("initial refresh: %v", err)
+	}
+
+	// Session A lives and dies.
+	ctxA, cancelA := context.WithCancel(context.Background())
+	defer cancelA()
+	idA := c.WatchSession(cancelA)
+	if err := c.CheckSession(idA, "fpA"); err != nil {
+		t.Fatalf("A handshake: %v", err)
+	}
+	cancelA()
+	c.UnwatchSession(idA)
+	_ = ctxA
+
+	// Session B registers and completes its handshake.
+	ctxB, cancelB := context.WithCancel(context.Background())
+	defer cancelB()
+	idB := c.WatchSession(cancelB)
+	if err := c.CheckSession(idB, "fpB"); err != nil {
+		t.Fatalf("B handshake: %v", err)
+	}
+
+	// A's transport finishes a stale dial handshake and a late teardown.
+	if err := c.CheckSession(idA, "fpA"); err != nil {
+		t.Fatalf("stale handshake still gets the policy verdict: %v", err)
+	}
+	c.UnwatchSession(idA)
+
+	// Revoking A's peer must NOT cancel B.
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("refresh revoking fpA: %v", err)
+	}
+	select {
+	case <-ctxB.Done():
+		t.Fatal("stale session A's fingerprint hijacked the watch: revoking fpA cancelled B")
+	default:
+	}
+
+	// Revoking B's actual peer must still cancel B (the stale unregister must
+	// not have cleared the live canceler).
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("refresh revoking fpB: %v", err)
+	}
+	select {
+	case <-ctxB.Done():
+	default:
+		t.Fatal("live session B was not cancelled when its own peer was revoked")
 	}
 }


### PR DESCRIPTION
Implements spec 31 AC 11 (WS-D of the 2026-07-18 spec-audit remediation): the agent must tear down a live gateway session when the CRL says its peer is no longer trustworthy.

## What changed

- **Session cancellation on revocation.** `crl.Cache` now tracks the live session's peer fingerprint. When a `Refresh` succeeds and the new CRL revokes the connected gateway's cert, or when the cached CRL expires while a session is live (including on a failed refresh in `Run`), the cache cancels the session context — the agent drops the connection instead of riding out a revoked peer until the next natural reconnect.
- **Registration tokens close the stale-dial race.** A torn-down client's transport can complete an in-flight dial handshake after the next session registers. `WatchSession` returns a registration token; `CheckSession(id, fp)` records the fingerprint only while `id` is the active registration, and `UnwatchSession(id)` is a no-op once replaced — a stale dial can neither re-arm the watch with the old fingerprint (spurious cancel) nor clobber the new one (missed cancel).
- Runtime wiring: the session context + `WatchSession` registration are created before the mTLS option, so the revocation-check closure carries the session token; teardown cancels and unregisters.

## Verification

- `gofmt` / `go vet` clean; full agent suite green (11 packages).
- Red-before-green on both cancellation paths and on the stale-registration regression test (`TestCheckSession_StaleRegistrationCannotHijackWatch` drives the full stale-dial sequence: revoking the stale fingerprint must not cancel the live session; revoking the live one must).
- Local CodeRabbit review: no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Active connections are now automatically terminated when their security certificate is revoked.
  * Connections are also ended when the certificate revocation information expires.

* **Bug Fixes**
  * Improved handling of connection registration and cleanup to prevent outdated connection state from affecting active sessions.

* **Tests**
  * Added coverage for certificate revocation, expired revocation information, and connection lifecycle edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->