### PR TITLE
fix(install): make signed release installers actually install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,14 @@ jobs:
             echo "release installer still contains the public-key placeholder" >&2
             exit 1
           fi
+          # Stamp the installer's own release so running it without -v
+          # installs THIS release: the GitHub "latest" alias resolves only
+          # non-prereleases and hands a prerelease user mismatched assets.
+          sed -i "s|__INSTALLER_RELEASE_VERSION__|${GITHUB_REF_NAME}|g" release/install.sh
+          if grep -q '__INSTALLER_RELEASE_VERSION__' release/install.sh; then
+            echo "release installer still contains the version placeholder" >&2
+            exit 1
+          fi
           cd release
           sha256sum power-manage-agent-linux-amd64 power-manage-agent-linux-arm64 install.sh > SHA256SUMS
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,14 @@ jobs:
           # Stamp the installer's own release so running it without -v
           # installs THIS release: the GitHub "latest" alias resolves only
           # non-prereleases and hands a prerelease user mismatched assets.
+          # The tag is validated against the release format first: git allows
+          # sed-significant characters like & and | in refnames, and while the
+          # placeholder grep below already fails closed on a corrupted
+          # substitution, a malformed tag should fail by name, not by symptom.
+          if ! printf '%s' "${GITHUB_REF_NAME}" | grep -Eq '^v[0-9]{4}\.[0-9]{2}(\.[0-9]{2})?(-[A-Za-z0-9.]+)?$'; then
+            echo "refusing to stamp non-release tag name: ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
           sed -i "s|__INSTALLER_RELEASE_VERSION__|${GITHUB_REF_NAME}|g" release/install.sh
           if grep -q '__INSTALLER_RELEASE_VERSION__' release/install.sh; then
             echo "release installer still contains the version placeholder" >&2

--- a/README.md
+++ b/README.md
@@ -924,7 +924,7 @@ Integration tests run automatically on push to `main` and on pull requests via G
 The release workflow (`.github/workflows/release.yml`) gates binary builds on
 passing integration tests, then signs the checksum manifest before publishing.
 
-<!-- docref: begin src=.github/workflows/release.yml#@release-signing:25ceebff -->
+<!-- docref: begin src=.github/workflows/release.yml#@release-signing:0f884921 -->
 Release signing uses two GitHub settings:
 
 - `RELEASE_SIGNING_PRIVATE_KEY`: the PKCS#8 PEM private key, stored only as a
@@ -945,7 +945,7 @@ Cloning or forking this repository does not provide MANCHTOOLS release-signing
 settings or private key material. Downstream maintainers must configure their
 own Ed25519 pair under the same Actions variable and environment-secret names.
 
-<!-- docref: begin src=.github/workflows/release.yml#@release-signing:25ceebff,internal/executor/release_signature.go#verifyReleaseManifest:ef74f2a3 -->
+<!-- docref: begin src=.github/workflows/release.yml#@release-signing:0f884921,internal/executor/release_signature.go#verifyReleaseManifest:ef74f2a3 -->
 There are two deliberately different build modes:
 
 - A normal `go build ./cmd/power-manage-agent` development build succeeds

--- a/README.md
+++ b/README.md
@@ -127,13 +127,16 @@ curl -fsSL https://your-server/install.sh | sudo bash -s -- \
   --pin YOUR_CA_SHA256
 ```
 
-<!-- docref: begin src=install.sh#download_binary:3f9090ea -->
+<!-- docref: begin src=install.sh#download_binary:2f3e9ce7 -->
 The install script:
-1. Downloads `SHA256SUMS` and `SHA256SUMS.sig`, verifies the manifest with the
+1. Installs its own release by default: the release build stamps the tag into
+   the installer, so a release asset run without `-v` fetches that release's
+   binaries rather than resolving GitHub's prerelease-skipping `latest` alias
+2. Downloads `SHA256SUMS` and `SHA256SUMS.sig`, verifies the manifest with the
    pinned Ed25519 release key, then verifies and installs the agent binary
-2. Creates `/var/lib/power-manage` as a root-owned, mode 0700 data directory
-3. Installs the systemd unit with `User=root` and the documented capability bounding set, then enables and starts the service
-4. Enrolls via the enrollment socket only when `--server`, `--token`, and `--pin` are provided
+3. Creates `/var/lib/power-manage` as a root-owned, mode 0700 data directory
+4. Installs the systemd unit with `User=root` and the documented capability bounding set, then enables and starts the service
+5. Enrolls via the enrollment socket only when `--server`, `--token`, and `--pin` are provided
 <!-- docref: end -->
 
 The `power-manage://` desktop URI handler is **opt-in** (`--enable-uri-handler` or `POWER_MANAGE_ENABLE_URI_HANDLER=true`) and **off by default** — an unconditional handler exposes the root-capable binary to drive-by browser links. When enabled, the `.desktop` entry sets `Terminal=false` so a link cannot auto-spawn a terminal.
@@ -921,7 +924,7 @@ Integration tests run automatically on push to `main` and on pull requests via G
 The release workflow (`.github/workflows/release.yml`) gates binary builds on
 passing integration tests, then signs the checksum manifest before publishing.
 
-<!-- docref: begin src=.github/workflows/release.yml#@release-signing:ad1354ab -->
+<!-- docref: begin src=.github/workflows/release.yml#@release-signing:25ceebff -->
 Release signing uses two GitHub settings:
 
 - `RELEASE_SIGNING_PRIVATE_KEY`: the PKCS#8 PEM private key, stored only as a
@@ -942,7 +945,7 @@ Cloning or forking this repository does not provide MANCHTOOLS release-signing
 settings or private key material. Downstream maintainers must configure their
 own Ed25519 pair under the same Actions variable and environment-secret names.
 
-<!-- docref: begin src=.github/workflows/release.yml#@release-signing:ad1354ab,internal/executor/release_signature.go#verifyReleaseManifest:ef74f2a3 -->
+<!-- docref: begin src=.github/workflows/release.yml#@release-signing:25ceebff,internal/executor/release_signature.go#verifyReleaseManifest:ef74f2a3 -->
 There are two deliberately different build modes:
 
 - A normal `go build ./cmd/power-manage-agent` development build succeeds

--- a/cmd/power-manage-agent/install_lint_test.go
+++ b/cmd/power-manage-agent/install_lint_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -261,5 +262,43 @@ func TestInstall_PlaceholderAppearsOnlyInTheAssignment(t *testing.T) {
 	substituted := strings.ReplaceAll(sh, placeholder, "TESTKEYBASE64")
 	if strings.Contains(substituted, `== "TESTKEYBASE64"`) {
 		t.Error("after key substitution the configured-key guard compares the key against itself; assemble the sentinel at run time")
+	}
+}
+
+// Self-discovering generalization of the placeholder rule: every release
+// placeholder declared in install.sh must (a) appear exactly once, on the
+// assignment its sed targets, (b) actually be substituted by the release
+// workflow, and (c) survive a simulated global substitution without any
+// guard comparing a variable against the freshly injected value. A new
+// placeholder added without workflow wiring, or referenced literally in a
+// second place, fails here instead of in the next broken release.
+func TestInstall_EveryPlaceholderStampedExactlyOnce(t *testing.T) {
+	sh := readRepoFile(t, "install.sh")
+	wf := readRepoFile(t, filepath.Join(".github", "workflows", "release.yml"))
+
+	pattern := regexp.MustCompile(`__[A-Z][A-Z0-9_]*__`)
+	counts := map[string]int{}
+	for _, token := range pattern.FindAllString(sh, -1) {
+		counts[token]++
+	}
+	if len(counts) == 0 {
+		t.Fatal("install.sh declares no release placeholders; the release build would stamp nothing")
+	}
+
+	substituted := sh
+	for token, count := range counts {
+		if count != 1 {
+			t.Errorf("placeholder %s appears %d times; the global release sed replaces every occurrence, so only its assignment may carry it", token, count)
+		}
+		if !strings.Contains(sh, `="`+token+`"`) {
+			t.Errorf("placeholder %s must appear as a quoted assignment for the release sed to stamp", token)
+		}
+		if !strings.Contains(wf, token) {
+			t.Errorf("release.yml never substitutes %s; a release would ship the raw placeholder and fail closed", token)
+		}
+		substituted = strings.ReplaceAll(substituted, token, "STAMPED_VALUE")
+	}
+	if strings.Contains(substituted, `== "STAMPED_VALUE"`) {
+		t.Error("after substitution a guard compares a variable against the injected value; assemble sentinels at run time")
 	}
 }

--- a/cmd/power-manage-agent/install_lint_test.go
+++ b/cmd/power-manage-agent/install_lint_test.go
@@ -232,3 +232,34 @@ func TestContainerfile_DataDirPerms(t *testing.T) {
 		t.Error("Containerfile must `chmod 700 /var/lib/power-manage` after creating it")
 	}
 }
+
+// The release build substitutes the public key into install.sh with a GLOBAL
+// sed over the placeholder. rc1 shipped an installer whose "not configured"
+// guard was itself the placeholder literal, so the sed rewrote the guard into
+// comparing the configured key against itself and every SIGNED release
+// refused to install. The full placeholder may therefore appear exactly once
+// — the assignment the sed is meant to hit — and the guard must assemble its
+// sentinel at run time where no substitution can reach it.
+func TestInstall_PlaceholderAppearsOnlyInTheAssignment(t *testing.T) {
+	sh := readRepoFile(t, "install.sh")
+	const placeholder = "__RELEASE_SIGNING_PUBLIC_KEY__"
+
+	count := strings.Count(sh, placeholder)
+	if count == 0 {
+		t.Fatal("install.sh must carry the release-key placeholder assignment; a build with none has nothing to substitute")
+	}
+	if count != 1 {
+		t.Errorf("the release-key placeholder appears %d times; the release sed replaces every occurrence, so only the assignment may carry it", count)
+	}
+	if !strings.Contains(sh, `RELEASE_SIGNING_PUBLIC_KEY="`+placeholder+`"`) {
+		t.Error("the single placeholder occurrence must be the assignment the release sed substitutes")
+	}
+
+	// Simulate the release substitution and prove the guard survives it: the
+	// substituted script must never compare the variable against the value
+	// that was just injected.
+	substituted := strings.ReplaceAll(sh, placeholder, "TESTKEYBASE64")
+	if strings.Contains(substituted, `== "TESTKEYBASE64"`) {
+		t.Error("after key substitution the configured-key guard compares the key against itself; assemble the sentinel at run time")
+	}
+}

--- a/install.sh
+++ b/install.sh
@@ -320,7 +320,14 @@ download_binary() {
         exit 1
     fi
 
-    if [[ "$RELEASE_SIGNING_PUBLIC_KEY" == "__RELEASE_SIGNING_PUBLIC_KEY__" ]] || \
+    # The sentinel is assembled at run time so the release build's GLOBAL
+    # placeholder substitution can never rewrite this comparison. rc1 shipped
+    # with the literal placeholder here: the sed replaced it with the real
+    # key, the guard compared the key against itself, and every SIGNED
+    # release refused to install precisely because the key WAS configured.
+    local placeholder_sentinel="__RELEASE_SIGNING_PUBLIC_KEY"
+    placeholder_sentinel="${placeholder_sentinel}__"
+    if [[ "$RELEASE_SIGNING_PUBLIC_KEY" == "$placeholder_sentinel" ]] || \
         [[ -z "$RELEASE_SIGNING_PUBLIC_KEY" ]]; then
         log_error "Release signing public key is not configured. Refusing to install."
         exit 1

--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,10 @@ GITHUB_REPO="MANCHTOOLS/power-manage-agent"
 # release artifact carries the pinned value.
 RELEASE_SIGNING_PUBLIC_KEY="__RELEASE_SIGNING_PUBLIC_KEY__"
 
+# Stamped by the release workflow exactly like the key above; the source tree
+# keeps the raw placeholder and the run-time default stays "latest".
+INSTALLER_RELEASE_VERSION="__INSTALLER_RELEASE_VERSION__"
+
 # Default values
 DATA_DIR="/var/lib/power-manage"
 BINARY_PATH="/usr/local/bin/power-manage-agent"
@@ -237,6 +241,21 @@ download_binary() {
         log_info "Using existing binary at $BINARY_PATH"
         chmod +x "$BINARY_PATH"
         return
+    fi
+
+    # A release installer installs its own release when no version was named:
+    # GitHub's "latest" alias resolves only non-prereleases, so a project that
+    # currently ships prereleases resolves it to an ancient stable whose
+    # assets do not match this installer. -v and --pre keep their meaning.
+    # The sentinel is assembled at run time for the same reason as the key
+    # guard below: the release sed must never rewrite this comparison.
+    local version_sentinel="__INSTALLER_RELEASE_VERSION"
+    version_sentinel="${version_sentinel}__"
+    if [[ "$VERSION" == "latest" ]] && [[ -z "$PRE_RELEASE" ]] \
+        && [[ -n "$INSTALLER_RELEASE_VERSION" ]] \
+        && [[ "$INSTALLER_RELEASE_VERSION" != "$version_sentinel" ]]; then
+        VERSION="$INSTALLER_RELEASE_VERSION"
+        log_info "No version named; installing this installer's release: ${VERSION}"
     fi
 
     # Resolve version for --pre flag


### PR DESCRIPTION
## Summary

Two defects made every signed release installer unusable through the
documented path; both are fixed with a shared root cause addressed.

1. **The "key not configured" guard compared the key against itself.**
   The release workflow substitutes the signing key into `install.sh`
   with a global `sed` over `__RELEASE_SIGNING_PUBLIC_KEY__` — and the
   guard that detects an unsubstituted build was that same literal, so
   the sed rewrote it into `key == key → refuse`. Every SIGNED release
   asset (rc1 included) refused to install precisely because the key
   was configured. The guard now assembles its sentinel at run time,
   out of the sed's reach.

2. **The release installer defaulted to GitHub's `latest`,** which
   resolves only non-prereleases: a prerelease user following the docs
   downloaded an ancient stable's assets and failed signature
   verification. The release workflow now stamps the tag into the
   installer beside the key, and a run without `-v`/`--pre` installs
   the installer's own release.

## Guards

`TestInstall_PlaceholderAppearsOnlyInTheAssignment` pins the key
placeholder to exactly one occurrence and simulates the release sed
(observed red on the shipped installer: placeholder twice, guard
self-comparison). `TestInstall_EveryPlaceholderStampedExactlyOnce`
generalizes it: every placeholder in install.sh must appear exactly
once as a quoted assignment, be substituted by `release.yml`, and
survive a simulated global substitution with no guard comparing
against the injected value (observed red with the workflow sed
absent).

## Verification

- `bash -n install.sh` clean
- `go test ./cmd/power-manage-agent/` green, red-first evidence for
  both new tests captured
- Repo gate (build, vet, tests, docref 8/8) green

## Consequence

rc1's baked assets can never self-install; a new release from this
branch's merge is required for the documented install path to work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Installers now default to the specific release version they were published with, avoiding reliance on a moving “latest” release.
  - Explicit version selections and prerelease installations continue to work as expected.

- **Security**
  - Installation documentation now explains verification using signed checksum manifests.

- **Documentation**
  - Updated installation guidance clarifies required enrollment parameters and release-signing procedures.

- **Reliability**
  - Release packaging now validates version metadata before publishing assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->