### PR TITLE
release: pin SDK and require signed agent updates

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,10 +13,12 @@ reviews:
         until their narrow sink; application frames are not signed.
     - path: "internal/executor/agent_update.go"
       instructions: >
-        Agent updates must verify either a control-pinned SHA-256 or the
-        Ed25519-signed release manifest before staging a binary, enforce
-        anti-rollback, self-test before the atomic swap, and retain one
-        recoverable previous binary.
+        Agent updates must authenticate the Ed25519-signed release manifest
+        before trusting its SHA-256 and staging a binary, enforce anti-rollback,
+        self-test before the atomic swap, and retain one recoverable previous
+        binary. Preserve operator-selected HTTPS release endpoints, including
+        private/internal hosts used by self-hosted deployments; do not require a
+        MANCHTOOLS or public-network host allowlist.
   tools:
     golangci-lint:
       enabled: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,28 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Resolve SDK ref
-        id: sdk_ref
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          if git ls-remote --tags https://github.com/MANCHTOOLS/power-manage-sdk.git "refs/tags/${TAG}" | grep -q .; then
-            echo "ref=${TAG}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=main" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout SDK
-        uses: actions/checkout@v5
-        with:
-          repository: MANCHTOOLS/power-manage-sdk
-          ref: ${{ steps.sdk_ref.outputs.ref }}
-          path: _sdk
-
-      - name: Rewrite SDK replace directive
-        run: go mod edit -replace github.com/manchtools/power-manage/sdk=./_sdk
-
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/README.md
+++ b/README.md
@@ -750,31 +750,27 @@ journalctl -u power-manage-agent -f
 
 The agent self-updates via the `ACTION_TYPE_AGENT_UPDATE` action. Admins
 schedule it on managed devices; the authenticated direct delivery carries an
-HTTPS `binary_url` and an integrity source.
+HTTPS `binary_url` and the publisher's HTTPS `checksum_url`.
 
-### Integrity: signed `checksum_url` or a pinned `expected_sha256`
+### Integrity: publisher-signed checksum manifest
 
-Each arch must provide **at least one** of:
+Each configured architecture must provide both `binary_url` and `checksum_url`.
+The checksum URL names a `SHA256SUMS` file with an adjacent `SHA256SUMS.sig`.
+The agent verifies the exact manifest bytes with its embedded Ed25519 release
+key before trusting the candidate binary's hash. Pointing both URLs at
+`releases/latest/...` lets the fleet track publisher-signed releases hands-off.
 
-- **`checksum_url`** (default) — a `SHA256SUMS` file with an adjacent
-  `SHA256SUMS.sig`. The agent verifies the exact manifest bytes with its pinned
-  Ed25519 release key before trusting a hash. This is the hands-off option:
-  point both URLs at `releases/latest/...` and the fleet tracks signed releases.
-- **`expected_sha256`** (opt-in) — an exact, lowercase-hex hash. When set it
-  **overrides** `checksum_url` and arrives in the authenticated delivery. Use
-  it to pin an exact binary for staged rollouts. A new version requires
-  updating the action.
-
-`binary_url` (and `checksum_url`, when used) must be HTTPS. An action with neither integrity source is rejected at create time and by the agent.
+Both URLs must be HTTPS. The server and agent reject an action without a signed
+checksum-manifest source; an update action cannot supply or replace the trusted
+public key.
 
 <!-- docref: begin src=internal/executor/release_signature.go#verifyReleaseManifest:ef74f2a3,internal/executor/agent_update.go#downloadAndExtractChecksum:ca7f8bef -->
 Once a trusted installer or agent containing the embedded key is present, a
 compromised artifact host can replace the binary, manifest, and signature but
 cannot produce a signature that it accepts. The initial `curl | bash` bootstrap
 still trusts the source serving that installer; retrieve or inspect it through
-a trusted repository or control-server channel. A control-pinned
-`expected_sha256` remains available for an exact staged rollout and bypasses
-manifest fetching entirely.
+a trusted repository or control-server channel. There is no action-supplied
+hash or public-key bypass for automatic updates.
 <!-- docref: end -->
 
 ### Anti-rollback
@@ -785,9 +781,9 @@ requires `allow_downgrade` in the authenticated delivery.
 
 ### Update Process
 
-1. Download the binary to `/var/lib/power-manage/update/agent-update-*.tmp` and
-   verify its SHA256 against pinned `expected_sha256`, or against a hash from
-   the publisher-signed manifest
+1. Download and authenticate the publisher-signed checksum manifest, then
+   download the binary to `/var/lib/power-manage/update/agent-update-*.tmp` and
+   verify its SHA-256 against the trusted manifest entry
 2. Run `<tmpPath> version`, compare with running — skip if same; refuse a downgrade unless `allow_downgrade`
 3. Run `<tmpPath> self-test` as a subprocess (60s timeout). The self-test:
    - Loads stored credentials
@@ -951,10 +947,8 @@ There are two deliberately different build modes:
 
 - A normal `go build ./cmd/power-manage-agent` development build succeeds
   without a release key, but contains no trusted publisher identity.
-  Automatic `checksum_url` updates do not work: the agent rejects the release
-  manifest before trusting its hashes. An exact `expected_sha256` delivered by
-  control still works, but that is an explicitly pinned update rather than
-  automatic release tracking.
+  Self-update does not work: the agent rejects the release manifest before
+  trusting its hashes, and no action field can bypass that check.
 - The tag-triggered release workflow requires
   `RELEASE_SIGNING_PUBLIC_KEY` before building release binaries and requires
   the matching `RELEASE_SIGNING_PRIVATE_KEY` before publishing them. It fails

--- a/README.md
+++ b/README.md
@@ -940,6 +940,32 @@ private secret and refuses to publish if it does not match the configured
 public value.
 <!-- docref: end -->
 
+#### Forks and downstream releases: bring your own keys
+
+Cloning or forking this repository does not provide MANCHTOOLS release-signing
+settings or private key material. Downstream maintainers must configure their
+own Ed25519 pair under the same Actions variable and environment-secret names.
+
+<!-- docref: begin src=.github/workflows/release.yml#@release-signing:aeab103d,internal/executor/release_signature.go#verifyReleaseManifest:ef74f2a3 -->
+There are two deliberately different build modes:
+
+- A normal `go build ./cmd/power-manage-agent` development build succeeds
+  without a release key, but contains no trusted publisher identity.
+  Automatic `checksum_url` updates do not work: the agent rejects the release
+  manifest before trusting its hashes. An exact `expected_sha256` delivered by
+  control still works, but that is an explicitly pinned update rather than
+  automatic release tracking.
+- The tag-triggered release workflow requires
+  `RELEASE_SIGNING_PUBLIC_KEY` before building release binaries and requires
+  the matching `RELEASE_SIGNING_PRIVATE_KEY` before publishing them. It fails
+  closed when either setting is absent, invalid, or mismatched.
+
+Therefore, producing a signed, automatically updateable downstream release is
+BYOK: generate and protect a fork-owned key pair, then configure both settings
+before creating a release tag. No MANCHTOOLS private signing key is present in
+the source tree or required by a fork.
+<!-- docref: end -->
+
 ## Integration Test Suite
 
 The test suite (`internal/executor/integration_test.go`, ~3,500 lines) exercises the executor against real system state inside containerized environments. Each test container mirrors production: tests run as `root` directly, the same way the agent runs in production (systemd `User=root`).

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.12
 
 require (
 	connectrpc.com/connect v1.18.1
-	github.com/manchtools/power-manage-sdk v0.5.4-0.20260809075732-1f98c6d6df19
+	github.com/manchtools/power-manage-sdk v0.5.4-0.20260809081706-6e8b0d70cb7c
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pressly/goose/v3 v3.26.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.12
 
 require (
 	connectrpc.com/connect v1.18.1
-	github.com/manchtools/power-manage-sdk v0.5.4-0.20260809081706-6e8b0d70cb7c
+	github.com/manchtools/power-manage-sdk v0.5.4-0.20260809083716-5f23bc6d3400
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pressly/goose/v3 v3.26.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.12
 
 require (
 	connectrpc.com/connect v1.18.1
-	github.com/manchtools/power-manage-sdk v0.5.4-0.20260808120009-f761803c4049
+	github.com/manchtools/power-manage-sdk v0.5.4-0.20260809075732-1f98c6d6df19
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pressly/goose/v3 v3.26.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/manchtools/power-manage-sdk v0.5.4-0.20260808113503-541746be378a h1:E
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260808113503-541746be378a/go.mod h1:tjwQAdTEB5Dl1iL9mBP5sMcnJczXyFvxSkiNyg+E8lE=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260808120009-f761803c4049 h1:lNnjYE+Z4zPK5sLFyl4OciiqNNsO52XAunocWQv3kPw=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260808120009-f761803c4049/go.mod h1:tjwQAdTEB5Dl1iL9mBP5sMcnJczXyFvxSkiNyg+E8lE=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260809075732-1f98c6d6df19 h1:xLxW20riAwTSUFRGgLTGYvsE24CqRejjyHibRjM2114=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260809075732-1f98c6d6df19/go.mod h1:kW40GYv7KS/CQRUCW8hyX06AOb/FtG6PF6cGXUu3/IQ=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/manchtools/power-manage-sdk v0.5.4-0.20260808120009-f761803c4049 h1:l
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260808120009-f761803c4049/go.mod h1:tjwQAdTEB5Dl1iL9mBP5sMcnJczXyFvxSkiNyg+E8lE=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260809075732-1f98c6d6df19 h1:xLxW20riAwTSUFRGgLTGYvsE24CqRejjyHibRjM2114=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260809075732-1f98c6d6df19/go.mod h1:kW40GYv7KS/CQRUCW8hyX06AOb/FtG6PF6cGXUu3/IQ=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260809081706-6e8b0d70cb7c h1:5YyazeQUsxwKUcv6DTNG7IWlOU2FfyMo5W0lWEV7KvQ=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260809081706-6e8b0d70cb7c/go.mod h1:kW40GYv7KS/CQRUCW8hyX06AOb/FtG6PF6cGXUu3/IQ=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/manchtools/power-manage-sdk v0.5.4-0.20260809075732-1f98c6d6df19 h1:x
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260809075732-1f98c6d6df19/go.mod h1:kW40GYv7KS/CQRUCW8hyX06AOb/FtG6PF6cGXUu3/IQ=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260809081706-6e8b0d70cb7c h1:5YyazeQUsxwKUcv6DTNG7IWlOU2FfyMo5W0lWEV7KvQ=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260809081706-6e8b0d70cb7c/go.mod h1:kW40GYv7KS/CQRUCW8hyX06AOb/FtG6PF6cGXUu3/IQ=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260809083716-5f23bc6d3400 h1:vufBOQU5xW0WHq4m+eJyY6J/lENWZ7nf3UkjEYrfagk=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260809083716-5f23bc6d3400/go.mod h1:kW40GYv7KS/CQRUCW8hyX06AOb/FtG6PF6cGXUu3/IQ=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/executor/agent_update.go
+++ b/internal/executor/agent_update.go
@@ -65,8 +65,8 @@ func (e *Executor) markAgentUpdateExecuted() bool {
 //  2. Look up AgentUpdateArch for own architecture
 //  3. If no entry → skip (success, no changes)
 //  4. Validate the binary URL is HTTPS
-//  5. Download binary to temp file, verify SHA256 against the CA-signed
-//     expected_sha256 (WS7 #1 — NOT a same-origin checksum file)
+//  5. Authenticate the publisher-signed checksum manifest, then download the
+//     binary and verify its SHA-256 against the trusted manifest entry
 //  6. Run ./agent-new version → extract version string
 //  7. Compare with running version → skip if same; refuse a downgrade
 //     unless allow_downgrade is set on the control-authored action (anti-rollback)
@@ -109,29 +109,18 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 		return nil, false, fmt.Errorf("binary URL validation: %w", err)
 	}
 
-	// Step 4: determine the expected binary hash. The operator can pin it
-	// directly; otherwise the publisher-signed release manifest is authoritative.
-	//   - expected_sha256 set → AUTHORITATIVE, control-authored pin. It rides
-	//     inside the control-authored action, so even a compromised download origin
-	//     cannot vouch for a tampered binary. Overrides checksum_url.
-	//   - otherwise → fetch checksum_url and checksum_url.sig, authenticate
-	//     the exact manifest bytes with the release Ed25519 key, then extract
-	//     the binary hash. The download origin cannot sign substituted bytes.
-	// At least one must be present (also enforced server-side) so an update
-	// never runs with no integrity check.
-	expectedChecksum := strings.ToLower(arch.ExpectedSha256)
-	if expectedChecksum == "" {
-		if arch.ChecksumUrl == "" {
-			return nil, false, fmt.Errorf("agent update rejected: action sets neither expected_sha256 nor checksum_url")
-		}
-		if err := sdk.ValidateHTTPSURL(arch.ChecksumUrl); err != nil {
-			return nil, false, fmt.Errorf("checksum URL validation: %w", err)
-		}
-		fileChecksum, err := downloadAndExtractChecksum(ctx, arch.ChecksumUrl, extractFilename(arch.BinaryUrl), updateRedirectPolicy(params))
-		if err != nil {
-			return nil, false, fmt.Errorf("download checksum: %w", err)
-		}
-		expectedChecksum = fileChecksum
+	// Step 4: authenticate the release manifest before trusting its binary hash.
+	// checksum_url is required by the public contract and server authoring, and
+	// this executor validates it again before any network access.
+	if arch.ChecksumUrl == "" {
+		return nil, false, fmt.Errorf("agent update rejected: checksum_url is required")
+	}
+	if err := sdk.ValidateHTTPSURL(arch.ChecksumUrl); err != nil {
+		return nil, false, fmt.Errorf("checksum URL validation: %w", err)
+	}
+	expectedChecksum, err := downloadAndExtractChecksum(ctx, arch.ChecksumUrl, extractFilename(arch.BinaryUrl), updateRedirectPolicy(params))
+	if err != nil {
+		return nil, false, fmt.Errorf("download checksum: %w", err)
 	}
 
 	// Step 5: Download binary to temp file in DataDir (agent-owned).
@@ -149,13 +138,13 @@ func (e *Executor) executeAgentUpdate(ctx context.Context, params *pb.AgentUpdat
 	_ = tmpFile.Close() // remote.Fetch writes via its own temp + atomic rename onto tmpPath
 	defer os.Remove(tmpPath)
 
-	// Download the binary, verify it against the (operator-or-CA-pinned)
-	// expected sha256, and place it at mode 0755 (executable for the version
+	// Download the binary, verify it against the hash from the signed release
+	// manifest, and place it at mode 0755 (executable for the version
 	// self-test below) — all in one atomic step via the SDK remote source. An
 	// integrity failure is the binary-doesn't-match-the-pin case.
 	if err := fetchArtifact(ctx, arch.BinaryUrl, tmpPath, expectedChecksum, "0755", updateRedirectPolicy(params)); err != nil {
 		if errors.Is(err, remote.ErrIntegrity) {
-			return nil, false, fmt.Errorf("binary does not match the expected_sha256 pin: %w", err)
+			return nil, false, fmt.Errorf("binary does not match the signed release manifest: %w", err)
 		}
 		return nil, false, fmt.Errorf("download binary: %w", err)
 	}
@@ -431,9 +420,9 @@ func extractFilename(rawURL string) string {
 // updateRedirectPolicy resolves the redirect policy for a self-update download
 // from the operator's explicit AllowRedirect choice on the action. Default false
 // keeps the strict same-origin guard; true follows cross-origin redirects (e.g.
-// a CDN such as GitHub releases). The binary is always verified against a SHA-256
-// (expected_sha256, or the hash resolved from checksum_url) and an https->http
-// downgrade is refused by the SDK regardless, so the flag opts into a
+// a CDN such as GitHub releases). The binary is always verified against the
+// hash resolved from the publisher-signed manifest and an https->http downgrade
+// is refused by the SDK regardless, so the flag opts into a
 // host-changing hop, not into unchecked bytes — mirroring allow_downgrade as a
 // security-sensitive operator decision that rides inside the control-authored action.
 func updateRedirectPolicy(params *pb.AgentUpdateParams) remote.RedirectPolicy {

--- a/internal/executor/agent_update_orchestration_test.go
+++ b/internal/executor/agent_update_orchestration_test.go
@@ -63,6 +63,9 @@ type updateHarness struct {
 // newUpdateHarness serves `serveBody` at /agent and `sumsBody` at /sums.
 func newUpdateHarness(t *testing.T, runningVersion string, serveBody, sumsBody []byte) *updateHarness {
 	t.Helper()
+	if sumsBody == nil {
+		sumsBody = []byte(sha256hex(serveBody) + "  agent\n")
+	}
 	dir := t.TempDir()
 	binaryPath := filepath.Join(dir, "power-manage-agent")
 	oldBytes := []byte("#!/bin/sh\necho OLD\n")
@@ -122,17 +125,15 @@ func newUpdateHarness(t *testing.T, runningVersion string, serveBody, sumsBody [
 	return h
 }
 
-func (h *updateHarness) params(expectedSha string) *pb.AgentUpdateParams {
+func (h *updateHarness) params() *pb.AgentUpdateParams {
 	return &pb.AgentUpdateParams{
 		Amd64: &pb.AgentUpdateArch{
-			BinaryUrl:      h.srv.URL + "/agent",
-			ChecksumUrl:    h.srv.URL + "/sums",
-			ExpectedSha256: expectedSha,
+			BinaryUrl:   h.srv.URL + "/agent",
+			ChecksumUrl: h.srv.URL + "/sums",
 		},
 		Arm64: &pb.AgentUpdateArch{
-			BinaryUrl:      h.srv.URL + "/agent",
-			ChecksumUrl:    h.srv.URL + "/sums",
-			ExpectedSha256: expectedSha,
+			BinaryUrl:   h.srv.URL + "/agent",
+			ChecksumUrl: h.srv.URL + "/sums",
 		},
 	}
 }
@@ -157,18 +158,19 @@ func (h *updateHarness) currentBinary(t *testing.T) []byte {
 	return b
 }
 
-// WS7 #6: a binary whose bytes do not hash to the action's
-// expected_sha256 is rejected; the swap is aborted, the live binary is
+// WS7 #6: a binary whose bytes do not hash to the signed manifest is
+// rejected; the swap is aborted, the live binary is
 // byte-identical, no .bak is created, Shutdown is not called.
 func TestExecuteAgentUpdate_ChecksumMismatchAbortsSwap(t *testing.T) {
 	genuine := agentScript("v2026.06.05", 0)
 	tampered := append([]byte{}, genuine...)
 	tampered[len(tampered)-2] ^= 0xff // flip a non-terminal byte
 
-	// expected_sha256 is the hash of the GENUINE bytes; the server serves
-	// TAMPERED bytes → mismatch (intent: hash binds content).
-	h := newUpdateHarness(t, "v2026.06.01", tampered, nil)
-	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params(sha256hex(genuine)))
+	// The signed manifest contains the GENUINE hash; the server serves
+	// TAMPERED bytes → mismatch (intent: signed hash binds content).
+	sums := []byte(sha256hex(genuine) + "  agent\n")
+	h := newUpdateHarness(t, "v2026.06.01", tampered, sums)
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params())
 
 	if err == nil {
 		t.Fatal("checksum mismatch must abort the update")
@@ -184,37 +186,12 @@ func TestExecuteAgentUpdate_ChecksumMismatchAbortsSwap(t *testing.T) {
 	}
 }
 
-// WS7 #1 (core): when expected_sha256 is present, the swap is gated on it
-// and a malicious same-origin checksum document is NOT trusted. Serve a
-// SHA256SUMS that advertises a MATCHING hash for the tampered bytes while
-// expected_sha256 holds the genuine hash → tampered binary rejected.
-func TestExecuteAgentUpdate_HashBoundToControlAction_NotChecksumFile(t *testing.T) {
-	genuine := agentScript("v2026.06.05", 0)
-	tampered := append([]byte{}, genuine...)
-	tampered[len(tampered)-2] ^= 0xff
-
-	// The lying checksum file vouches for the tampered bytes.
-	sums := []byte(sha256hex(tampered) + "  agent\n")
-	h := newUpdateHarness(t, "v2026.06.01", tampered, sums)
-
-	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params(sha256hex(genuine)))
-	if err == nil {
-		t.Fatal("tampered binary must be rejected even when a same-origin checksum file vouches for it")
-	}
-	if changed {
-		t.Error("changed must be false")
-	}
-	if got := h.currentBinary(t); string(got) != string(h.oldBytes) {
-		t.Error("live binary must be unchanged")
-	}
-}
-
 // WS7 #6: a staged binary whose self-test fails keeps the current binary.
 func TestExecuteAgentUpdate_SelfTestFailKeepsBinary(t *testing.T) {
 	staged := agentScript("v2026.06.05", 1) // self-test exits non-zero
 	h := newUpdateHarness(t, "v2026.06.01", staged, nil)
 
-	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params(sha256hex(staged)))
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params())
 	if err == nil {
 		t.Fatal("self-test failure must abort the update")
 	}
@@ -232,7 +209,7 @@ func TestExecuteAgentUpdate_HappyPathSwapsAndShutsDown(t *testing.T) {
 	staged := agentScript("v2026.06.05", 0)
 	h := newUpdateHarness(t, "v2026.06.01", staged, nil)
 
-	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params(sha256hex(staged)))
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params())
 	if err != nil {
 		t.Fatalf("happy-path update failed: %v", err)
 	}
@@ -263,7 +240,7 @@ func TestExecuteAgentUpdate_RefreshesUnitFromNewBinary(t *testing.T) {
 	staged := agentScript("v2026.06.05", 0)
 	h := newUpdateHarness(t, "v2026.06.01", staged, nil)
 
-	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params(sha256hex(staged)))
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params())
 	if err != nil {
 		t.Fatalf("update failed: %v", err)
 	}
@@ -290,7 +267,7 @@ func TestExecuteAgentUpdate_UnitInstallFailureIsFailOpen(t *testing.T) {
 	staged := agentScriptUnitExit("v2026.06.05", 0, 1)
 	h := newUpdateHarness(t, "v2026.06.01", staged, nil)
 
-	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params(sha256hex(staged)))
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params())
 	if err != nil {
 		t.Fatalf("update must succeed despite install-unit failure: %v", err)
 	}
@@ -302,15 +279,15 @@ func TestExecuteAgentUpdate_UnitInstallFailureIsFailOpen(t *testing.T) {
 	}
 }
 
-// WS7 (revised): an action with NEITHER expected_sha256 NOR checksum_url
-// has no integrity source and is refused fail-closed (also enforced
+// An action without checksum_url has no signed integrity source and is
+// refused fail-closed (also enforced
 // server-side). The agent-update path uses downloadToFile, which has no
 // checksum chokepoint of its own.
 func TestExecuteAgentUpdate_RefusesNoIntegritySource(t *testing.T) {
 	staged := agentScript("v2026.06.05", 0)
 	h := newUpdateHarness(t, "v2026.06.01", staged, nil)
 
-	// No expected_sha256 AND no checksum_url.
+	// No checksum_url.
 	noIntegrity := &pb.AgentUpdateParams{
 		Amd64: &pb.AgentUpdateArch{BinaryUrl: h.srv.URL + "/agent"},
 		Arm64: &pb.AgentUpdateArch{BinaryUrl: h.srv.URL + "/agent"},
@@ -327,24 +304,23 @@ func TestExecuteAgentUpdate_RefusesNoIntegritySource(t *testing.T) {
 	}
 }
 
-// WS7 (revised): the DEFAULT path — no pinned expected_sha256, integrity
-// verified against the operator's checksum_url (SHA256SUMS). This is what
+// The only update path verifies the publisher's signed checksum manifest.
+// This is what
 // lets binary_url/checksum_url track "latest" hands-off. A correct
 // checksum file + newer version → swap + shutdown.
-func TestExecuteAgentUpdate_ChecksumURLFallback(t *testing.T) {
+func TestExecuteAgentUpdate_SignedManifest(t *testing.T) {
 	staged := agentScript("v2026.06.05", 0)
 	// SHA256SUMS line for the binary served at /agent (filename "agent").
 	sums := []byte(sha256hex(staged) + "  agent\n")
 	h := newUpdateHarness(t, "v2026.06.01", staged, sums)
 
-	// No expected_sha256 → agent fetches + verifies via checksum_url.
 	p := &pb.AgentUpdateParams{
 		Amd64: &pb.AgentUpdateArch{BinaryUrl: h.srv.URL + "/agent", ChecksumUrl: h.srv.URL + "/sums"},
 		Arm64: &pb.AgentUpdateArch{BinaryUrl: h.srv.URL + "/agent", ChecksumUrl: h.srv.URL + "/sums"},
 	}
 	_, changed, err := h.e.executeAgentUpdate(context.Background(), p)
 	if err != nil {
-		t.Fatalf("checksum_url fallback update failed: %v", err)
+		t.Fatalf("signed-manifest update failed: %v", err)
 	}
 	if !changed {
 		t.Error("changed must be true on a successful checksum_url-verified update")
@@ -420,7 +396,7 @@ func TestExecuteAgentUpdate_ChecksumURLSignatureRejected(t *testing.T) {
 func TestExecuteAgentUpdate_HTTPSourceRejected(t *testing.T) {
 	staged := agentScript("v2026.06.05", 0)
 	h := newUpdateHarness(t, "v2026.06.01", staged, nil)
-	p := h.params(sha256hex(staged))
+	p := h.params()
 	p.Amd64.BinaryUrl = "http://example.com/agent"
 	p.Arm64.BinaryUrl = "http://example.com/agent"
 

--- a/internal/executor/anti_rollback_test.go
+++ b/internal/executor/anti_rollback_test.go
@@ -75,7 +75,7 @@ func TestExecuteAgentUpdate_RefusesOlderVersion(t *testing.T) {
 	staged := agentScript("v2026.05.01", 0)
 	h := newUpdateHarness(t, "v2026.06.02", staged, nil) // running newer than staged
 
-	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params(sha256hex(staged)))
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params())
 	if err == nil {
 		t.Fatal("a downgrade must be refused by default")
 	}
@@ -93,7 +93,7 @@ func TestExecuteAgentUpdate_RefusesMalformedVersion(t *testing.T) {
 	staged := agentScript("garbage", 0)
 	h := newUpdateHarness(t, "v2026.06.02", staged, nil)
 
-	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params(sha256hex(staged)))
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params())
 	if err == nil {
 		t.Fatal("an unparseable staged version must be refused fail-closed")
 	}
@@ -109,7 +109,7 @@ func TestExecuteAgentUpdate_RefusesMalformedRunningVersion(t *testing.T) {
 	staged := agentScript("v2026.06.02", 0)
 	h := newUpdateHarness(t, "garbage", staged, nil) // running version unparseable
 
-	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params(sha256hex(staged)))
+	_, changed, err := h.e.executeAgentUpdate(context.Background(), h.params())
 	if err == nil {
 		t.Fatal("an unparseable running version must be refused fail-closed")
 	}
@@ -126,7 +126,7 @@ func TestExecuteAgentUpdate_RefusesMalformedRunningVersion(t *testing.T) {
 func TestExecuteAgentUpdate_AllowDowngradeBypass(t *testing.T) {
 	staged := agentScript("v2026.05.01", 0)
 	h := newUpdateHarness(t, "v2026.06.02", staged, nil)
-	p := h.params(sha256hex(staged))
+	p := h.params()
 	p.AllowDowngrade = true
 
 	_, changed, err := h.e.executeAgentUpdate(context.Background(), p)

--- a/internal/executor/release_signature.go
+++ b/internal/executor/release_signature.go
@@ -12,7 +12,7 @@ import (
 
 // releaseSigningPublicKey is a base64-encoded PKIX Ed25519 public key injected
 // by the protected release workflow. A normal development build deliberately
-// cannot trust checksum_url; control-pinned expected_sha256 updates still work.
+// cannot authenticate release manifests, so self-update fails closed.
 var releaseSigningPublicKey = "__RELEASE_SIGNING_PUBLIC_KEY__"
 
 func verifyReleaseManifest(manifest, signature []byte) error {


### PR DESCRIPTION
## What changed

- removes the release-time SDK tag lookup, temporary checkout, and obsolete `replace` rewrite
- release builds use the exact SDK pseudo-version committed in `go.mod`
- removes the action-supplied `expected_sha256` update path
- always authenticates `SHA256SUMS` with its adjacent Ed25519 signature before trusting the binary hash
- fails closed when the checksum URL, publisher key, signature, or binary hash is invalid
- documents the downstream BYOK signing contract and development-build behavior
- updates orchestration and anti-rollback tests to exercise the signed-manifest path

## Why

Release artifacts must be reproducible from reviewed source and dependencies. Automatic updates should have one publisher-authenticated trust path, with the public key embedded in the running agent rather than supplied by the update action.

## Validation

- `./scripts/verify.sh`
- `docref check`
- `docref suggest README.md`
- `git diff --check`
- `docref affected --since origin/main --json`

Local CodeRabbit execution was intentionally skipped; cloud review is authoritative for this PR.