### PR TITLE
docs: state only verifiable facts in the contributor guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,21 +3,25 @@
 ## Prerequisites
 
 - Go 1.25+
-- A Linux system for testing (the agent manages Linux devices)
+- A Linux system for testing (the agent manages Linux devices; integration
+  tests exercise real package managers and system services)
 
-## Getting Started
+## Getting started
 
-This repo is part of a Go workspace. Clone all four repos (`sdk`, `server`, `agent`, `web`) into the same parent directory.
+The agent builds standalone against its pinned SDK dependency:
 
 ```bash
-# Build
-go build ./cmd/agent
-
-# Run tests
+go build ./cmd/power-manage-agent
 go test ./...
 ```
 
-See `CLAUDE.md` for the full build command reference.
+For coordinated changes against a local SDK checkout, clone
+[power-manage-sdk](https://github.com/manchtools/power-manage-sdk) beside this
+repository and point a `go.work` at it:
+
+```bash
+go work init . && go work edit -replace github.com/manchtools/power-manage-sdk=../sdk
+```
 
 ## Workflow
 
@@ -33,32 +37,28 @@ See `CLAUDE.md` for the full build command reference.
 3. Open a pull request. CodeRabbit reviews automatically.
 4. Ensure CI passes before requesting review.
 
-## Code Style
+## Code style
 
 - Follow existing patterns in the codebase.
-- Always handle errors -- never silently ignore them.
+- Always handle errors — never silently ignore them.
+- Bug fixes come with a regression test that fails on the buggy version.
 
 ## Guardrails (architectural fitness functions)
 
 `internal/archtest/` holds build-failing invariant tests that run in the
-normal `go test ./...` path:
+normal `go test ./...` path. Among what they enforce: string-literal SQL with
+`?` placeholders only, constant-time comparison of secrets and signatures, no
+unabstracted `time.Now()` in runtime code, no `context.Background()` in
+request paths, no `math/rand` for anything cryptographic, no proto secret
+fields reaching log or error sinks, no direct OS I/O in sensitive paths, and
+no return of the abolished pre-rewrite agent runtime. Read the test files in
+that package for the full, current list — the tests are the authority, not
+this summary.
 
-- **`TestNoDynamicSQL`** — the hand-written sqlite queries (`s.db`/`tx`) must
-  use string-literal SQL with `?` placeholders; never `fmt.Sprintf`/
-  concatenate SQL.
-- **`TestSecretComparesAreConstantTime`** — compare secrets/tokens/MACs/
-  signatures with `subtle.ConstantTimeCompare`/`hmac.Equal`, never
-  `==`/`bytes.Equal`.
-- **`TestNoUnabstractedTimeNow`** — no direct `time.Now()` calls in runtime
-  code. Read the clock through an injected `now func() time.Time` seam
-  (defaulting to `time.Now`) and call `t.now()`, so time-dependent logic (the
-  offline scheduler's maintenance-window gate, expiry, rotation cutoffs) is
-  testable with a fixed clock.
-
-Each guard ships a documented, no-stale-guarded allowlist for genuine
-exceptions. **Prefer fixing the code over adding an allowlist entry.** The
-rationale lives in the server repo's `docs/adr/0002-architectural-fitness-functions.md`.
+Each guard ships a documented allowlist for genuine exceptions. **Prefer
+fixing the code over adding an allowlist entry.**
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the AGPL-3.0 license.
+By contributing, you agree that your contributions will be licensed under the
+repository's [GPL-3.0](../LICENSE) license.


### PR DESCRIPTION
## What

Rewrites `.github/CONTRIBUTING.md` so every statement in it is derivable from the tree.

## Why

The guide contradicted the repository on several points:

- claimed **AGPL-3.0** inbound licensing; the repository LICENSE is **GPL-3.0**
- build command named `./cmd/agent`; the executable lives at `./cmd/power-manage-agent`
- told contributors to clone "all four repos" including `web`, which is a proprietary hosted client and not publicly cloneable
- referenced a repo-local `CLAUDE.md` that is not tracked here
- cited `docs/adr/0002-architectural-fitness-functions.md` in the server repo, which does not exist
- listed three archtest guards while `internal/archtest/` enforces far more

## How

The guide now describes the standalone build, a `go.work` replace recipe for local SDK development, the actual guard surface (with the test files named as the authority), and the repository's real license. Docs-only change; the full agent gate ran green before push.

Fixes #201
